### PR TITLE
Fix relation types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+
+* added: The `Relation`-related classes now required up to four template parameters instead of one: `TRelatedModel` (required as before), `TDeclaringModel` (required), `TResult` (required by base classes like `HasOneOrMany`, not required by user-facing classes like `HasMany`) and `TIntermediateModel` (only required by `...Through...`-relations) https://github.com/nunomaduro/larastan/pull/1285  
 * fix: Resolve correct model factory instance when application namespace is empty
 
 ### Fixed

--- a/src/Methods/BuilderHelper.php
+++ b/src/Methods/BuilderHelper.php
@@ -74,11 +74,11 @@ class BuilderHelper
             $returnClassReflection = $returnObject->getClassReflection();
 
             if ($returnClassReflection !== null) {
-                $modelType = $returnClassReflection->getActiveTemplateTypeMap()->getType('TModelClass');
-
-                if ($modelType === null) {
-                    $modelType = $returnClassReflection->getActiveTemplateTypeMap()->getType('TRelatedModel');
-                }
+                $templateTypeMap = $returnClassReflection->getActiveTemplateTypeMap();
+                $modelType =
+                    $templateTypeMap->getType('TModelClass') ??
+                    $templateTypeMap->getType('TRelatedModel') ??
+                    $templateTypeMap->getType('TDeclaringModel');
 
                 if ($modelType !== null) {
                     $finder = substr($methodName, 5);

--- a/src/Methods/EloquentBuilderForwardsCallsExtension.php
+++ b/src/Methods/EloquentBuilderForwardsCallsExtension.php
@@ -18,9 +18,7 @@ use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\Generic\TemplateMixedType;
-use PHPStan\Type\Generic\TemplateObjectType;
 use PHPStan\Type\IntegerType;
-use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeWithClassName;
 
@@ -87,14 +85,6 @@ final class EloquentBuilderForwardsCallsExtension implements MethodsClassReflect
         // Generic type is not specified
         if ($modelType === null) {
             return null;
-        }
-
-        if ($modelType instanceof TemplateObjectType) {
-            $modelType = $modelType->getBound();
-
-            if ($modelType->equals(new ObjectType(Model::class))) {
-                return null;
-            }
         }
 
         if ($modelType instanceof TypeWithClassName) {

--- a/src/Methods/EloquentBuilderForwardsCallsExtension.php
+++ b/src/Methods/EloquentBuilderForwardsCallsExtension.php
@@ -77,8 +77,12 @@ final class EloquentBuilderForwardsCallsExtension implements MethodsClassReflect
             return null;
         }
 
+        $templateTypeMap = $classReflection->getActiveTemplateTypeMap();
         /** @var Type|TemplateMixedType|null $modelType */
-        $modelType = $classReflection->getActiveTemplateTypeMap()->getType('TModelClass');
+        $modelType =
+            $templateTypeMap->getType('TModelClass') ??
+            $templateTypeMap->getType('TRelatedModel') ??
+            $templateTypeMap->getType('TDeclaringModel');
 
         // Generic type is not specified
         if ($modelType === null) {

--- a/src/Methods/RelationForwardsCallsExtension.php
+++ b/src/Methods/RelationForwardsCallsExtension.php
@@ -6,7 +6,6 @@ namespace NunoMaduro\Larastan\Methods;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use NunoMaduro\Larastan\Reflection\EloquentBuilderMethodReflection;
 use PHPStan\Reflection\ClassReflection;
@@ -109,14 +108,12 @@ final class RelationForwardsCallsExtension implements MethodsClassReflectionExte
         $parametersAcceptor = ParametersAcceptorSelector::selectSingle($reflection->getVariants());
         $returnType = $parametersAcceptor->getReturnType();
 
-        $types = [$relatedModel];
-
-        // BelongsTo relation needs second generic type
-        if ((new ObjectType(BelongsTo::class))->isSuperTypeOf(new ObjectType($classReflection->getName()))->yes()) {
-            $childType = $classReflection->getActiveTemplateTypeMap()->getType('TChildModel');
-
-            if ($childType !== null) {
-                $types[] = $childType;
+        // Copy template parameters with generic types of relation
+        $types = [];
+        foreach (['TRelatedModel', 'TDeclaringModel', 'TIntermediateModel', 'TResult'] as $templateParameter) {
+            $type = $classReflection->getActiveTemplateTypeMap()->getType($templateParameter);
+            if ($type !== null) {
+                $types[] = $type;
             }
         }
 

--- a/src/ReturnTypes/BuilderModelFindExtension.php
+++ b/src/ReturnTypes/BuilderModelFindExtension.php
@@ -59,9 +59,13 @@ final class BuilderModelFindExtension implements DynamicMethodReturnTypeExtensio
             return false;
         }
 
-        $model = $methodReflection->getDeclaringClass()->getActiveTemplateTypeMap()->getType('TModelClass');
+        $templateTypeMap = $methodReflection->getDeclaringClass()->getActiveTemplateTypeMap();
+        $model =
+            $templateTypeMap->getType('TModelClass') ??
+            $templateTypeMap->getType('TRelatedModel') ??
+            $templateTypeMap->getType('TDeclaringModel');
 
-        if ($model === null || ! $model instanceof ObjectType) {
+        if (! $model instanceof ObjectType) {
             return false;
         }
 
@@ -81,8 +85,12 @@ final class BuilderModelFindExtension implements DynamicMethodReturnTypeExtensio
         MethodCall $methodCall,
         Scope $scope
     ): Type {
+        $templateTypeMap = $methodReflection->getDeclaringClass()->getActiveTemplateTypeMap();
         /** @var ObjectType $model */
-        $model = $methodReflection->getDeclaringClass()->getActiveTemplateTypeMap()->getType('TModelClass');
+        $model =
+            $templateTypeMap->getType('TModelClass') ??
+            $templateTypeMap->getType('TRelatedModel') ??
+            $templateTypeMap->getType('TDeclaringModel');
         $returnType = $methodReflection->getVariants()[0]->getReturnType();
         $argType = $scope->getType($methodCall->getArgs()[0]->value);
 

--- a/src/ReturnTypes/EloquentBuilderExtension.php
+++ b/src/ReturnTypes/EloquentBuilderExtension.php
@@ -57,8 +57,12 @@ final class EloquentBuilderExtension implements DynamicMethodReturnTypeExtension
         }
 
         $templateTypeMap = $methodReflection->getDeclaringClass()->getActiveTemplateTypeMap();
+        $model =
+            $templateTypeMap->getType('TModelClass') ??
+            $templateTypeMap->getType('TRelatedModel') ??
+            $templateTypeMap->getType('TDeclaringModel');
 
-        if (! $templateTypeMap->getType('TModelClass') instanceof ObjectType) {
+        if (! $model instanceof ObjectType) {
             return false;
         }
 
@@ -74,7 +78,10 @@ final class EloquentBuilderExtension implements DynamicMethodReturnTypeExtension
         $templateTypeMap = $methodReflection->getDeclaringClass()->getActiveTemplateTypeMap();
 
         /** @var Type|ObjectType|TemplateMixedType $modelType */
-        $modelType = $templateTypeMap->getType('TModelClass');
+        $modelType =
+            $templateTypeMap->getType('TModelClass') ??
+            $templateTypeMap->getType('TRelatedModel') ??
+            $templateTypeMap->getType('TDeclaringModel');
 
         if ($modelType instanceof ObjectType && in_array(Collection::class, $returnType->getReferencedClasses(), true)) {
             $collectionClassName = $this->builderHelper->determineCollectionClassName($modelType->getClassName());

--- a/src/Types/RelationDynamicMethodReturnTypeExtension.php
+++ b/src/Types/RelationDynamicMethodReturnTypeExtension.php
@@ -69,7 +69,7 @@ class RelationDynamicMethodReturnTypeExtension implements DynamicMethodReturnTyp
 
         if (
             // Special case for MorphTo. `morphTo` can be called without arguments.
-            ($methodName !== 'morphTo' && $numArgs < 1 ) ||
+            ($methodName !== 'morphTo' && $numArgs < 1) ||
             // Special case for "...Through". `has...Through` must be called with a 2nd parameter for the intermediate model
             (in_array($methodName, ['hasOneThrough', 'hasManyThrough']) && $numArgs < 2)
         ) {

--- a/src/Types/RelationDynamicMethodReturnTypeExtension.php
+++ b/src/Types/RelationDynamicMethodReturnTypeExtension.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace NunoMaduro\Larastan\Types;
 
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Database\Eloquent\Relations\HasManyThrough;
+use NunoMaduro\Larastan\Methods\BuilderHelper;
 use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionVariant;
@@ -17,16 +17,19 @@ use PHPStan\ShouldNotHappenException;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\DynamicMethodReturnTypeExtension;
 use PHPStan\Type\Generic\GenericObjectType;
+use PHPStan\Type\IntegerType;
 use PHPStan\Type\ObjectType;
-use PHPStan\Type\StaticType;
 use PHPStan\Type\Type;
+use PHPStan\Type\TypeWithClassName;
 
 class RelationDynamicMethodReturnTypeExtension implements DynamicMethodReturnTypeExtension
 {
+    private BuilderHelper $builderHelper;
     private ReflectionProvider $provider;
 
-    public function __construct(ReflectionProvider $provider)
+    public function __construct(BuilderHelper $builderHelper, ReflectionProvider $provider)
     {
+        $this->builderHelper = $builderHelper;
         $this->provider = $provider;
     }
 
@@ -53,6 +56,9 @@ class RelationDynamicMethodReturnTypeExtension implements DynamicMethodReturnTyp
         MethodCall $methodCall,
         Scope $scope
     ): Type {
+        $methodName = $methodReflection->getName();
+        $methodArgs = $methodCall->getArgs();
+        $numArgs = count($methodArgs);
         /** @var FunctionVariant $functionVariant */
         $functionVariant = ParametersAcceptorSelector::selectSingle($methodReflection->getVariants());
         $returnType = $functionVariant->getReturnType();
@@ -61,38 +67,65 @@ class RelationDynamicMethodReturnTypeExtension implements DynamicMethodReturnTyp
             return $returnType;
         }
 
-        $calledOnType = $scope->getType($methodCall->var);
-
-        if ($calledOnType instanceof StaticType) {
-            $calledOnType = new ObjectType($calledOnType->getClassName());
-        }
-
-        if (count($methodCall->getArgs()) === 0) {
+        if (
             // Special case for MorphTo. `morphTo` can be called without arguments.
-            if ($methodReflection->getName() === 'morphTo') {
-                return new GenericObjectType($returnType->getClassName(), [new ObjectType(Model::class), $calledOnType]);
+            ($methodName !== 'morphTo' && $numArgs < 1 ) ||
+            // Special case for "...Through". `has...Through` must be called with a 2nd parameter for the intermediate model
+            (in_array($methodName, ['hasOneThrough', 'hasManyThrough']) && $numArgs < 2)
+        ) {
+            return $returnType;
+        }
+
+        $templateTypes = [];
+
+        // Determine TRelatedModel; this is the 1st parameter, if given, or `Eloquent\Model`
+        $relatedModelClassArgType = $numArgs === 0 ?
+            new ConstantStringType(Model::class, true) :
+            $scope->getType($methodCall->getArgs()[0]->value);
+        if (! $relatedModelClassArgType instanceof ConstantStringType) {
+            return $returnType;
+        }
+        $relatedModelClassName = $relatedModelClassArgType->getValue();
+        if (! $this->provider->hasClass($relatedModelClassName)) {
+            $relatedModelClassName = Model::class;
+        }
+        $templateTypes[] = new ObjectType($relatedModelClassName);
+
+        // Determine TDeclaringModel; this is the model on whose instance the method is called
+        $calledOnType = $scope->getType($methodCall->var);
+        if (! $calledOnType instanceof TypeWithClassName) {
+            return $returnType;
+        }
+        $declaringModelClassName = $calledOnType->getClassName();
+        $templateTypes[] = new ObjectType($declaringModelClassName);
+
+        // Determine TIntermediateModel for "Through" types; this is the 2nd parameter
+        $hasManyThroughType = new ObjectType(HasManyThrough::class);
+        if ($hasManyThroughType->isSuperTypeOf($returnType)->yes()) {
+            $intermediateModelClassArgType = $scope->getType($methodCall->getArgs()[1]->value);
+            if (! $intermediateModelClassArgType instanceof ConstantStringType) {
+                return $returnType;
             }
-
-            return $returnType;
+            $intermediateModelClassName = $intermediateModelClassArgType->getValue();
+            $templateTypes[] = new ObjectType($intermediateModelClassName);
         }
 
-        $argType = $scope->getType($methodCall->getArgs()[0]->value);
-
-        if (! $argType instanceof ConstantStringType) {
-            return $returnType;
+        // Work-around for a Laravel bug
+        // Opposed to other `HasOne...` and `HasMany...` methods,
+        // `HasOneThrough` and `HasManyThrough` do not extend a common
+        // `HasOneOrManyThrough` base class, but `HasOneThrough` directly
+        // extends `HasManyThrough`.
+        // This does not only violate Liskov's Substitution Principle but also
+        // has the unfortunate side effect that `HasManyThrough` cannot
+        // bind the template parameter `TResult` to a Collection, but needs
+        // to keep it unbound for `HasOneThrough` to overwrite it.
+        // Hence, if `HasManyTrough` is used directly, we must bind the
+        // fourth template parameter `TResult` here.
+        if ($hasManyThroughType->equals($returnType)) {
+            $collectionClassName = $this->builderHelper->determineCollectionClassName($relatedModelClassName);
+            $templateTypes[] = new GenericObjectType($collectionClassName, [new IntegerType(), new ObjectType($relatedModelClassName)]);
         }
 
-        $argClassName = $argType->getValue();
-
-        if (! $this->provider->hasClass($argClassName)) {
-            $argClassName = Model::class;
-        }
-
-        // Special case for BelongsTo. We need to add the child model as a generic type also.
-        if ((new ObjectType(BelongsTo::class))->isSuperTypeOf($returnType)->yes()) {
-            return new GenericObjectType($returnType->getClassName(), [new ObjectType($argClassName), $calledOnType]);
-        }
-
-        return new GenericObjectType($returnType->getClassName(), [new ObjectType($argClassName)]);
+        return new GenericObjectType($returnType->getClassName(), $templateTypes);
     }
 }

--- a/src/Types/RelationParserHelper.php
+++ b/src/Types/RelationParserHelper.php
@@ -38,6 +38,19 @@ class RelationParserHelper
     public function findRelatedModelInRelationMethod(
         MethodReflection $methodReflection
     ): ?string {
+        return $this->findNthModelInRelationMethod($methodReflection, 0);
+    }
+
+    public function findIntermediateModelInRelationMethod(
+        MethodReflection $methodReflection
+    ): ?string {
+        return $this->findNthModelInRelationMethod($methodReflection, 1);
+    }
+
+    private function findNthModelInRelationMethod(
+        MethodReflection $methodReflection,
+        int $argIndex
+    ): ?string {
         if (method_exists($methodReflection, 'getDeclaringTrait') && $methodReflection->getDeclaringTrait() !== null) {
             $fileName = $methodReflection->getDeclaringTrait()->getFileName();
         } else {
@@ -74,7 +87,7 @@ class RelationParserHelper
             $methodCall = $methodCall->var;
         }
 
-        if (count($methodCall->getArgs()) < 1) {
+        if (count($methodCall->getArgs()) < $argIndex + 1) {
             return null;
         }
 
@@ -89,7 +102,7 @@ class RelationParserHelper
             ->enterClass($methodReflection->getDeclaringClass())
             ->enterClassMethod($relationMethod, TemplateTypeMap::createEmpty(), [], null, null, null, false, false, false);
 
-        $argType = $methodScope->getType($methodCall->getArgs()[0]->value);
+        $argType = $methodScope->getType($methodCall->getArgs()[$argIndex]->value);
         $returnClass = null;
 
         if ($argType instanceof ConstantStringType) {

--- a/stubs/BelongsTo.stub
+++ b/stubs/BelongsTo.stub
@@ -6,9 +6,9 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 
 /**
- * @template TRelatedModel of Model
- * @template TDeclaringModel of Model
- * @extends Relation<TRelatedModel, TDeclaringModel, TRelatedModel>
+ * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+ * @template TDeclaringModel of \Illuminate\Database\Eloquent\Model
+ * @extends \Illuminate\Database\Eloquent\Relations\Relation<TRelatedModel, TDeclaringModel, TRelatedModel>
  */
 class BelongsTo extends Relation
 {
@@ -16,11 +16,11 @@ class BelongsTo extends Relation
     protected $child;
 
     /**
-     * @param  Builder<TRelatedModel>  $query
-     * @param  TDeclaringModel  $child
-     * @param  string  $foreignKey
-     * @param  string  $ownerKey
-     * @param  string  $relationName
+     * @param  \Illuminate\Database\Eloquent\Builder<TRelatedModel>  $query
+     * @param  TDeclaringModel                                       $child
+     * @param  string                                                $foreignKey
+     * @param  string                                                $ownerKey
+     * @param  string                                                $relationName
      */
     public function __construct(Builder $query, Model $child, $foreignKey, $ownerKey, $relationName);
 

--- a/stubs/BelongsTo.stub
+++ b/stubs/BelongsTo.stub
@@ -2,26 +2,66 @@
 
 namespace Illuminate\Database\Eloquent\Relations;
 
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
 /**
- * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
- * @template TChildModel of \Illuminate\Database\Eloquent\Model
- * @extends Relation<TRelatedModel>
+ * @template TRelatedModel of Model
+ * @template TDeclaringModel of Model
+ * @extends Relation<TRelatedModel, TDeclaringModel, TRelatedModel>
  */
 class BelongsTo extends Relation
 {
-    /** @phpstan-return TChildModel */
-    public function associate();
+    /** @var TDeclaringModel */
+    protected $child;
 
-    /** @phpstan-return TChildModel */
+    /**
+     * @param  Builder<TRelatedModel>  $query
+     * @param  TDeclaringModel  $child
+     * @param  string  $foreignKey
+     * @param  string  $ownerKey
+     * @param  string  $relationName
+     */
+    public function __construct(Builder $query, Model $child, $foreignKey, $ownerKey, $relationName);
+
+    /**
+     * Gather the keys from an array of related models.
+     *
+     * @param  array<TDeclaringModel> $models
+     * @return array<model-property<TDeclaringModel>>
+     */
+    protected function getEagerModelKeys(array $models);
+
+    /**
+     * @param  TRelatedModel|int|string|null  $model
+     * @phpstan-return TDeclaringModel
+     */
+    public function associate($model);
+
+    /** @phpstan-return TDeclaringModel */
     public function dissociate();
 
-    /** @phpstan-return TChildModel */
+    /** @phpstan-return TDeclaringModel */
+    public function disassociate();
+
+    /**
+     * @param  TDeclaringModel  $parent
+     * @return TRelatedModel
+     */
+    protected function newRelatedInstanceFor(Model $parent);
+
+    /** @phpstan-return TDeclaringModel */
     public function getChild();
 
     /**
-     * Get the results of the relationship.
-     *
-     * @phpstan-return ?TRelatedModel
+     * @param  TRelatedModel $model
+     * @return string|int
      */
-    public function getResults();
+    protected function getRelatedKeyFrom(Model $model);
+
+    /**
+     * @param  TDeclaringModel $parent
+     * @return TRelatedModel|null
+     */
+    protected function getDefaultFor(Model $parent);
 }

--- a/stubs/BelongsToMany.stub
+++ b/stubs/BelongsToMany.stub
@@ -8,27 +8,28 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 
 /**
- * @template TRelatedModel of Model
- * @template TDeclaringModel of Model
- * @extends Relation<TRelatedModel, TDeclaringModel, Collection<int, TRelatedModel>>
+ * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+ * @template TDeclaringModel of \Illuminate\Database\Eloquent\Model
+ * @extends \Illuminate\Database\Eloquent\Relations\Relation<TRelatedModel, TDeclaringModel, \Illuminate\Database\Eloquent\Collection<int, TRelatedModel>>
  */
 class BelongsToMany extends Relation
 {
     /**
-     * @param  Builder<TRelatedModel>  $query
-     * @param  TDeclaringModel  $parent
-     * @param  string  $table
-     * @param  string  $foreignPivotKey
-     * @param  string  $relatedPivotKey
-     * @param  string  $parentKey
-     * @param  string  $relatedKey
-     * @param  string|null  $relationName
+     * @param  \Illuminate\Database\Eloquent\Builder<TRelatedModel> $query
+     * @param  TDeclaringModel                                      $parent
+     * @param  string                                               $table
+     * @param  string                                               $foreignPivotKey
+     * @param  string                                               $relatedPivotKey
+     * @param  string                                               $parentKey
+     * @param  string                                               $relatedKey
+     * @param  string|null                                          $relationName
      */
     public function __construct(Builder $query, Model $parent, $table, $foreignPivotKey,
                                 $relatedPivotKey, $parentKey, $relatedKey, $relationName = null);
 
     /**
-     * @param Collection<int, TRelatedModel> $results
+     * @param  \Illuminate\Database\Eloquent\Collection<int, TRelatedModel> $results
+     *
      * @return array<string, TRelatedModel>
      */
     protected function buildDictionary(Collection $results);
@@ -36,9 +37,10 @@ class BelongsToMany extends Relation
     /**
      * Find a related model by its primary key or return new instance of the related model.
      *
-     * @param  mixed  $id
+     * @param  mixed                                            $id
      * @param  array<int, (model-property<TRelatedModel>|'*')>  $columns
-     * @phpstan-return ($id is (\Illuminate\Contracts\Support\Arrayable<array-key, mixed>|array<mixed>) ? \Illuminate\Support\Collection<int, TRelatedModel> : TRelatedModel)
+     *
+     * @return ($id is (\Illuminate\Contracts\Support\Arrayable<array-key, mixed>|array<mixed>) ? \Illuminate\Support\Collection<int, TRelatedModel> : TRelatedModel)
      */
     public function findOrNew($id, $columns = ['*']);
 
@@ -47,6 +49,7 @@ class BelongsToMany extends Relation
      *
      * @param  array<model-property<TRelatedModel>, mixed>  $attributes
      * @param  array<model-property<TRelatedModel>, mixed>  $values
+     *
      * @return TRelatedModel
      */
     public function firstOrNew(array $attributes = [], array $values = []);
@@ -56,8 +59,9 @@ class BelongsToMany extends Relation
      *
      * @param  array<model-property<TRelatedModel>, mixed>  $attributes
      * @param  array<model-property<TRelatedModel>, mixed>  $values
-     * @param  array<mixed>  $joining
-     * @param  bool  $touch
+     * @param  array<mixed>                                 $joining
+     * @param  bool                                         $touch
+     *
      * @return TRelatedModel
      */
     public function firstOrCreate(array $attributes = [], array $values = [], array $joining = [], $touch = true);
@@ -67,8 +71,9 @@ class BelongsToMany extends Relation
      *
      * @param  array<model-property<TRelatedModel>, mixed>  $attributes
      * @param  array<model-property<TRelatedModel>, mixed>  $values
-     * @param  array<mixed>  $joining
-     * @param  bool  $touch
+     * @param  array<mixed>                                 $joining
+     * @param  bool                                         $touch
+     *
      * @return TRelatedModel
      */
     public function updateOrCreate(array $attributes, array $values = [], array $joining = [], $touch = true);
@@ -76,9 +81,10 @@ class BelongsToMany extends Relation
     /**
      * Find a related model by its primary key.
      *
-     * @param  mixed  $id
+     * @param  mixed                                            $id
      * @param  array<int, (model-property<TRelatedModel>|'*')>  $columns
-     * @phpstan-return ($id is (\Illuminate\Contracts\Support\Arrayable<array-key, mixed>|array<mixed>) ? Collection<int, TRelatedModel> : TRelatedModel)|null
+     *
+     * @return ($id is (\Illuminate\Contracts\Support\Arrayable<array-key, mixed>|array<mixed>) ? \Illuminate\Database\Eloquent\Collection<int, TRelatedModel> : TRelatedModel)|null
      */
     public function find($id, $columns = ['*']);
 
@@ -86,18 +92,21 @@ class BelongsToMany extends Relation
      * Find multiple related models by their primary keys.
      *
      * @param  \Illuminate\Contracts\Support\Arrayable<array-key, mixed>|array<mixed>  $ids
-     * @param  array<int, (model-property<TRelatedModel>|'*')>  $columns
-     * @return Collection<int, TRelatedModel>
+     * @param  array<int, (model-property<TRelatedModel>|'*')>                         $columns
+     *
+     * @return \Illuminate\Database\Eloquent\Collection<int, TRelatedModel>
      */
     public function findMany($ids, $columns = ['*']);
 
     /**
      * Find a related model by its primary key or throw an exception.
      *
-     * @param  mixed  $id
+     * @param  mixed                                            $id
      * @param  array<int, (model-property<TRelatedModel>|'*')>  $columns
-     * @phpstan-return ($id is (\Illuminate\Contracts\Support\Arrayable<array-key, mixed>|array<mixed>) ? Collection<int, TRelatedModel> : TRelatedModel)
-     * @throws ModelNotFoundException<TRelatedModel>
+     *
+     * @return ($id is (\Illuminate\Contracts\Support\Arrayable<array-key, mixed>|array<mixed>) ? \Illuminate\Database\Eloquent\Collection<int, TRelatedModel> : TRelatedModel)
+     *
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException<TRelatedModel>
      */
     public function findOrFail($id, $columns = ['*']);
 
@@ -106,8 +115,9 @@ class BelongsToMany extends Relation
      *
      * @param  mixed  $id
      * @param  \Closure|array<int, (model-property<TRelatedModel>|'*')>  $columns
-     * @param  \Closure|null  $callback
-     * @phpstan-return ($id is (\Illuminate\Contracts\Support\Arrayable<array-key, mixed>|array<mixed>) ? Collection<int, TRelatedModel> : TRelatedModel)|mixed
+     * @param  \Closure|null                                             $callback
+     *
+     * @return ($id is (\Illuminate\Contracts\Support\Arrayable<array-key, mixed>|array<mixed>) ? \Illuminate\Database\Eloquent\Collection<int, TRelatedModel> : TRelatedModel)|mixed
      */
     public function findOr($id, $columns = ['*'], \Closure $callback = null);
 
@@ -115,9 +125,10 @@ class BelongsToMany extends Relation
      * Add a basic where clause to the query, and return the first result.
      *
      * @param  \Closure|model-property<TRelatedModel>|'*'|array<int, (model-property<TRelatedModel>|'*')>  $column
-     * @param  mixed  $operator
-     * @param  mixed  $value
-     * @param  'and'|'or'  $boolean
+     * @param  mixed                                                                                       $operator
+     * @param  mixed                                                                                       $value
+     * @param  'and'|'or'                                                                                  $boolean
+     *
      * @return TRelatedModel|null
      */
     public function firstWhere($column, $operator = null, $value = null, $boolean = 'and');
@@ -126,6 +137,7 @@ class BelongsToMany extends Relation
      * Execute the query and get the first result.
      *
      * @param  array<int, (model-property<TRelatedModel>|'*')> $columns
+     *
      * @return TRelatedModel|null
      */
     public function first($columns = ['*']);
@@ -134,8 +146,10 @@ class BelongsToMany extends Relation
      * Execute the query and get the first result or throw an exception.
      *
      * @param  array<int, (model-property<TRelatedModel>|'*')> $columns
+     *
      * @return TRelatedModel
-     * @throws ModelNotFoundException<TRelatedModel>
+     *
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException<TRelatedModel>
      */
     public function firstOrFail($columns = ['*']);
 
@@ -143,8 +157,9 @@ class BelongsToMany extends Relation
      * Save a new model and attach it to the parent model.
      *
      * @param  TRelatedModel  $model
-     * @param  array<mixed>  $pivotAttributes
-     * @param  bool  $touch
+     * @param  array<mixed>   $pivotAttributes
+     * @param  bool           $touch
+     *
      * @return TRelatedModel
      */
     public function save(Model $model, array $pivotAttributes = [], $touch = true);
@@ -153,8 +168,9 @@ class BelongsToMany extends Relation
      * Save a new model without raising any events and attach it to the parent model.
      *
      * @param  TRelatedModel  $model
-     * @param  array<mixed>  $pivotAttributes
-     * @param  bool  $touch
+     * @param  array<mixed>   $pivotAttributes
+     * @param  bool           $touch
+     *
      * @return TRelatedModel
      */
     public function saveQuietly(Model $model, array $pivotAttributes = [], $touch = true);
@@ -163,7 +179,8 @@ class BelongsToMany extends Relation
      * Save an array of new models and attach them to the parent model.
      *
      * @param  \Illuminate\Support\Collection<int, TRelatedModel>|array<TRelatedModel>  $models
-     * @param  array<mixed>  $pivotAttributes
+     * @param  array<mixed>                                                             $pivotAttributes
+     *
      * @return \Illuminate\Support\Collection<int, TRelatedModel>|array<TRelatedModel>
      */
     public function saveMany($models, array $pivotAttributes = []);
@@ -172,8 +189,9 @@ class BelongsToMany extends Relation
      * Create a new instance of the related model.
      *
      * @param  array<model-property<TRelatedModel>, mixed>  $attributes
-     * @param  mixed[]  $joining
-     * @param  bool  $touch
+     * @param  mixed[]                                      $joining
+     * @param  bool                                         $touch
+     *
      * @return TRelatedModel
      */
     public function create(array $attributes = [], array $joining = [], $touch = true);
@@ -182,7 +200,8 @@ class BelongsToMany extends Relation
      * Create an array of new instances of the related models.
      *
      * @param  iterable<array<model-property<TRelatedModel>, mixed>>  $records
-     * @param  mixed[]  $joinings
+     * @param  mixed[]                                                $joinings
+     *
      * @return array<TRelatedModel>
      */
     public function createMany(iterable $records, array $joinings = []);

--- a/stubs/BelongsToMany.stub
+++ b/stubs/BelongsToMany.stub
@@ -2,44 +2,71 @@
 
 namespace Illuminate\Database\Eloquent\Relations;
 
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+
 /**
- * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
- * @extends Relation<TRelatedModel>
+ * @template TRelatedModel of Model
+ * @template TDeclaringModel of Model
+ * @extends Relation<TRelatedModel, TDeclaringModel, Collection<int, TRelatedModel>>
  */
 class BelongsToMany extends Relation
 {
     /**
+     * @param  Builder<TRelatedModel>  $query
+     * @param  TDeclaringModel  $parent
+     * @param  string  $table
+     * @param  string  $foreignPivotKey
+     * @param  string  $relatedPivotKey
+     * @param  string  $parentKey
+     * @param  string  $relatedKey
+     * @param  string|null  $relationName
+     */
+    public function __construct(Builder $query, Model $parent, $table, $foreignPivotKey,
+                                $relatedPivotKey, $parentKey, $relatedKey, $relationName = null);
+
+    /**
+     * @param Collection<int, TRelatedModel> $results
+     * @return array<string, TRelatedModel>
+     */
+    protected function buildDictionary(Collection $results);
+
+    /**
      * Find a related model by its primary key or return new instance of the related model.
      *
      * @param  mixed  $id
-     * @param  array<int, (model-property<TRelatedModel>|'*')>|model-property<TRelatedModel>|'*'  $columns
-     * @return ($id is (\Illuminate\Contracts\Support\Arrayable<array-key, mixed>|array<mixed>) ? \Illuminate\Support\Collection<int, TRelatedModel> : TRelatedModel)
+     * @param  array<int, (model-property<TRelatedModel>|'*')>  $columns
+     * @phpstan-return ($id is (\Illuminate\Contracts\Support\Arrayable<array-key, mixed>|array<mixed>) ? \Illuminate\Support\Collection<int, TRelatedModel> : TRelatedModel)
      */
     public function findOrNew($id, $columns = ['*']);
 
     /**
      * Get the first related model record matching the attributes or instantiate it.
      *
-     * @param  array<string, mixed>  $attributes
+     * @param  array<model-property<TRelatedModel>, mixed>  $attributes
+     * @param  array<model-property<TRelatedModel>, mixed>  $values
      * @return TRelatedModel
      */
-    public function firstOrNew(array $attributes);
+    public function firstOrNew(array $attributes = [], array $values = []);
 
     /**
      * Get the first related record matching the attributes or create it.
      *
-     * @param  array<string, mixed>  $attributes
+     * @param  array<model-property<TRelatedModel>, mixed>  $attributes
+     * @param  array<model-property<TRelatedModel>, mixed>  $values
      * @param  array<mixed>  $joining
      * @param  bool  $touch
      * @return TRelatedModel
      */
-    public function firstOrCreate(array $attributes, array $joining = [], $touch = true);
+    public function firstOrCreate(array $attributes = [], array $values = [], array $joining = [], $touch = true);
 
     /**
      * Create or update a related record matching the attributes, and fill it with values.
      *
-     * @param  array<string, mixed>  $attributes
-     * @param  array<mixed>  $values
+     * @param  array<model-property<TRelatedModel>, mixed>  $attributes
+     * @param  array<model-property<TRelatedModel>, mixed>  $values
      * @param  array<mixed>  $joining
      * @param  bool  $touch
      * @return TRelatedModel
@@ -50,17 +77,17 @@ class BelongsToMany extends Relation
      * Find a related model by its primary key.
      *
      * @param  mixed  $id
-     * @param  array<int, mixed>  $columns
-     * @return ($id is (\Illuminate\Contracts\Support\Arrayable<array-key, mixed>|array<mixed>) ? \Illuminate\Database\Eloquent\Collection<int, TRelatedModel> : TRelatedModel)|null
+     * @param  array<int, (model-property<TRelatedModel>|'*')>  $columns
+     * @phpstan-return ($id is (\Illuminate\Contracts\Support\Arrayable<array-key, mixed>|array<mixed>) ? Collection<int, TRelatedModel> : TRelatedModel)|null
      */
     public function find($id, $columns = ['*']);
 
     /**
      * Find multiple related models by their primary keys.
      *
-     * @param  \Illuminate\Contracts\Support\Arrayable<array-key, mixed>|int[]  $ids
-     * @param  array<int, mixed>  $columns
-     * @return \Illuminate\Database\Eloquent\Collection<int, TRelatedModel>
+     * @param  \Illuminate\Contracts\Support\Arrayable<array-key, mixed>|array<mixed>  $ids
+     * @param  array<int, (model-property<TRelatedModel>|'*')>  $columns
+     * @return Collection<int, TRelatedModel>
      */
     public function findMany($ids, $columns = ['*']);
 
@@ -68,17 +95,37 @@ class BelongsToMany extends Relation
      * Find a related model by its primary key or throw an exception.
      *
      * @param  mixed  $id
-     * @param  array<int, mixed>  $columns
-     * @return ($id is (\Illuminate\Contracts\Support\Arrayable<array-key, mixed>|array<mixed>) ? \Illuminate\Database\Eloquent\Collection<int, TRelatedModel> : TRelatedModel)
-     *
-     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
+     * @param  array<int, (model-property<TRelatedModel>|'*')>  $columns
+     * @phpstan-return ($id is (\Illuminate\Contracts\Support\Arrayable<array-key, mixed>|array<mixed>) ? Collection<int, TRelatedModel> : TRelatedModel)
+     * @throws ModelNotFoundException<TRelatedModel>
      */
     public function findOrFail($id, $columns = ['*']);
 
     /**
+     * Find a related model by its primary key or call a callback.
+     *
+     * @param  mixed  $id
+     * @param  \Closure|array<int, (model-property<TRelatedModel>|'*')>  $columns
+     * @param  \Closure|null  $callback
+     * @phpstan-return ($id is (\Illuminate\Contracts\Support\Arrayable<array-key, mixed>|array<mixed>) ? Collection<int, TRelatedModel> : TRelatedModel)|mixed
+     */
+    public function findOr($id, $columns = ['*'], \Closure $callback = null);
+
+    /**
+     * Add a basic where clause to the query, and return the first result.
+     *
+     * @param  \Closure|model-property<TRelatedModel>|'*'|array<int, (model-property<TRelatedModel>|'*')>  $column
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @param  'and'|'or'  $boolean
+     * @return TRelatedModel|null
+     */
+    public function firstWhere($column, $operator = null, $value = null, $boolean = 'and');
+
+    /**
      * Execute the query and get the first result.
      *
-     * @param  array<int, mixed>  $columns
+     * @param  array<int, (model-property<TRelatedModel>|'*')> $columns
      * @return TRelatedModel|null
      */
     public function first($columns = ['*']);
@@ -86,12 +133,40 @@ class BelongsToMany extends Relation
     /**
      * Execute the query and get the first result or throw an exception.
      *
-     * @param  array<int, mixed>  $columns
+     * @param  array<int, (model-property<TRelatedModel>|'*')> $columns
      * @return TRelatedModel
-     *
-     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
+     * @throws ModelNotFoundException<TRelatedModel>
      */
     public function firstOrFail($columns = ['*']);
+
+    /**
+     * Save a new model and attach it to the parent model.
+     *
+     * @param  TRelatedModel  $model
+     * @param  array<mixed>  $pivotAttributes
+     * @param  bool  $touch
+     * @return TRelatedModel
+     */
+    public function save(Model $model, array $pivotAttributes = [], $touch = true);
+
+    /**
+     * Save a new model without raising any events and attach it to the parent model.
+     *
+     * @param  TRelatedModel  $model
+     * @param  array<mixed>  $pivotAttributes
+     * @param  bool  $touch
+     * @return TRelatedModel
+     */
+    public function saveQuietly(Model $model, array $pivotAttributes = [], $touch = true);
+
+    /**
+     * Save an array of new models and attach them to the parent model.
+     *
+     * @param  \Illuminate\Support\Collection<int, TRelatedModel>|array<TRelatedModel>  $models
+     * @param  array<mixed>  $pivotAttributes
+     * @return \Illuminate\Support\Collection<int, TRelatedModel>|array<TRelatedModel>
+     */
+    public function saveMany($models, array $pivotAttributes = []);
 
     /**
      * Create a new instance of the related model.
@@ -104,9 +179,11 @@ class BelongsToMany extends Relation
     public function create(array $attributes = [], array $joining = [], $touch = true);
 
     /**
-     * Get the results of the relationship.
+     * Create an array of new instances of the related models.
      *
-     * @phpstan-return \Traversable<int, TRelatedModel>
+     * @param  iterable<array<model-property<TRelatedModel>, mixed>>  $records
+     * @param  mixed[]  $joinings
+     * @return array<TRelatedModel>
      */
-    public function getResults();
+    public function createMany(iterable $records, array $joinings = []);
 }

--- a/stubs/EloquentBuilder.stub
+++ b/stubs/EloquentBuilder.stub
@@ -84,7 +84,7 @@ class Builder
      * @param  array<int, (model-property<TModelClass>|'*')>|model-property<TModelClass>|'*'  $columns
      * @phpstan-return ($id is (\Illuminate\Contracts\Support\Arrayable<array-key, mixed>|array<mixed>) ? \Illuminate\Database\Eloquent\Collection<int, TModelClass> : TModelClass)
      *
-     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException<TModelClass>
      */
     public function findOrFail($id, $columns = ['*']);
 
@@ -150,7 +150,7 @@ class Builder
      * @param  array<int, (model-property<TModelClass>|'*')>|model-property<TModelClass>|'*'  $columns
      * @phpstan-return TModelClass
      *
-     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException<TModelClass>
      */
     public function firstOrFail($columns = ['*']);
 
@@ -175,7 +175,8 @@ class Builder
      * Add a relationship count / exists condition to the query.
      *
      * @template TRelatedModel of Model
-     * @param  \Illuminate\Database\Eloquent\Relations\Relation<TRelatedModel>|string  $relation
+     * @template TResult
+     * @param  \Illuminate\Database\Eloquent\Relations\Relation<TRelatedModel, TModelClass, TResult>|string  $relation
      * @param  string  $operator
      * @param  int  $count
      * @param  string  $boolean
@@ -272,8 +273,7 @@ class Builder
      * Add a polymorphic relationship count / exists condition to the query.
      *
      * @template TRelatedModel of Model
-     * @template TChildModel of Model
-     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<TRelatedModel, TChildModel>|string  $relation
+     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<TRelatedModel, TModelClass>|string  $relation
      * @param  string|array<string>  $types
      * @param  string  $operator
      * @param  int  $count
@@ -287,8 +287,7 @@ class Builder
      * Add a polymorphic relationship count / exists condition to the query with an "or".
      *
      * @template TRelatedModel of Model
-     * @template TChildModel of Model
-     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<TRelatedModel, TChildModel>|string  $relation
+     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<TRelatedModel, TModelClass>|string  $relation
      * @param  string|array<string>  $types
      * @param  string  $operator
      * @param  int  $count
@@ -300,8 +299,7 @@ class Builder
      * Add a polymorphic relationship count / exists condition to the query.
      *
      * @template TRelatedModel of Model
-     * @template TChildModel of Model
-     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<TRelatedModel, TChildModel>|string  $relation
+     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<TRelatedModel, TModelClass>|string  $relation
      * @param  string|array<string>  $types
      * @param  string  $boolean
      * @param  \Closure|null  $callback
@@ -313,8 +311,7 @@ class Builder
      * Add a polymorphic relationship count / exists condition to the query with an "or".
      *
      * @template TRelatedModel of Model
-     * @template TChildModel of Model
-     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<TRelatedModel, TChildModel>|string  $relation
+     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<TRelatedModel, TModelClass>|string  $relation
      * @param  string|array<string>  $types
      * @return static
      */
@@ -324,8 +321,7 @@ class Builder
      * Add a polymorphic relationship count / exists condition to the query with where clauses.
      *
      * @template TRelatedModel of Model
-     * @template TChildModel of Model
-     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<TRelatedModel, TChildModel>|string  $relation
+     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<TRelatedModel, TModelClass>|string  $relation
      * @param  string|array<string>  $types
      * @param  \Closure|null  $callback
      * @param  string  $operator
@@ -338,8 +334,7 @@ class Builder
      * Add a polymorphic relationship count / exists condition to the query with where clauses and an "or".
      *
      * @template TRelatedModel of Model
-     * @template TChildModel of Model
-     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<TRelatedModel, TChildModel>|string  $relation
+     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<TRelatedModel, TModelClass>|string  $relation
      * @param  string|array<string>  $types
      * @param  \Closure|null  $callback
      * @param  string  $operator
@@ -352,8 +347,7 @@ class Builder
      * Add a polymorphic relationship count / exists condition to the query with where clauses.
      *
      * @template TRelatedModel of Model
-     * @template TChildModel of Model
-     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<TRelatedModel, TChildModel>|string  $relation
+     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<TRelatedModel, TModelClass>|string  $relation
      * @param  string|array<string>  $types
      * @param  \Closure|null  $callback
      * @return static
@@ -364,8 +358,7 @@ class Builder
      * Add a polymorphic relationship count / exists condition to the query with where clauses and an "or".
      *
      * @template TRelatedModel of Model
-     * @template TChildModel of Model
-     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<TRelatedModel, TChildModel>|string  $relation
+     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<TRelatedModel, TModelClass>|string  $relation
      * @param  string|array<string>  $types
      * @param  \Closure|null  $callback
      * @return static

--- a/stubs/HasMany.stub
+++ b/stubs/HasMany.stub
@@ -2,16 +2,14 @@
 
 namespace Illuminate\Database\Eloquent\Relations;
 
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
+
 /**
- * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
- * @extends HasOneOrMany<TRelatedModel>
+ * @template TRelatedModel of Model
+ * @template TDeclaringModel of Model
+ * @extends HasOneOrMany<TRelatedModel, TDeclaringModel, Collection<int, TRelatedModel>>
  */
 class HasMany extends HasOneOrMany
 {
-    /**
-     * Get the results of the relationship.
-     *
-     * @phpstan-return \Traversable<int, TRelatedModel>
-     */
-    public function getResults();
 }

--- a/stubs/HasMany.stub
+++ b/stubs/HasMany.stub
@@ -2,13 +2,10 @@
 
 namespace Illuminate\Database\Eloquent\Relations;
 
-use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Database\Eloquent\Model;
-
 /**
- * @template TRelatedModel of Model
- * @template TDeclaringModel of Model
- * @extends HasOneOrMany<TRelatedModel, TDeclaringModel, Collection<int, TRelatedModel>>
+ * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+ * @template TDeclaringModel of \Illuminate\Database\Eloquent\Model
+ * @extends \Illuminate\Database\Eloquent\Relations\HasOneOrMany<TRelatedModel, TDeclaringModel, \Illuminate\Database\Eloquent\Collection<int, TRelatedModel>>
  */
 class HasMany extends HasOneOrMany
 {

--- a/stubs/HasManyThrough.stub
+++ b/stubs/HasManyThrough.stub
@@ -2,16 +2,126 @@
 
 namespace Illuminate\Database\Eloquent\Relations;
 
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+
 /**
- * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
- * @extends Relation<TRelatedModel>
+ * @template TRelatedModel of Model
+ * @template TDeclaringModel of Model
+ * @template TIntermediateModel of Model
+ * @template TResult
+ * @extends Relation<TRelatedModel, TIntermediateModel, TResult>
  */
 class HasManyThrough extends Relation
 {
     /**
-     * Get the results of the relationship.
-     *
-     * @phpstan-return \Traversable<int, TRelatedModel>
+     * @var TIntermediateModel
      */
-    public function getResults();
+    protected $throughParent;
+
+    /**
+     * @var TDeclaringModel
+     */
+    protected $farParent;
+
+    /**
+     * @param  Builder<TRelatedModel>  $query
+     * @param  TDeclaringModel  $farParent
+     * @param  TIntermediateModel  $throughParent
+     * @param  string  $firstKey
+     * @param  string  $secondKey
+     * @param  string  $localKey
+     * @param  string  $secondLocalKey
+     */
+    public function __construct(Builder $query, Model $farParent, Model $throughParent, $firstKey, $secondKey, $localKey, $secondLocalKey);
+
+    /**
+     * @param  Builder<TRelatedModel>|null  $query
+     * @return void
+     */
+    protected function performJoin(Builder $query = null);
+
+    /**
+     * @param  Collection<int, TRelatedModel>  $results
+     * @return array<array<TRelatedModel>>
+     */
+    protected function buildDictionary(Collection $results);
+
+    /**
+     * @param  array<model-property<TRelatedModel>, mixed> $attributes
+     * @return TRelatedModel
+     */
+    public function firstOrNew(array $attributes);
+
+    /**
+     * @param  array<model-property<TRelatedModel>, mixed>  $attributes
+     * @param  array<model-property<TRelatedModel>, mixed>  $values
+     * @return TRelatedModel
+     */
+    public function updateOrCreate(array $attributes, array $values = []);
+
+    /**
+     * @param  \Closure|model-property<TRelatedModel>|'*'|array<int, (model-property<TRelatedModel>|'*')>  $column
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @param  'and'|'or' $boolean
+     * @return TRelatedModel|null
+     */
+    public function firstWhere($column, $operator = null, $value = null, $boolean = 'and');
+
+    /**
+     * @param  array<int, (model-property<TRelatedModel>|'*')> $columns
+     * @return TRelatedModel|null
+     */
+    public function first($columns = ['*']);
+
+    /**
+     * @param  array<int, (model-property<TRelatedModel>|'*')>  $columns
+     * @return TRelatedModel
+     * @throws ModelNotFoundException<TRelatedModel>
+     */
+    public function firstOrFail($columns = ['*']);
+
+    /**
+     * Execute the query and get the first result or call a callback.
+     *
+     * @param  \Closure|array<int, (model-property<TRelatedModel>|'*')>  $columns
+     * @param  \Closure|null  $callback
+     * @return TRelatedModel|mixed
+     */
+    public function firstOr($columns = ['*'], \Closure $callback = null);
+
+    /**
+     * @param  mixed  $id
+     * @param  array<int, (model-property<TRelatedModel>|'*')>  $columns
+     * @phpstan-return ($id is (\Illuminate\Contracts\Support\Arrayable<array-key, mixed>|array<mixed>) ? Collection<int, TRelatedModel> : TRelatedModel)|null
+     */
+    public function find($id, $columns = ['*']);
+
+    /**
+     * @param  \Illuminate\Contracts\Support\Arrayable<array-key, mixed>|array<mixed>  $ids
+     * @param  array<int, (model-property<TRelatedModel>|'*')>  $columns
+     * @return Collection<int, TRelatedModel>
+     */
+    public function findMany($ids, $columns = ['*']);
+
+    /**
+     * @param  mixed  $id
+     * @param  array<int, (model-property<TRelatedModel>|'*')>  $columns
+     * @phpstan-return ($id is (\Illuminate\Contracts\Support\Arrayable<array-key, mixed>|array<mixed>) ? Collection<int, TRelatedModel> : TRelatedModel)
+     * @throws ModelNotFoundException<TRelatedModel>
+     */
+    public function findOrFail($id, $columns = ['*']);
+
+    /**
+     * Find a related model by its primary key or call a callback.
+     *
+     * @param  mixed  $id
+     * @param  \Closure|array<int, (model-property<TRelatedModel>|'*')>  $columns
+     * @param  \Closure|null  $callback
+     * @phpstan-return ($id is (\Illuminate\Contracts\Support\Arrayable<array-key, mixed>|array<mixed>) ? Collection<int, TRelatedModel> : TRelatedModel)|mixed
+     */
+    public function findOr($id, $columns = ['*'], \Closure $callback = null);
 }

--- a/stubs/HasManyThrough.stub
+++ b/stubs/HasManyThrough.stub
@@ -3,16 +3,14 @@
 namespace Illuminate\Database\Eloquent\Relations;
 
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\ModelNotFoundException;
 
 /**
- * @template TRelatedModel of Model
- * @template TDeclaringModel of Model
- * @template TIntermediateModel of Model
+ * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+ * @template TDeclaringModel of \Illuminate\Database\Eloquent\Model
+ * @template TIntermediateModel of \Illuminate\Database\Eloquent\Model
  * @template TResult
- * @extends Relation<TRelatedModel, TIntermediateModel, TResult>
+ * @extends \Illuminate\Database\Eloquent\Relations\Relation<TRelatedModel, TIntermediateModel, TResult>
  */
 class HasManyThrough extends Relation
 {
@@ -27,30 +25,33 @@ class HasManyThrough extends Relation
     protected $farParent;
 
     /**
-     * @param  Builder<TRelatedModel>  $query
-     * @param  TDeclaringModel  $farParent
-     * @param  TIntermediateModel  $throughParent
-     * @param  string  $firstKey
-     * @param  string  $secondKey
-     * @param  string  $localKey
-     * @param  string  $secondLocalKey
+     * @param  \Illuminate\Database\Eloquent\Builder<TRelatedModel>  $query
+     * @param  TDeclaringModel                                       $farParent
+     * @param  TIntermediateModel                                    $throughParent
+     * @param  string                                                $firstKey
+     * @param  string                                                $secondKey
+     * @param  string                                                $localKey
+     * @param  string                                                $secondLocalKey
      */
     public function __construct(Builder $query, Model $farParent, Model $throughParent, $firstKey, $secondKey, $localKey, $secondLocalKey);
 
     /**
-     * @param  Builder<TRelatedModel>|null  $query
+     * @param  \Illuminate\Database\Eloquent\Builder<TRelatedModel>|null  $query
+     *
      * @return void
      */
     protected function performJoin(Builder $query = null);
 
     /**
-     * @param  Collection<int, TRelatedModel>  $results
+     * @param  \Illuminate\Database\Eloquent\Collection<int, TRelatedModel>  $results
+     *
      * @return array<array<TRelatedModel>>
      */
-    protected function buildDictionary(Collection $results);
+    protected function buildDictionary(\Illuminate\Database\Eloquent\Collection $results);
 
     /**
      * @param  array<model-property<TRelatedModel>, mixed> $attributes
+     *
      * @return TRelatedModel
      */
     public function firstOrNew(array $attributes);
@@ -64,23 +65,27 @@ class HasManyThrough extends Relation
 
     /**
      * @param  \Closure|model-property<TRelatedModel>|'*'|array<int, (model-property<TRelatedModel>|'*')>  $column
-     * @param  mixed  $operator
-     * @param  mixed  $value
-     * @param  'and'|'or' $boolean
+     * @param  mixed                                                                                       $operator
+     * @param  mixed                                                                                       $value
+     * @param  'and'|'or'                                                                                  $boolean
+     *
      * @return TRelatedModel|null
      */
     public function firstWhere($column, $operator = null, $value = null, $boolean = 'and');
 
     /**
      * @param  array<int, (model-property<TRelatedModel>|'*')> $columns
+     *
      * @return TRelatedModel|null
      */
     public function first($columns = ['*']);
 
     /**
      * @param  array<int, (model-property<TRelatedModel>|'*')>  $columns
+     *
      * @return TRelatedModel
-     * @throws ModelNotFoundException<TRelatedModel>
+     *
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException<TRelatedModel>
      */
     public function firstOrFail($columns = ['*']);
 
@@ -88,40 +93,46 @@ class HasManyThrough extends Relation
      * Execute the query and get the first result or call a callback.
      *
      * @param  \Closure|array<int, (model-property<TRelatedModel>|'*')>  $columns
-     * @param  \Closure|null  $callback
+     * @param  \Closure|null                                             $callback
+     *
      * @return TRelatedModel|mixed
      */
     public function firstOr($columns = ['*'], \Closure $callback = null);
 
     /**
-     * @param  mixed  $id
+     * @param  mixed                                            $id
      * @param  array<int, (model-property<TRelatedModel>|'*')>  $columns
-     * @phpstan-return ($id is (\Illuminate\Contracts\Support\Arrayable<array-key, mixed>|array<mixed>) ? Collection<int, TRelatedModel> : TRelatedModel)|null
+     *
+     * @return ($id is (\Illuminate\Contracts\Support\Arrayable<array-key, mixed>|array<mixed>) ? \Illuminate\Database\Eloquent\Collection<int, TRelatedModel> : TRelatedModel)|null
      */
     public function find($id, $columns = ['*']);
 
     /**
      * @param  \Illuminate\Contracts\Support\Arrayable<array-key, mixed>|array<mixed>  $ids
-     * @param  array<int, (model-property<TRelatedModel>|'*')>  $columns
-     * @return Collection<int, TRelatedModel>
+     * @param  array<int, (model-property<TRelatedModel>|'*')>                         $columns
+     *
+     * @return \Illuminate\Database\Eloquent\Collection<int, TRelatedModel>
      */
     public function findMany($ids, $columns = ['*']);
 
     /**
-     * @param  mixed  $id
+     * @param  mixed                                            $id
      * @param  array<int, (model-property<TRelatedModel>|'*')>  $columns
-     * @phpstan-return ($id is (\Illuminate\Contracts\Support\Arrayable<array-key, mixed>|array<mixed>) ? Collection<int, TRelatedModel> : TRelatedModel)
-     * @throws ModelNotFoundException<TRelatedModel>
+     *
+     * @return ($id is (\Illuminate\Contracts\Support\Arrayable<array-key, mixed>|array<mixed>) ? \Illuminate\Database\Eloquent\Collection<int, TRelatedModel> : TRelatedModel)
+     *
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException<TRelatedModel>
      */
     public function findOrFail($id, $columns = ['*']);
 
     /**
      * Find a related model by its primary key or call a callback.
      *
-     * @param  mixed  $id
+     * @param  mixed                                                     $id
      * @param  \Closure|array<int, (model-property<TRelatedModel>|'*')>  $columns
-     * @param  \Closure|null  $callback
-     * @phpstan-return ($id is (\Illuminate\Contracts\Support\Arrayable<array-key, mixed>|array<mixed>) ? Collection<int, TRelatedModel> : TRelatedModel)|mixed
+     * @param  \Closure|null                                             $callback
+     *
+     * @return ($id is (\Illuminate\Contracts\Support\Arrayable<array-key, mixed>|array<mixed>) ? \Illuminate\Database\Eloquent\Collection<int, TRelatedModel> : TRelatedModel)|mixed
      */
     public function findOr($id, $columns = ['*'], \Closure $callback = null);
 }

--- a/stubs/HasOne.stub
+++ b/stubs/HasOne.stub
@@ -2,16 +2,39 @@
 
 namespace Illuminate\Database\Eloquent\Relations;
 
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
 /**
- * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
- * @extends HasOneOrMany<TRelatedModel>
+ * @template TRelatedModel of Model
+ * @template TDeclaringModel of Model
+ * @extends HasOneOrMany<TRelatedModel, TDeclaringModel, ?TRelatedModel>
  */
 class HasOne extends HasOneOrMany
 {
     /**
-     * Get the results of the relationship.
+     * Add constraints for inner join subselect for one of many relationships.
      *
-     * @phpstan-return ?TRelatedModel
+     * @param  Builder<TRelatedModel>  $query
+     * @param  model-property<TRelatedModel>|null  $column
+     * @param  string|null  $aggregate
+     * @return void
      */
-    public function getResults();
+    public function addOneOfManySubQueryConstraints(Builder $query, $column = null, $aggregate = null);
+
+    /**
+     * Make a new related instance for the given model.
+     *
+     * @param  TDeclaringModel  $parent
+     * @return TRelatedModel
+     */
+    public function newRelatedInstanceFor(Model $parent);
+
+    /**
+     * Get the value of the model's foreign key.
+     *
+     * @param  TRelatedModel $model
+     * @return mixed
+     */
+    protected function getRelatedKeyFrom(Model $model);
 }

--- a/stubs/HasOne.stub
+++ b/stubs/HasOne.stub
@@ -8,16 +8,17 @@ use Illuminate\Database\Eloquent\Model;
 /**
  * @template TRelatedModel of Model
  * @template TDeclaringModel of Model
- * @extends HasOneOrMany<TRelatedModel, TDeclaringModel, ?TRelatedModel>
+ * @extends \Illuminate\Database\Eloquent\Relations\HasOneOrMany<TRelatedModel, TDeclaringModel, ?TRelatedModel>
  */
 class HasOne extends HasOneOrMany
 {
     /**
      * Add constraints for inner join subselect for one of many relationships.
      *
-     * @param  Builder<TRelatedModel>  $query
-     * @param  model-property<TRelatedModel>|null  $column
-     * @param  string|null  $aggregate
+     * @param  \Illuminate\Database\Eloquent\Builder<TRelatedModel>  $query
+     * @param  model-property<TRelatedModel>|null                    $column
+     * @param  string|null                                           $aggregate
+     *
      * @return void
      */
     public function addOneOfManySubQueryConstraints(Builder $query, $column = null, $aggregate = null);
@@ -26,6 +27,7 @@ class HasOne extends HasOneOrMany
      * Make a new related instance for the given model.
      *
      * @param  TDeclaringModel  $parent
+     *
      * @return TRelatedModel
      */
     public function newRelatedInstanceFor(Model $parent);
@@ -34,6 +36,7 @@ class HasOne extends HasOneOrMany
      * Get the value of the model's foreign key.
      *
      * @param  TRelatedModel $model
+     *
      * @return mixed
      */
     protected function getRelatedKeyFrom(Model $model);

--- a/stubs/HasOneOrMany.stub
+++ b/stubs/HasOneOrMany.stub
@@ -7,48 +7,54 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 
 /**
- * @template TRelatedModel of Model
- * @template TDeclaringModel of Model
+ * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+ * @template TDeclaringModel of \Illuminate\Database\Eloquent\Model
  * @template TResult
- * @extends Relation<TRelatedModel, TDeclaringModel, TResult>
+ *
+ * @extends \Illuminate\Database\Eloquent\Relations\Relation<TRelatedModel, TDeclaringModel, TResult>
  */
 abstract class HasOneOrMany extends Relation
 {
     /**
      * Create a new has one or many relationship instance.
      *
-     * @param  Builder<TRelatedModel>  $query
-     * @param  TDeclaringModel  $parent
-     * @param  string  $foreignKey
-     * @param  string  $localKey
+     * @param  \Illuminate\Database\Eloquent\Builder<TRelatedModel>  $query
+     * @param  TDeclaringModel                                       $parent
+     * @param  string                                                $foreignKey
+     * @param  string                                                $localKey
+     *
      * @return void
      */
     public function __construct(Builder $query, Model $parent, $foreignKey, $localKey);
 
     /**
      * @param array<model-property<TRelatedModel>, mixed> $attributes
-     * @phpstan-return TRelatedModel
+     *
+     * @return TRelatedModel
      */
     public function make(array $attributes = []);
 
     /**
      * @param  iterable<array<model-property<TRelatedModel>, mixed>>  $records
-     * @return Collection<int, TRelatedModel>
+     *
+     * @return \Illuminate\Database\Eloquent\Collection<int, TRelatedModel>
      */
     public function makeMany($records);
 
     /**
-     * @param  array<TDeclaringModel>  $models
-     * @param  Collection<int, TRelatedModel>  $results
-     * @param  string  $relation
+     * @param  array<TDeclaringModel>                                        $models
+     * @param  \Illuminate\Database\Eloquent\Collection<int, TRelatedModel>  $results
+     * @param  string                                                        $relation
+     *
      * @return array<TDeclaringModel>
      */
     public function matchOne(array $models, Collection $results, $relation);
 
     /**
-     * @param  array<TDeclaringModel>  $models
-     * @param  Collection<int, TRelatedModel>  $results
-     * @param  string  $relation
+     * @param  array<TDeclaringModel>                                        $models
+     * @param  \Illuminate\Database\Eloquent\Collection<int, TRelatedModel>  $results
+     * @param  string                                                        $relation
+     *
      * @return array<TDeclaringModel>
      */
     public function matchMany(array $models, Collection $results, $relation);
@@ -56,10 +62,11 @@ abstract class HasOneOrMany extends Relation
     /**
      * Match the eagerly loaded results to their many parents.
      *
-     * @param  array<TDeclaringModel>  $models
-     * @param  Collection<int, TRelatedModel>  $results
-     * @param  string  $relation
-     * @phpstan-param  'one'|'many'  $type
+     * @param  array<TDeclaringModel>                                        $models
+     * @param  \Illuminate\Database\Eloquent\Collection<int, TRelatedModel>  $results
+     * @param  string                                                        $relation
+     * @param  'one'|'many'                                                  $type
+     *
      * @return array<TDeclaringModel>
      */
     protected function matchOneOrMany(array $models, Collection $results, $relation, $type);
@@ -67,7 +74,8 @@ abstract class HasOneOrMany extends Relation
     /**
      * Build model dictionary keyed by the relation's foreign key.
      *
-     * @param  Collection<int, TRelatedModel> $results
+     * @param  \Illuminate\Database\Eloquent\Collection<int, TRelatedModel> $results
+     *
      * @return array<array<TRelatedModel>>
      */
     protected function buildDictionary(Collection $results);
@@ -75,9 +83,10 @@ abstract class HasOneOrMany extends Relation
     /**
      * Find a model by its primary key or return new instance of the related model.
      *
-     * @param  mixed  $id
+     * @param  mixed                                            $id
      * @param  array<int, (model-property<TRelatedModel>|'*')>  $columns
-     * @phpstan-return ($id is (\Illuminate\Contracts\Support\Arrayable<array-key, mixed>|array<mixed>) ? \Illuminate\Support\Collection<int, TRelatedModel> : TRelatedModel)
+     *
+     * @return ($id is (\Illuminate\Contracts\Support\Arrayable<array-key, mixed>|array<mixed>) ? \Illuminate\Support\Collection<int, TRelatedModel> : TRelatedModel)
      */
     public function findOrNew($id, $columns = ['*']);
 
@@ -86,6 +95,7 @@ abstract class HasOneOrMany extends Relation
      *
      * @param  array<model-property<TRelatedModel>, mixed>  $attributes
      * @param  array<model-property<TRelatedModel>, mixed>  $values
+     *
      * @return TRelatedModel
      */
     public function firstOrNew(array $attributes = [], array $values = []);
@@ -95,6 +105,7 @@ abstract class HasOneOrMany extends Relation
      *
      * @param  array<model-property<TRelatedModel>, mixed>  $attributes
      * @param  array<model-property<TRelatedModel>, mixed>  $values
+     *
      * @return TRelatedModel
      */
     public function firstOrCreate(array $attributes = [], array $values = []);
@@ -104,6 +115,7 @@ abstract class HasOneOrMany extends Relation
      *
      * @param  array<model-property<TRelatedModel>, mixed>  $attributes
      * @param  array<model-property<TRelatedModel>, mixed>  $values
+     *
      * @return TRelatedModel
      */
     public function updateOrCreate(array $attributes, array $values = []);
@@ -112,6 +124,7 @@ abstract class HasOneOrMany extends Relation
      * Attach a model instance to the parent model.
      *
      * @param  TRelatedModel  $model
+     *
      * @return TRelatedModel|false
      */
     public function save(Model $model);
@@ -120,6 +133,7 @@ abstract class HasOneOrMany extends Relation
      * Attach a model instance without raising any events to the parent model.
      *
      * @param  TRelatedModel  $model
+     *
      * @return TRelatedModel|false
      */
     public function saveQuietly(Model $model);
@@ -128,14 +142,15 @@ abstract class HasOneOrMany extends Relation
      * Attach a collection of models to the parent instance.
      *
      * @param  iterable<TRelatedModel>  $models
+     *
      * @return iterable<TRelatedModel>
      */
     public function saveMany($models);
 
     /**
-     * @phpstan-param array<model-property<TRelatedModel>, mixed> $attributes
+     * @param array<model-property<TRelatedModel>, mixed> $attributes
      *
-     * @phpstan-return TRelatedModel
+     * @return TRelatedModel
      */
     public function create(array $attributes = []);
 
@@ -143,6 +158,7 @@ abstract class HasOneOrMany extends Relation
      * Create a new instance of the related model. Allow mass-assignment.
      *
      * @param  array<model-property<TRelatedModel>, mixed> $attributes
+     *
      * @return TRelatedModel
      */
     public function forceCreate(array $attributes = []);
@@ -151,7 +167,8 @@ abstract class HasOneOrMany extends Relation
      * Create a Collection of new instances of the related model.
      *
      * @param  iterable<array<model-property<TRelatedModel>, mixed>>  $records
-     * @return Collection<int, TRelatedModel>
+     *
+     * @return \Illuminate\Database\Eloquent\Collection<int, TRelatedModel>
      */
     public function createMany(iterable $records);
 
@@ -159,6 +176,7 @@ abstract class HasOneOrMany extends Relation
      * Set the foreign ID for creating a related model.
      *
      * @param  TRelatedModel  $model
+     *
      * @return void
      */
     protected function setForeignAttributesForCreate(Model $model);

--- a/stubs/HasOneOrMany.stub
+++ b/stubs/HasOneOrMany.stub
@@ -2,22 +2,28 @@
 
 namespace Illuminate\Database\Eloquent\Relations;
 
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
+
 /**
- * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
- * @extends Relation<TRelatedModel>
+ * @template TRelatedModel of Model
+ * @template TDeclaringModel of Model
+ * @template TResult
+ * @extends Relation<TRelatedModel, TDeclaringModel, TResult>
  */
 abstract class HasOneOrMany extends Relation
 {
     /**
      * Create a new has one or many relationship instance.
      *
-     * @param  \Illuminate\Database\Eloquent\Builder<TRelatedModel>  $query
-     * @param  TRelatedModel  $parent
+     * @param  Builder<TRelatedModel>  $query
+     * @param  TDeclaringModel  $parent
      * @param  string  $foreignKey
      * @param  string  $localKey
      * @return void
      */
-    public function __construct(\Illuminate\Database\Eloquent\Builder $query, \Illuminate\Database\Eloquent\Model $parent, $foreignKey, $localKey);
+    public function __construct(Builder $query, Model $parent, $foreignKey, $localKey);
 
     /**
      * @param array<model-property<TRelatedModel>, mixed> $attributes
@@ -26,11 +32,52 @@ abstract class HasOneOrMany extends Relation
     public function make(array $attributes = []);
 
     /**
+     * @param  iterable<array<model-property<TRelatedModel>, mixed>>  $records
+     * @return Collection<int, TRelatedModel>
+     */
+    public function makeMany($records);
+
+    /**
+     * @param  array<TDeclaringModel>  $models
+     * @param  Collection<int, TRelatedModel>  $results
+     * @param  string  $relation
+     * @return array<TDeclaringModel>
+     */
+    public function matchOne(array $models, Collection $results, $relation);
+
+    /**
+     * @param  array<TDeclaringModel>  $models
+     * @param  Collection<int, TRelatedModel>  $results
+     * @param  string  $relation
+     * @return array<TDeclaringModel>
+     */
+    public function matchMany(array $models, Collection $results, $relation);
+
+    /**
+     * Match the eagerly loaded results to their many parents.
+     *
+     * @param  array<TDeclaringModel>  $models
+     * @param  Collection<int, TRelatedModel>  $results
+     * @param  string  $relation
+     * @phpstan-param  'one'|'many'  $type
+     * @return array<TDeclaringModel>
+     */
+    protected function matchOneOrMany(array $models, Collection $results, $relation, $type);
+
+    /**
+     * Build model dictionary keyed by the relation's foreign key.
+     *
+     * @param  Collection<int, TRelatedModel> $results
+     * @return array<array<TRelatedModel>>
+     */
+    protected function buildDictionary(Collection $results);
+
+    /**
      * Find a model by its primary key or return new instance of the related model.
      *
      * @param  mixed  $id
-     * @param  array<int, mixed>  $columns
-     * @return ($id is (\Illuminate\Contracts\Support\Arrayable<array-key, mixed>|array<mixed>) ? \Illuminate\Support\Collection<int, TRelatedModel> : TRelatedModel)
+     * @param  array<int, (model-property<TRelatedModel>|'*')>  $columns
+     * @phpstan-return ($id is (\Illuminate\Contracts\Support\Arrayable<array-key, mixed>|array<mixed>) ? \Illuminate\Support\Collection<int, TRelatedModel> : TRelatedModel)
      */
     public function findOrNew($id, $columns = ['*']);
 
@@ -38,25 +85,25 @@ abstract class HasOneOrMany extends Relation
      * Get the first related model record matching the attributes or instantiate it.
      *
      * @param  array<model-property<TRelatedModel>, mixed>  $attributes
-     * @param  array<mixed, mixed>  $values
+     * @param  array<model-property<TRelatedModel>, mixed>  $values
      * @return TRelatedModel
      */
-    public function firstOrNew(array $attributes, array $values = []);
+    public function firstOrNew(array $attributes = [], array $values = []);
 
     /**
      * Get the first related record matching the attributes or create it.
      *
      * @param  array<model-property<TRelatedModel>, mixed>  $attributes
-     * @param  array<mixed, mixed>  $values
+     * @param  array<model-property<TRelatedModel>, mixed>  $values
      * @return TRelatedModel
      */
-    public function firstOrCreate(array $attributes, array $values = []);
+    public function firstOrCreate(array $attributes = [], array $values = []);
 
     /**
      * Create or update a related record matching the attributes, and fill it with values.
      *
      * @param  array<model-property<TRelatedModel>, mixed>  $attributes
-     * @param  array<array-key, mixed>  $values
+     * @param  array<model-property<TRelatedModel>, mixed>  $values
      * @return TRelatedModel
      */
     public function updateOrCreate(array $attributes, array $values = []);
@@ -64,10 +111,26 @@ abstract class HasOneOrMany extends Relation
     /**
      * Attach a model instance to the parent model.
      *
-     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  TRelatedModel  $model
      * @return TRelatedModel|false
      */
-    public function save(\Illuminate\Database\Eloquent\Model $model);
+    public function save(Model $model);
+
+    /**
+     * Attach a model instance without raising any events to the parent model.
+     *
+     * @param  TRelatedModel  $model
+     * @return TRelatedModel|false
+     */
+    public function saveQuietly(Model $model);
+
+    /**
+     * Attach a collection of models to the parent instance.
+     *
+     * @param  iterable<TRelatedModel>  $models
+     * @return iterable<TRelatedModel>
+     */
+    public function saveMany($models);
 
     /**
      * @phpstan-param array<model-property<TRelatedModel>, mixed> $attributes
@@ -77,10 +140,26 @@ abstract class HasOneOrMany extends Relation
     public function create(array $attributes = []);
 
     /**
+     * Create a new instance of the related model. Allow mass-assignment.
+     *
+     * @param  array<model-property<TRelatedModel>, mixed> $attributes
+     * @return TRelatedModel
+     */
+    public function forceCreate(array $attributes = []);
+
+    /**
      * Create a Collection of new instances of the related model.
      *
-     * @param  iterable<mixed>  $records
-     * @return \Illuminate\Database\Eloquent\Collection<int, TRelatedModel>
+     * @param  iterable<array<model-property<TRelatedModel>, mixed>>  $records
+     * @return Collection<int, TRelatedModel>
      */
     public function createMany(iterable $records);
+
+    /**
+     * Set the foreign ID for creating a related model.
+     *
+     * @param  TRelatedModel  $model
+     * @return void
+     */
+    protected function setForeignAttributesForCreate(Model $model);
 }

--- a/stubs/HasOneThrough.stub
+++ b/stubs/HasOneThrough.stub
@@ -2,20 +2,19 @@
 
 namespace Illuminate\Database\Eloquent\Relations;
 
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 
-
 /**
- * @template TRelatedModel of Model
- * @template TDeclaringModel of Model
- * @template TIntermediateModel of Model
- * @extends HasManyThrough<TRelatedModel, TDeclaringModel, TIntermediateModel, TRelatedModel>
+ * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+ * @template TDeclaringModel of \Illuminate\Database\Eloquent\Model
+ * @template TIntermediateModel of \Illuminate\Database\Eloquent\Model
+ * @extends \Illuminate\Database\Eloquent\Relations\HasManyThrough<TRelatedModel, TDeclaringModel, TIntermediateModel, TRelatedModel>
  */
 class HasOneThrough extends HasManyThrough
 {
     /**
      * @param  TDeclaringModel  $parent
+     *
      * @return TRelatedModel
      */
     public function newRelatedInstanceFor(Model $parent);

--- a/stubs/HasOneThrough.stub
+++ b/stubs/HasOneThrough.stub
@@ -2,23 +2,21 @@
 
 namespace Illuminate\Database\Eloquent\Relations;
 
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+
 /**
- * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
- * @extends HasManyThrough<TRelatedModel>
+ * @template TRelatedModel of Model
+ * @template TDeclaringModel of Model
+ * @template TIntermediateModel of Model
+ * @extends HasManyThrough<TRelatedModel, TDeclaringModel, TIntermediateModel, TRelatedModel>
  */
 class HasOneThrough extends HasManyThrough
 {
     /**
-     * @param array<model-property<TRelatedModel>, mixed> $attributes
-     *
-     * @phpstan-return TRelatedModel
+     * @param  TDeclaringModel  $parent
+     * @return TRelatedModel
      */
-    public function create(array $attributes = []);
-
-    /**
-     * Get the results of the relationship.
-     *
-     * @phpstan-return \Traversable<int, TRelatedModel>
-     */
-    public function getResults();
+    public function newRelatedInstanceFor(Model $parent);
 }

--- a/stubs/Model.stub
+++ b/stubs/Model.stub
@@ -40,4 +40,7 @@ abstract class Model implements \JsonSerializable, \ArrayAccess
     public static function with($relations);
 }
 
+/**
+ * @template TModel of \Illuminate\Database\Eloquent\Model
+ */
 class ModelNotFoundException extends \RuntimeException {}

--- a/stubs/MorphMany.stub
+++ b/stubs/MorphMany.stub
@@ -3,22 +3,21 @@
 namespace Illuminate\Database\Eloquent\Relations;
 
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 
 /**
- * @template TRelatedModel of Model
- * @template TDeclaringModel of Model
- * @extends MorphOneOrMany<TRelatedModel, TDeclaringModel, Collection<int, TRelatedModel>>
+ * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+ * @template TDeclaringModel of \Illuminate\Database\Eloquent\Model
+ * @extends \Illuminate\Database\Eloquent\Relations\MorphOneOrMany<TRelatedModel, TDeclaringModel, \Illuminate\Database\Eloquent\Collection<int, TRelatedModel>>
  */
 class MorphMany extends MorphOneOrMany
 {
     /**
-     * @param  Builder<TRelatedModel>  $query
-     * @param  TDeclaringModel  $parent
-     * @param  string  $type
-     * @param  string  $id
-     * @param  string  $localKey
+     * @param  \Illuminate\Database\Eloquent\Builder<TRelatedModel>  $query
+     * @param  TDeclaringModel                                       $parent
+     * @param  string                                                $type
+     * @param  string                                                $id
+     * @param  string                                                $localKey
      */
     public function __construct(Builder $query, Model $parent, $type, $id, $localKey);
 }

--- a/stubs/MorphMany.stub
+++ b/stubs/MorphMany.stub
@@ -2,23 +2,23 @@
 
 namespace Illuminate\Database\Eloquent\Relations;
 
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
+
 /**
- * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
- * @extends MorphOneOrMany<TRelatedModel>
+ * @template TRelatedModel of Model
+ * @template TDeclaringModel of Model
+ * @extends MorphOneOrMany<TRelatedModel, TDeclaringModel, Collection<int, TRelatedModel>>
  */
 class MorphMany extends MorphOneOrMany
 {
     /**
-     * @param array<model-property<TRelatedModel>, mixed> $attributes
-     *
-     * @phpstan-return TRelatedModel
+     * @param  Builder<TRelatedModel>  $query
+     * @param  TDeclaringModel  $parent
+     * @param  string  $type
+     * @param  string  $id
+     * @param  string  $localKey
      */
-    public function create(array $attributes = []);
-
-    /**
-     * Get the results of the relationship.
-     *
-     * @phpstan-return \Traversable<int, TRelatedModel>
-     */
-    public function getResults();
+    public function __construct(Builder $query, Model $parent, $type, $id, $localKey);
 }

--- a/stubs/MorphOne.stub
+++ b/stubs/MorphOne.stub
@@ -2,16 +2,13 @@
 
 namespace Illuminate\Database\Eloquent\Relations;
 
+use Illuminate\Database\Eloquent\Model;
+
 /**
- * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
- * @extends MorphOneOrMany<TRelatedModel>
+ * @template TRelatedModel of Model
+ * @template TDeclaringModel of Model
+ * @extends MorphOneOrMany<TRelatedModel, TDeclaringModel, ?TRelatedModel>
  */
 class MorphOne extends MorphOneOrMany
 {
-    /**
-     * Get the results of the relationship.
-     *
-     * @phpstan-return ?TRelatedModel
-     */
-    public function getResults();
 }

--- a/stubs/MorphOne.stub
+++ b/stubs/MorphOne.stub
@@ -2,12 +2,10 @@
 
 namespace Illuminate\Database\Eloquent\Relations;
 
-use Illuminate\Database\Eloquent\Model;
-
 /**
- * @template TRelatedModel of Model
- * @template TDeclaringModel of Model
- * @extends MorphOneOrMany<TRelatedModel, TDeclaringModel, ?TRelatedModel>
+ * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+ * @template TDeclaringModel of \Illuminate\Database\Eloquent\Model
+ * @extends \Illuminate\Database\Eloquent\Relations\MorphOneOrMany<TRelatedModel, TDeclaringModel, ?TRelatedModel>
  */
 class MorphOne extends MorphOneOrMany
 {

--- a/stubs/MorphOneOrMany.stub
+++ b/stubs/MorphOneOrMany.stub
@@ -6,28 +6,29 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 
 /**
- * @template TRelatedModel of Model
- * @template TDeclaringModel of Model
+ * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+ * @template TDeclaringModel of \Illuminate\Database\Eloquent\Model
  * @template TResult
- * @extends HasOneOrMany<TRelatedModel, TDeclaringModel, TResult>
+ * @extends \Illuminate\Database\Eloquent\Relations\HasOneOrMany<TRelatedModel, TDeclaringModel, TResult>
  */
 abstract class MorphOneOrMany extends HasOneOrMany
 {
    /**
-    * @param  Builder<TRelatedModel>  $query
-    * @param  TDeclaringModel  $parent
-    * @param  string  $type
-    * @param  string  $id
-    * @param  string  $localKey
+    * @param  \Illuminate\Database\Eloquent\Builder<TRelatedModel>  $query
+    * @param  TDeclaringModel                                       $parent
+    * @param  string                                                $type
+    * @param  string                                                $id
+    * @param  string                                                $localKey
     */
    public function __construct(Builder $query, Model $parent, $type, $id, $localKey);
 
     /**
      * Add constraints for inner join subselect for one of many relationships.
      *
-     * @param  Builder<TRelatedModel>  $query
-     * @param  model-property<TRelatedModel>|null  $column
-     * @param  string|null  $aggregate
+     * @param  \Illuminate\Database\Eloquent\Builder<TRelatedModel>  $query
+     * @param  model-property<TRelatedModel>|null                    $column
+     * @param  string|null                                           $aggregate
+     *
      * @return void
      */
     public function addOneOfManySubQueryConstraints(Builder $query, $column = null, $aggregate = null);
@@ -36,6 +37,7 @@ abstract class MorphOneOrMany extends HasOneOrMany
      * Make a new related instance for the given model.
      *
      * @param  TDeclaringModel  $parent
+     *
      * @return TRelatedModel
      */
     public function newRelatedInstanceFor(Model $parent);
@@ -43,7 +45,8 @@ abstract class MorphOneOrMany extends HasOneOrMany
     /**
      * Get the value of the model's foreign key.
      *
-     * @param  TRelatedModel $model
+     * @param  TRelatedModel  $model
+     *
      * @return mixed
      */
     protected function getRelatedKeyFrom(Model $model);

--- a/stubs/MorphOneOrMany.stub
+++ b/stubs/MorphOneOrMany.stub
@@ -2,16 +2,49 @@
 
 namespace Illuminate\Database\Eloquent\Relations;
 
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
 /**
- * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
- * @extends HasOneOrMany<TRelatedModel>
+ * @template TRelatedModel of Model
+ * @template TDeclaringModel of Model
+ * @template TResult
+ * @extends HasOneOrMany<TRelatedModel, TDeclaringModel, TResult>
  */
 abstract class MorphOneOrMany extends HasOneOrMany
 {
+   /**
+    * @param  Builder<TRelatedModel>  $query
+    * @param  TDeclaringModel  $parent
+    * @param  string  $type
+    * @param  string  $id
+    * @param  string  $localKey
+    */
+   public function __construct(Builder $query, Model $parent, $type, $id, $localKey);
+
     /**
-     * @param array<model-property<TRelatedModel>, mixed> $attributes
+     * Add constraints for inner join subselect for one of many relationships.
      *
-     * @phpstan-return TRelatedModel
+     * @param  Builder<TRelatedModel>  $query
+     * @param  model-property<TRelatedModel>|null  $column
+     * @param  string|null  $aggregate
+     * @return void
      */
-    public function create(array $attributes = []);
+    public function addOneOfManySubQueryConstraints(Builder $query, $column = null, $aggregate = null);
+
+    /**
+     * Make a new related instance for the given model.
+     *
+     * @param  TDeclaringModel  $parent
+     * @return TRelatedModel
+     */
+    public function newRelatedInstanceFor(Model $parent);
+
+    /**
+     * Get the value of the model's foreign key.
+     *
+     * @param  TRelatedModel $model
+     * @return mixed
+     */
+    protected function getRelatedKeyFrom(Model $model);
 }

--- a/stubs/MorphTo.stub
+++ b/stubs/MorphTo.stub
@@ -6,19 +6,19 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 
 /**
- * @template TRelatedModel of Model
- * @template TDeclaringModel of Model
- * @extends BelongsTo<TRelatedModel, TDeclaringModel>
+ * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+ * @template TDeclaringModel of \Illuminate\Database\Eloquent\Model
+ * @extends \Illuminate\Database\Eloquent\Relations\BelongsTo<TRelatedModel, TDeclaringModel>
  */
 class MorphTo extends BelongsTo
 {
     /**
-     * @param  Builder<TRelatedModel>  $query
-     * @param  TDeclaringModel  $parent
-     * @param  string  $foreignKey
-     * @param  string  $ownerKey
-     * @param  string  $type
-     * @param  string  $relation
+     * @param  \Illuminate\Database\Eloquent\Builder<TRelatedModel>  $query
+     * @param  TDeclaringModel                                       $parent
+     * @param  string                                                $foreignKey
+     * @param  string                                                $ownerKey
+     * @param  string                                                $type
+     * @param  string                                                $relation
      */
     public function __construct(Builder $query, Model $parent, $foreignKey, $ownerKey, $type, $relation);
 }

--- a/stubs/MorphTo.stub
+++ b/stubs/MorphTo.stub
@@ -2,10 +2,23 @@
 
 namespace Illuminate\Database\Eloquent\Relations;
 
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
 /**
- * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
- * @template TChildModel of \Illuminate\Database\Eloquent\Model
- * @extends BelongsTo<TRelatedModel, TChildModel>
+ * @template TRelatedModel of Model
+ * @template TDeclaringModel of Model
+ * @extends BelongsTo<TRelatedModel, TDeclaringModel>
  */
 class MorphTo extends BelongsTo
-{}
+{
+    /**
+     * @param  Builder<TRelatedModel>  $query
+     * @param  TDeclaringModel  $parent
+     * @param  string  $foreignKey
+     * @param  string  $ownerKey
+     * @param  string  $type
+     * @param  string  $relation
+     */
+    public function __construct(Builder $query, Model $parent, $foreignKey, $ownerKey, $type, $relation);
+}

--- a/stubs/MorphToMany.stub
+++ b/stubs/MorphToMany.stub
@@ -2,10 +2,30 @@
 
 namespace Illuminate\Database\Eloquent\Relations;
 
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
 /**
- * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
- * @extends BelongsToMany<TRelatedModel>
+ * @template TRelatedModel of Model
+ * @template TDeclaringModel of Model
+ * @extends BelongsToMany<TRelatedModel, TDeclaringModel>
  */
 class MorphToMany extends BelongsToMany
 {
+    /**
+     * Create a new morph to many relationship instance.
+     *
+     * @param  Builder<TRelatedModel>  $query
+     * @param  TDeclaringModel  $parent
+     * @param  string  $name
+     * @param  string  $table
+     * @param  string  $foreignPivotKey
+     * @param  string  $relatedPivotKey
+     * @param  string  $parentKey
+     * @param  string  $relatedKey
+     * @param  string|null  $relationName
+     * @param  bool  $inverse
+     */
+    public function __construct(Builder $query, Model $parent, $name, $table, $foreignPivotKey,
+                                $relatedPivotKey, $parentKey, $relatedKey, $relationName = null, $inverse = false);
 }

--- a/stubs/MorphToMany.stub
+++ b/stubs/MorphToMany.stub
@@ -6,25 +6,25 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 
 /**
- * @template TRelatedModel of Model
- * @template TDeclaringModel of Model
- * @extends BelongsToMany<TRelatedModel, TDeclaringModel>
+ * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+ * @template TDeclaringModel of \Illuminate\Database\Eloquent\Model
+ * @extends \Illuminate\Database\Eloquent\Relations\BelongsToMany<TRelatedModel, TDeclaringModel>
  */
 class MorphToMany extends BelongsToMany
 {
     /**
      * Create a new morph to many relationship instance.
      *
-     * @param  Builder<TRelatedModel>  $query
-     * @param  TDeclaringModel  $parent
-     * @param  string  $name
-     * @param  string  $table
-     * @param  string  $foreignPivotKey
-     * @param  string  $relatedPivotKey
-     * @param  string  $parentKey
-     * @param  string  $relatedKey
-     * @param  string|null  $relationName
-     * @param  bool  $inverse
+     * @param  \Illuminate\Database\Eloquent\Builder<TRelatedModel>  $query
+     * @param  TDeclaringModel                                       $parent
+     * @param  string                                                $name
+     * @param  string                                                $table
+     * @param  string                                                $foreignPivotKey
+     * @param  string                                                $relatedPivotKey
+     * @param  string                                                $parentKey
+     * @param  string                                                $relatedKey
+     * @param  string|null                                           $relationName
+     * @param  bool                                                  $inverse
      */
     public function __construct(Builder $query, Model $parent, $name, $table, $foreignPivotKey,
                                 $relatedPivotKey, $parentKey, $relatedKey, $relationName = null, $inverse = false);

--- a/stubs/Relation.stub
+++ b/stubs/Relation.stub
@@ -103,8 +103,8 @@ abstract class Relation
     public function getRelationExistenceQuery(Builder $query, Builder $parentQuery, $columns = ['*']);
 
     /**
-     * @param  array<TRelatedModel>  $models
-     * @param  model-property<TRelatedModel>|null  $key
+     * @param  array<TDeclaringModel>  $models
+     * @param  model-property<TDeclaringModel>|null  $key
      * @return array<int, mixed>
      */
     protected function getKeys(array $models, $key = null);

--- a/stubs/Relation.stub
+++ b/stubs/Relation.stub
@@ -2,19 +2,132 @@
 
 namespace Illuminate\Database\Eloquent\Relations;
 
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
+
 /**
- * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+ * @template TRelatedModel of Model
+ * @template TDeclaringModel of Model
+ * @template TResult
  */
 abstract class Relation
 {
     /**
+     * @var Builder<TRelatedModel>
+     */
+    protected $query;
+
+    /**
+     * @var TDeclaringModel
+     */
+    protected $parent;
+
+    /**
+     * @var TRelatedModel
+     */
+    protected $related;
+
+    /**
+     * @param Builder<TRelatedModel> $query
+     * @param TDeclaringModel $parent
+     */
+    public function __construct(Builder $query, Model $parent);
+
+    /**
+     * @param  array<TDeclaringModel>  $models
+     * @return void
+     */
+    abstract public function addEagerConstraints(array $models);
+
+    /**
+     * Initialize the relation on a set of models.
+     *
+     * @param  array<TDeclaringModel> $models
+     * @param  model-property<TDeclaringModel> $relation
+     * @return array<TDeclaringModel>
+     */
+    abstract public function initRelation(array $models, $relation);
+
+    /**
+     * @param array<TDeclaringModel> $models
+     * @param Collection<int, TRelatedModel> $results
+     * @param string $relation
+     * @return array<TDeclaringModel>
+     */
+    abstract public function match(array $models, Collection $results, $relation);
+
+    /**
+     * @return TResult
+     */
+    abstract public function getResults();
+
+    /**
+     * @return Collection<int, TRelatedModel>
+     */
+    public function getEager();
+
+    /**
+     * @param  array<model-property<TRelatedModel>|'*'> $columns
+     * @return TRelatedModel
+     */
+    public function sole($columns = ['*']);
+
+    /**
      * Execute the query as a "select" statement.
      *
-     * @param array<int, string> $columns
-     * @phpstan-return \Illuminate\Database\Eloquent\Collection<int, TRelatedModel>
+     * @param array<model-property<TRelatedModel>|'*'> $columns
+     * @phpstan-return Collection<int, TRelatedModel>
      */
     public function get($columns = ['*']);
 
+    /**
+     * @param  array<model-property<TRelatedModel>, mixed>  $attributes
+     * @return int
+     */
+    public function rawUpdate(array $attributes = []);
+
+    /**
+     * @param  Builder<TRelatedModel>  $query
+     * @param  Builder<TDeclaringModel>  $parentQuery
+     * @return Builder<TRelatedModel>
+     */
+    public function getRelationExistenceCountQuery(Builder $query, Builder $parentQuery);
+
+    /**
+     * @param  Builder<TRelatedModel> $query
+     * @param  Builder<TDeclaringModel> $parentQuery
+     * @param  array<model-property<TRelatedModel>|'*'> $columns
+     * @return Builder<TRelatedModel>
+     */
+    public function getRelationExistenceQuery(Builder $query, Builder $parentQuery, $columns = ['*']);
+
+    /**
+     * @param  array<TRelatedModel>  $models
+     * @param  model-property<TRelatedModel>|null  $key
+     * @return array<int, mixed>
+     */
+    protected function getKeys(array $models, $key = null);
+
+    /**
+     * @return Builder<TRelatedModel>
+     */
+    protected function getRelationQuery();
+
+    /**
+     * @return Builder<TRelatedModel>
+     */
+    public function getQuery();
+
+    /**
+     * @return TDeclaringModel
+     */
+    public function getParent();
+
+    /**
+     * @return TRelatedModel
+     */
+    public function getRelated();
 
     /**
      * @param array<model-property<TRelatedModel>, mixed> $attributes

--- a/stubs/Relation.stub
+++ b/stubs/Relation.stub
@@ -7,14 +7,14 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 
 /**
- * @template TRelatedModel of Model
- * @template TDeclaringModel of Model
+ * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+ * @template TDeclaringModel of \Illuminate\Database\Eloquent\Model
  * @template TResult
  */
 abstract class Relation
 {
     /**
-     * @var Builder<TRelatedModel>
+     * @var \Illuminate\Database\Eloquent\Builder<TRelatedModel>
      */
     protected $query;
 
@@ -29,13 +29,14 @@ abstract class Relation
     protected $related;
 
     /**
-     * @param Builder<TRelatedModel> $query
-     * @param TDeclaringModel $parent
+     * @param  \Illuminate\Database\Eloquent\Builder<TRelatedModel>  $query
+     * @param  TDeclaringModel                                       $parent
      */
     public function __construct(Builder $query, Model $parent);
 
     /**
      * @param  array<TDeclaringModel>  $models
+     *
      * @return void
      */
     abstract public function addEagerConstraints(array $models);
@@ -43,16 +44,18 @@ abstract class Relation
     /**
      * Initialize the relation on a set of models.
      *
-     * @param  array<TDeclaringModel> $models
-     * @param  model-property<TDeclaringModel> $relation
+     * @param  array<TDeclaringModel>           $models
+     * @param  model-property<TDeclaringModel>  $relation
+     *
      * @return array<TDeclaringModel>
      */
     abstract public function initRelation(array $models, $relation);
 
     /**
-     * @param array<TDeclaringModel> $models
-     * @param Collection<int, TRelatedModel> $results
-     * @param string $relation
+     * @param  array<TDeclaringModel>                                        $models
+     * @param  \Illuminate\Database\Eloquent\Collection<int, TRelatedModel>  $results
+     * @param  string                                                        $relation
+     *
      * @return array<TDeclaringModel>
      */
     abstract public function match(array $models, Collection $results, $relation);
@@ -63,12 +66,13 @@ abstract class Relation
     abstract public function getResults();
 
     /**
-     * @return Collection<int, TRelatedModel>
+     * @return \Illuminate\Database\Eloquent\Collection<int, TRelatedModel>
      */
     public function getEager();
 
     /**
-     * @param  array<model-property<TRelatedModel>|'*'> $columns
+     * @param  array<model-property<TRelatedModel>|'*'>  $columns
+     *
      * @return TRelatedModel
      */
     public function sole($columns = ['*']);
@@ -76,8 +80,9 @@ abstract class Relation
     /**
      * Execute the query as a "select" statement.
      *
-     * @param array<model-property<TRelatedModel>|'*'> $columns
-     * @phpstan-return Collection<int, TRelatedModel>
+     * @param  array<model-property<TRelatedModel>|'*'>  $columns
+     *
+     * @return \Illuminate\Database\Eloquent\Collection<int, TRelatedModel>
      */
     public function get($columns = ['*']);
 
@@ -88,34 +93,36 @@ abstract class Relation
     public function rawUpdate(array $attributes = []);
 
     /**
-     * @param  Builder<TRelatedModel>  $query
-     * @param  Builder<TDeclaringModel>  $parentQuery
-     * @return Builder<TRelatedModel>
+     * @param  \Illuminate\Database\Eloquent\Builder<TRelatedModel>    $query
+     * @param  \Illuminate\Database\Eloquent\Builder<TDeclaringModel>  $parentQuery
+     *
+     * @return \Illuminate\Database\Eloquent\Builder<TRelatedModel>
      */
     public function getRelationExistenceCountQuery(Builder $query, Builder $parentQuery);
 
     /**
-     * @param  Builder<TRelatedModel> $query
-     * @param  Builder<TDeclaringModel> $parentQuery
-     * @param  array<model-property<TRelatedModel>|'*'> $columns
-     * @return Builder<TRelatedModel>
+     * @param  \Illuminate\Database\Eloquent\Builder<TRelatedModel>    $query
+     * @param  \Illuminate\Database\Eloquent\Builder<TDeclaringModel>  $parentQuery
+     * @param  array<model-property<TRelatedModel>|'*'>                $columns
+     * @return \Illuminate\Database\Eloquent\Builder<TRelatedModel>
      */
     public function getRelationExistenceQuery(Builder $query, Builder $parentQuery, $columns = ['*']);
 
     /**
-     * @param  array<TDeclaringModel>  $models
+     * @param  array<TDeclaringModel>                $models
      * @param  model-property<TDeclaringModel>|null  $key
+     *
      * @return array<int, mixed>
      */
     protected function getKeys(array $models, $key = null);
 
     /**
-     * @return Builder<TRelatedModel>
+     * @return \Illuminate\Database\Eloquent\Builder<TRelatedModel>
      */
     protected function getRelationQuery();
 
     /**
-     * @return Builder<TRelatedModel>
+     * @return \Illuminate\Database\Eloquent\Builder<TRelatedModel>
      */
     public function getQuery();
 
@@ -131,7 +138,8 @@ abstract class Relation
 
     /**
      * @param array<model-property<TRelatedModel>, mixed> $attributes
-     * @phpstan-return TRelatedModel
+     *
+     * @return TRelatedModel
      */
     public function make(array $attributes = []);
 }

--- a/tests/Application/HasManySyncable.php
+++ b/tests/Application/HasManySyncable.php
@@ -6,7 +6,8 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 
 /**
  * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
- * @extends HasMany<TRelatedModel>
+ * @template TDeclaringModel of \Illuminate\Database\Eloquent\Model
+ * @extends HasMany<TRelatedModel, TDeclaringModel>
  */
 class HasManySyncable extends HasMany
 {

--- a/tests/Application/app/Group.php
+++ b/tests/Application/app/Group.php
@@ -13,13 +13,13 @@ class Group extends Model
 {
     use NestedSoftDeletes;
 
-    /** @phpstan-return HasMany<Account> */
+    /** @phpstan-return HasMany<Account, Group> */
     public function accounts(): HasMany
     {
         return $this->hasMany(Account::class);
     }
 
-    /** @phpstan-return HasMany<User> */
+    /** @phpstan-return HasMany<User, Group> */
     public function users(): HasMany
     {
         return $this->hasMany(User::class);

--- a/tests/Application/app/User.php
+++ b/tests/Application/app/User.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\AsArrayObject;
 use Illuminate\Database\Eloquent\Casts\AsCollection;
 use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -89,12 +90,13 @@ class User extends Authenticatable
         return $this->belongsTo(Group::class)->withTrashed();
     }
 
-    /** @phpstan-return HasMany<Account> */
+    /** @phpstan-return HasMany<Account, User> */
     public function accounts(): HasMany
     {
         return $this->hasMany(Account::class);
     }
 
+    /** @phpstan-return HasManyThrough<Transaction, User, Account, Collection<Transaction>> */
     public function transactions(): HasManyThrough
     {
         return $this->hasManyThrough(Transaction::class, Account::class);

--- a/tests/Features/Methods/HigherOrderCollectionProxyMethods.php
+++ b/tests/Features/Methods/HigherOrderCollectionProxyMethods.php
@@ -72,7 +72,7 @@ class HigherOrderCollectionProxyMethods
         return $this->users->map->isActive();
     }
 
-    /** @return SupportCollection<int, HasMany<Account>> */
+    /** @return SupportCollection<int, HasMany<Account, User>> */
     public function testMapWithRelationMethod(): SupportCollection
     {
         return $this->users->map->accounts();

--- a/tests/Features/Models/Relations.php
+++ b/tests/Features/Models/Relations.php
@@ -28,19 +28,19 @@ class Relations
         return $user->accounts()->firstOrCreate([]);
     }
 
-    /** @phpstan-return HasMany<Account> */
+    /** @phpstan-return HasMany<Account, User> */
     public function testRelationWhere(): HasMany
     {
         return (new User())->accounts()->where('name', 'bar');
     }
 
-    /** @phpstan-return HasMany<Account> */
+    /** @phpstan-return HasMany<Account, User> */
     public function testRelationWhereIn(): HasMany
     {
         return (new User())->accounts()->whereIn('id', [1, 2, 3]);
     }
 
-    /** @phpstan-return HasMany<Account> */
+    /** @phpstan-return HasMany<Account, User> */
     public function testRelationDynamicWhere(): HasMany
     {
         return (new User())->accounts()->whereActive(true);
@@ -99,13 +99,13 @@ class Relations
         return $address->addressable()->where('name', 'bar');
     }
 
-    /** @return MorphMany<\App\Address> */
+    /** @return MorphMany<\App\Address, User> */
     public function testMorphMany(User $user): MorphMany
     {
         return $user->address()->where('name', 'bar');
     }
 
-    /** @phpstan-return HasMany<Account> */
+    /** @phpstan-return HasMany<Account, User> */
     public function testModelScopesOnRelation(User $user): HasMany
     {
         return $user->accounts()->active();
@@ -171,7 +171,7 @@ class Relations
         return $account->parent();
     }
 
-    /** @phpstan-return HasMany<User> */
+    /** @phpstan-return HasMany<User, User> */
     public function testSameClassRelation(User $user): HasMany
     {
         return $user->children();
@@ -212,7 +212,7 @@ class Relations
     }
 
     /**
-     * @phpstan-return MorphToMany<Address>
+     * @phpstan-return MorphToMany<Address, Tag>
      */
     public function testMorphToManyWithTimestamps(Tag $tag): MorphToMany
     {
@@ -220,7 +220,7 @@ class Relations
     }
 
     /**
-     * @phpstan-return MorphToMany<Address>
+     * @phpstan-return MorphToMany<Address, Tag>
      */
     public function testMorphToManyWithPivot(Tag $tag): MorphToMany
     {
@@ -270,7 +270,7 @@ class Relations
  */
 class RelationCreateExample extends Model
 {
-    /** @return HasMany<User> */
+    /** @return HasMany<User, RelationCreateExample> */
     public function relation(): HasMany
     {
         return $this->hasMany(User::class);
@@ -284,7 +284,7 @@ class RelationCreateExample extends Model
 
 class ModelWithoutPropertyAnnotation extends Model
 {
-    /** @return HasMany<User> */
+    /** @return HasMany<User, ModelWithoutPropertyAnnotation> */
     public function relation(): HasMany
     {
         return $this->hasMany(User::class);
@@ -299,13 +299,13 @@ class ModelWithoutPropertyAnnotation extends Model
  */
 class ModelWithPropertyAnnotations extends Model
 {
-    /** @return HasOne<User> */
+    /** @return HasOne<User, ModelWithPropertyAnnotations> */
     public function nullableUser(): HasOne
     {
         return $this->hasOne(User::class);
     }
 
-    /** @return HasOne<User> */
+    /** @return HasOne<User, ModelWithPropertyAnnotations> */
     public function nonNullableUser(): HasOne
     {
         return $this->hasOne(User::class);
@@ -329,7 +329,7 @@ class ExtendsModelWithPropertyAnnotations extends ModelWithPropertyAnnotations
 class Tag extends Model
 {
     /**
-     * @phpstan-return MorphToMany<Address>
+     * @phpstan-return MorphToMany<Address, Tag>
      */
     public function addresses(): MorphToMany
     {
@@ -337,7 +337,7 @@ class Tag extends Model
     }
 
     /**
-     * @phpstan-return MorphToMany<Address>
+     * @phpstan-return MorphToMany<Address, Tag>
      */
     public function addressesWithPivot(): MorphToMany
     {

--- a/tests/Features/Models/Scopes.php
+++ b/tests/Features/Models/Scopes.php
@@ -16,13 +16,13 @@ class Scopes extends Model
     /** @var User */
     private $user;
 
-    /** @phpstan-return HasOne<User> */
+    /** @phpstan-return HasOne<User, Scopes> */
     public function testScopeAfterRelation(): HasOne
     {
         return $this->hasOne(User::class)->active();
     }
 
-    /** @phpstan-return HasMany<User> */
+    /** @phpstan-return HasMany<User, Scopes> */
     public function testScopeAfterRelationWithHasMany(): HasMany
     {
         return $this->hasMany(User::class)->active();

--- a/tests/Features/Properties/ModelRelationsExtension.php
+++ b/tests/Features/Properties/ModelRelationsExtension.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Features\Properties;
 
 use App\User;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -41,13 +42,13 @@ class ModelRelationsExtension
 
 class DummyModel extends Model
 {
-    /** @return HasMany<OtherDummyModel> */
+    /** @return HasMany<OtherDummyModel, DummyModel> */
     public function hasManyRelation(): HasMany
     {
         return $this->hasMany(OtherDummyModel::class);
     }
 
-    /** @return HasManyThrough<OtherDummyModel> */
+    /** @return HasManyThrough<OtherDummyModel, DummyModel, User, Collection<int, OtherDummyModel>> */
     public function hasManyThroughRelation(): HasManyThrough
     {
         return $this->hasManyThrough(OtherDummyModel::class, User::class);

--- a/tests/Features/Relations/HasSortableMany.php
+++ b/tests/Features/Relations/HasSortableMany.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Features\Relations;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+ * @template TDeclaringModel of \Illuminate\Database\Eloquent\Model&\Tests\Features\Relations\HasSortingAttribute
+ * @extends \Illuminate\Database\Eloquent\Relations\HasMany<TRelatedModel, TDeclaringModel>
+ */
+class HasSortableMany extends HasMany
+{
+    /**
+     * Set the constraint for a single parent model.
+     *
+     * @internal Here we exploit that `$this->parent` is defined as
+     * `TDeclaringModel` in the base class, otherwise
+     * `$this->parent->getSortingCriterion()` and `$this->parent->getSortingDirection()`
+     * would be undefined.
+     *
+     * @return void
+     */
+    public function addConstraints(): void
+    {
+        if (static::$constraints) {
+            $query = $this->getRelationQuery();
+
+            $query
+                ->where($this->foreignKey, '=', $this->getParentKey())
+                ->orderBy($this->parent->getSortingCriterion(), $this->parent->getSortingDirection());
+        }
+    }
+
+    /**
+     * Set the constraints for an eager load of the relation.
+     *
+     * @param  array<TDeclaringModel>  $models
+     * @return void
+     */
+    public function addEagerConstraints(array $models): void
+    {
+        $query = $this->getRelationQuery();
+        foreach ($models as $model) {
+            $query->union(
+                $query->newQuery()
+                    ->where($this->foreignKey, '=', $model->getKey())
+                    ->orderBy($model->getSortingCriterion(), $model->getSortingDirection()),
+                true
+            );
+        }
+    }
+}
+
+interface HasSortingAttribute
+{
+    public function getSortingCriterion(): string;
+
+    public function getSortingDirection(): string;
+}
+
+class Post extends Model
+{
+}
+
+class Topic extends Model implements HasSortingAttribute
+{
+    public function getSortingCriterion(): string
+    {
+        return 'created_at';
+    }
+
+    public function getSortingDirection(): string
+    {
+        return 'asc';
+    }
+
+    /**
+     * @return HasSortableMany<Post, Topic>
+     */
+    public function posts(): HasSortableMany
+    {
+        /** @phpstan-ignore-next-line, see https://github.com/phpstan/phpstan/issues/6732 */
+        return new HasSortableMany(Post::query(), $this, 'posts.topic_id', 'id');
+    }
+}

--- a/tests/Features/ReturnTypes/CustomEloquentBuilderTest.php
+++ b/tests/Features/ReturnTypes/CustomEloquentBuilderTest.php
@@ -35,7 +35,7 @@ class CustomEloquentBuilderTest
         return ModelWithCustomBuilder::type('foo');
     }
 
-    /** @phpstan-return HasMany<ModelWithCustomBuilder> */
+    /** @phpstan-return HasMany<ModelWithCustomBuilder, FooModel> */
     public function testCustomBuilderMethodThroughRelation(): HasMany
     {
         $foo = new FooModel();
@@ -215,7 +215,7 @@ class CustomEloquentBuilderTest
 
 class FooModel extends Model
 {
-    /** @return HasMany<ModelWithCustomBuilder> */
+    /** @return HasMany<ModelWithCustomBuilder, FooModel> */
     public function customModels(): HasMany
     {
         return $this->hasMany(ModelWithCustomBuilder::class);
@@ -230,7 +230,7 @@ class FooModel extends Model
 class ModelWithCustomBuilder extends Model
 {
     // Dummy relation
-    /** @return HasMany<User> */
+    /** @return HasMany<User, ModelWithCustomBuilder> */
     public function users(): HasMany
     {
         return $this->hasMany(User::class);


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes
- [x] Updated CHANGELOG.md

Resolves #1284

**Changes**

This PR

 - heavily adds more PHPstan annotations to the `Relation`-related classes and
 - introduces two, resp. three, new template parameters besides the already existing `TRelatedModel`:
    - `TDeclaringModel`
    - `TResult`
    - `TIntermediateModel` (only in case of the `...Through...`-relations)

Therewith it also resolves issue #1284.

_Rationale_

A relation links two models with each other which are not necessary identical. The `TRelatedModel` is the type of model to which the relaton points to. The `TDeclaringModel` is the type of model which declares the relation (i.e. the "base" of the arrow in the picture).

![relation](https://user-images.githubusercontent.com/7428426/174491616-0e06adee-4e49-4bb7-84a1-25aef18139dd.svg)

Note that the roles `TRelatedModel` and `TDeclaringModel` are independent of the definition of the foreign key on SQL layer. In the example above, only `Post` has an attribute `topic_id` to realize a (1:*)-relation. But the relations `hasMany` and `belongsTo` live on the "object space" and each points from its declaring model to the related model.

In its most general form a `Relation` has a third template type `TResult` which _is not_ necessarily a model. Typically `TResult` is either identical to `TRelatedModel` or a `Collection<int, TRelatedModel>`. This is true for the `Has...One` and `Has...Many`-relations. The latter also shows why `TResult` must not be restricted to a sub-type of `Model`.

However, for custom relations which extend `Relation` this must not be true. For example, instead of an Eloquent collection a custom relation could use another type of container, like a `FixedSizeArray<TRelatedModel>` which provides higher efficiency if one has a (1:_n_)-relation for a fixed _n_. (See https://github.com/nunomaduro/larastan/discussions/1275#discussion-4138347 for a real-world example.) However, `TResult` could also be something like `\DateTime`. In the example above, a topic could have two relations `HasDateOfLeastRecentPost` and `HasDateOfMostRecentPost` which resolve to the date/time of the least/most recent post. In other words, the result of a relation is a value which depends on the related model(s), but is not necessarily the related model(s).

_A Remark on Notation_

I chose the term `TDeclaringModel` over `TParentModel` intentionally, although Laravel calls this model the "parent model" of the relation in most cases and the corresponding variable is called `$parent`. See 

https://github.com/laravel/framework/blob/9.x/src/Illuminate/Database/Eloquent/Relations/Relation.php#L30-L35

However, it does not do so consistently. In `BelongsTo` the names are not used according to their usage in the code but are based on the use case. The declaring model is named the "child model" and the "parent" becomes the related model. See

https://github.com/laravel/framework/blob/9.x/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php#L62-L65

Even worse `BelongsTo` does not apply this change of names consistently, i.e. the related model and the declaring model are both called the parent model. In order to avoid strange constructs like `TParentModel $child`, I decided to use `TDeclaringModel`. Moreover, the term "declaring" class has already been used inside the Larastan sources.

This gives the following table

| Template parameter | Classes `Relation`, `HasMany`, `HasOne`, ..., `BelongsToMany` | Class `BelongsTo` (only) |
|:---------------------------|:--------------------------------------------------------------------------|:--------------------------|
| `TRelatedModel`      | `$related`                                                                         | `$related`                |
| `TDeclaringModel`   | `$parent`                                                                          | `$child`                   |


**Breaking changes**

The `Relation`-related classes now require up to four template parameters.

There should be no breaking change for ordinary users which only use the provided relations and create relations via the methods `hasMany`, `hasOne`, ..., etc. provided by [`\Illuminate\Database\Eloquent\Concerns\HasRelationships`](https://github.com/laravel/framework/blob/9.x/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php). The classes [`ModelRelationsDynamicMethodReturnTypeExtension`](https://github.com/nunomaduro/larastan/commit/427c38b0fae617c735c12f43b003856321567037#diff-af11dc0a6cb05bc6063795b995b97210c60aeee56368b84f649bbb7052210d7b) and [`RelationDynamicMethodReturnTypeExtension`](https://github.com/nunomaduro/larastan/commit/d271a3297c359308b780bc072a542a9212b79323#diff-aada7b039f78eb30ba0fb377413da4c64a98e1fbc96894f427735d4831666e86) have been adopted to bound all template parameters accordingly.

A breaking change may occur for users which implement their own relation classes and extend from `Relation` or its sub-classes. They need to bind the newly added template parameters. But I assume this group to be rather small. Otherwise someone else would already have recognized this bug earlier.