### PR TITLE
feat: Auth::user() returns all auth models when no parameter specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixes
 
 * fix: Change QueryBuilder::newQuery() @return from `$this` to `static`
+* feat: Auth::user() returns all possible auth models when no $guard parameter specified by @mirucon in https://github.com/nunomaduro/larastan/pull/1232
 
 ## [2.1.4] - 2022-03-30
 

--- a/src/Concerns/LoadsAuthModel.php
+++ b/src/Concerns/LoadsAuthModel.php
@@ -4,21 +4,53 @@ declare(strict_types=1);
 
 namespace NunoMaduro\Larastan\Concerns;
 
+use function array_key_exists;
 use Illuminate\Config\Repository as ConfigRepository;
+use function in_array;
+use function is_array;
 
 trait LoadsAuthModel
 {
-    /** @phpstan-return class-string|null */
-    private function getAuthModel(ConfigRepository $config, ?string $guard = null): ?string
+    /** @phpstan-return array<int, class-string> */
+    private function getAuthModels(ConfigRepository $config, ?string $guard = null): array
     {
         if (
-            ($guard === null && ! ($guard = $config->get('auth.defaults.guard'))) ||
-            ! ($provider = $config->get('auth.guards.'.$guard.'.provider')) ||
-            ! ($authModel = $config->get('auth.providers.'.$provider.'.model'))
+            $guard !== null &&
+            ($provider = $config->get('auth.guards.'.$guard.'.provider')) &&
+            ($authModel = $config->get('auth.providers.'.$provider.'.model'))
         ) {
-            return null;
+            return [$authModel];
         }
 
-        return $authModel;
+        $guards = $config->get('auth.guards');
+        $providers = $config->get('auth.providers');
+
+        if (! is_array($guards) || ! is_array($providers)) {
+            return [];
+        }
+
+        return array_reduce(
+            array_keys($guards),
+            function (array $carry, $guardName) use ($guards, $providers): array {
+                $provider = $guards[$guardName]['provider'] ?? null;
+                if (! array_key_exists($provider, $providers)) {
+                    return $carry;
+                }
+
+                $authModel = $providers[$provider]['model'] ?? null;
+                if (! $authModel) {
+                    return $carry;
+                }
+
+                if (in_array($authModel, $carry, true)) {
+                    return $carry;
+                }
+
+                $carry[] = $authModel;
+
+                return $carry;
+            },
+            [],
+        );
     }
 }

--- a/src/Methods/Pipes/Auths.php
+++ b/src/Methods/Pipes/Auths.php
@@ -43,10 +43,14 @@ final class Auths implements PipeContract
         $config = $this->resolve('config');
 
         if ($config !== null && in_array($classReflectionName, $this->classes, true)) {
-            $authModel = $this->getAuthModel($config);
+            $authModels = $this->getAuthModels($config);
 
-            if ($authModel !== null) {
-                $found = $passable->sendToPipeline($authModel);
+            if (! empty($authModels)) {
+                foreach ($authModels as $authModel) {
+                    if ($found = $passable->sendToPipeline($authModel)) {
+                        break;
+                    }
+                }
             }
         } elseif ($classReflectionName === \Illuminate\Contracts\Auth\Factory::class || $classReflectionName === \Illuminate\Auth\AuthManager::class) {
             $found = $passable->sendToPipeline(

--- a/src/Methods/Pipes/Auths.php
+++ b/src/Methods/Pipes/Auths.php
@@ -45,7 +45,7 @@ final class Auths implements PipeContract
         if ($config !== null && in_array($classReflectionName, $this->classes, true)) {
             $authModels = $this->getAuthModels($config);
 
-            if (! empty($authModels)) {
+            if (count($authModels) !== 0) {
                 foreach ($authModels as $authModel) {
                     if ($found = $passable->sendToPipeline($authModel)) {
                         break;

--- a/src/ReturnTypes/AuthExtension.php
+++ b/src/ReturnTypes/AuthExtension.php
@@ -48,16 +48,23 @@ final class AuthExtension implements DynamicStaticMethodReturnTypeExtension
         Scope $scope
     ): Type {
         $config = $this->getContainer()->get('config');
-        $authModel = null;
+        $authModels = [];
 
         if ($config !== null) {
-            $authModel = $this->getAuthModel($config);
+            $authModels = $this->getAuthModels($config);
         }
 
-        if ($authModel === null) {
+        if (empty($authModels)) {
             return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
         }
 
-        return TypeCombinator::addNull(new ObjectType($authModel));
+        return TypeCombinator::addNull(
+            TypeCombinator::union(
+                ...array_map(
+                    fn (string $authModel): Type => new ObjectType($authModel),
+                    $authModels,
+                ),
+            ),
+        );
     }
 }

--- a/src/ReturnTypes/AuthExtension.php
+++ b/src/ReturnTypes/AuthExtension.php
@@ -54,7 +54,7 @@ final class AuthExtension implements DynamicStaticMethodReturnTypeExtension
             $authModels = $this->getAuthModels($config);
         }
 
-        if (empty($authModels)) {
+        if (count($authModels) === 0) {
             return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
         }
 

--- a/src/ReturnTypes/AuthManagerExtension.php
+++ b/src/ReturnTypes/AuthManagerExtension.php
@@ -45,7 +45,7 @@ final class AuthManagerExtension implements DynamicMethodReturnTypeExtension
             $authModels = $this->getAuthModels($config);
         }
 
-        if (empty($authModels)) {
+        if (count($authModels) === 0) {
             return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
         }
 

--- a/src/ReturnTypes/AuthManagerExtension.php
+++ b/src/ReturnTypes/AuthManagerExtension.php
@@ -39,16 +39,23 @@ final class AuthManagerExtension implements DynamicMethodReturnTypeExtension
         Scope $scope
     ): Type {
         $config = $this->getContainer()->get('config');
-        $authModel = null;
+        $authModels = [];
 
         if ($config !== null) {
-            $authModel = $this->getAuthModel($config);
+            $authModels = $this->getAuthModels($config);
         }
 
-        if ($authModel === null) {
+        if (empty($authModels)) {
             return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
         }
 
-        return TypeCombinator::addNull(new ObjectType($authModel));
+        return TypeCombinator::addNull(
+            TypeCombinator::union(
+                ...array_map(
+                    fn (string $authModel): Type => new ObjectType($authModel),
+                    $authModels,
+                ),
+            ),
+        );
     }
 }

--- a/src/ReturnTypes/GuardExtension.php
+++ b/src/ReturnTypes/GuardExtension.php
@@ -49,7 +49,7 @@ final class GuardExtension implements DynamicMethodReturnTypeExtension
             $authModels = $this->getAuthModels($config, $guard);
         }
 
-        if (empty($authModels)) {
+        if (count($authModels) === 0) {
             return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
         }
 

--- a/src/ReturnTypes/GuardExtension.php
+++ b/src/ReturnTypes/GuardExtension.php
@@ -42,18 +42,25 @@ final class GuardExtension implements DynamicMethodReturnTypeExtension
         Scope $scope
     ): Type {
         $config = $this->getContainer()->get('config');
-        $authModel = null;
+        $authModels = [];
 
         if ($config !== null) {
             $guard = $this->getGuardFromMethodCall($scope, $methodCall);
-            $authModel = $this->getAuthModel($config, $guard);
+            $authModels = $this->getAuthModels($config, $guard);
         }
 
-        if ($authModel === null) {
+        if (empty($authModels)) {
             return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
         }
 
-        return TypeCombinator::addNull(new ObjectType($authModel));
+        return TypeCombinator::addNull(
+            TypeCombinator::union(
+                ...array_map(
+                    fn (string $authModel): Type => new ObjectType($authModel),
+                    $authModels,
+                ),
+            ),
+        );
     }
 
     private function getGuardFromMethodCall(Scope $scope, MethodCall $methodCall): ?string

--- a/src/ReturnTypes/RequestUserExtension.php
+++ b/src/ReturnTypes/RequestUserExtension.php
@@ -49,16 +49,23 @@ final class RequestUserExtension implements DynamicMethodReturnTypeExtension
         Scope $scope
     ): Type {
         $config = $this->getContainer()->get('config');
-        $authModel = null;
+        $authModels = [];
 
         if ($config !== null) {
-            $authModel = $this->getAuthModel($config);
+            $authModels = $this->getAuthModels($config);
         }
 
-        if ($authModel === null) {
+        if (empty($authModels)) {
             return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
         }
 
-        return TypeCombinator::addNull(new ObjectType($authModel));
+        return TypeCombinator::addNull(
+            TypeCombinator::union(
+                ...array_map(
+                    fn (string $authModel): Type => new ObjectType($authModel),
+                    $authModels,
+                ),
+            ),
+        );
     }
 }

--- a/src/ReturnTypes/RequestUserExtension.php
+++ b/src/ReturnTypes/RequestUserExtension.php
@@ -55,7 +55,7 @@ final class RequestUserExtension implements DynamicMethodReturnTypeExtension
             $authModels = $this->getAuthModels($config);
         }
 
-        if (empty($authModels)) {
+        if (count($authModels) === 0) {
             return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
         }
 

--- a/tests/Features/ReturnTypes/AuthExtension.php
+++ b/tests/Features/ReturnTypes/AuthExtension.php
@@ -12,7 +12,7 @@ use Illuminate\Support\Facades\Auth;
 
 class AuthExtension
 {
-    public function testUser(): ?User
+    public function testUser(): User|Admin|null
     {
         return Auth::user();
     }

--- a/tests/Features/ReturnTypes/Helpers/AuthExtension.php
+++ b/tests/Features/ReturnTypes/Helpers/AuthExtension.php
@@ -26,7 +26,7 @@ class AuthExtension
         return auth('web');
     }
 
-    public function testUser(): ?User
+    public function testUser(): User|Admin|null
     {
         return auth()->user();
     }

--- a/tests/Type/data/request-object.php
+++ b/tests/Type/data/request-object.php
@@ -15,4 +15,4 @@ assertType('Illuminate\Routing\Route|null', $request->route());
 assertType('object|string|null', $request->route('foo'));
 assertType('object|string|null', $request->route('foo', 'bar'));
 
-assertType('Illuminate\Foundation\Auth\User|null', $request->user());
+assertType('App\Admin|App\User|null', $request->user());

--- a/tests/Type/data/request-object.php
+++ b/tests/Type/data/request-object.php
@@ -15,4 +15,4 @@ assertType('Illuminate\Routing\Route|null', $request->route());
 assertType('object|string|null', $request->route('foo'));
 assertType('object|string|null', $request->route('foo', 'bar'));
 
-assertType('App\Admin|App\User|null', $request->user());
+assertType('Illuminate\Foundation\Auth\User|null', $request->user());


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [x] Updated CHANGELOG.md

Resolves #1230

**Changes**

Currently when no $guard parameter is passed to `Auth::user()` method, it always returns the model of *default* guard.
However this behaviour doesn't match how the method actually works as it might return non-default models as well.
This PR corrected the `Auth::user()` method to return all possible auth models.

p.s. I had no idea what `src/Methods/Pipes/Auths.php` is for, so please kindly let me know how I should handle this one.

**Breaking changes**

Yes
