### PR TITLE
fix type specification for blank helper

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -339,6 +339,11 @@ services:
             negate: true
 
     -
+        class: NunoMaduro\Larastan\Types\BlankFunctionTypeSpecifyingExtension
+        tags:
+            - phpstan.typeSpecifier.functionTypeSpecifyingExtension
+            
+    -
         class: NunoMaduro\Larastan\ReturnTypes\Helpers\AppExtension
         tags:
             - phpstan.broker.dynamicFunctionReturnTypeExtension

--- a/src/Types/BlankFunctionTypeSpecifyingExtension.php
+++ b/src/Types/BlankFunctionTypeSpecifyingExtension.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\Larastan\Types;
+
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Analyser\SpecifiedTypes;
+use PHPStan\Analyser\TypeSpecifier;
+use PHPStan\Analyser\TypeSpecifierAwareExtension;
+use PHPStan\Analyser\TypeSpecifierContext;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\Constant\ConstantArrayType;
+use PHPStan\Type\Constant\ConstantBooleanType;
+use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\FunctionTypeSpecifyingExtension;
+use PHPStan\Type\NullType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+use PHPStan\Type\UnionType;
+
+final class BlankFunctionTypeSpecifyingExtension implements FunctionTypeSpecifyingExtension, TypeSpecifierAwareExtension
+{
+    /** @var TypeSpecifier */
+    private $typeSpecifier;
+
+    public function isFunctionSupported(
+        FunctionReflection $functionReflection,
+        FuncCall $node,
+        TypeSpecifierContext $context
+    ): bool {
+        return $functionReflection->getName() === 'blank' && ! $context->null() && isset($node->getArgs()[0]);
+    }
+
+    public function specifyTypes(
+        FunctionReflection $functionReflection,
+        FuncCall $node,
+        Scope $scope,
+        TypeSpecifierContext $context
+    ): SpecifiedTypes {
+        $expr = $node->getArgs()[0]->value;
+        $typeBefore = $scope->getType($expr);
+
+        $falseyTypes = $this->getFalseyTypes();
+
+        if ($this->isCalledOnIterable($typeBefore)) {
+            if ($context->falsey()) {
+                $typeBefore = TypeCombinator::remove($typeBefore, new NullType());
+            }
+
+            return $this->typeSpecifier->create($expr, $typeBefore, TypeSpecifierContext::createTruthy());
+        }
+
+        if ($context->falsey()) {
+            $nonFalseyTypes = TypeCombinator::remove($typeBefore, $falseyTypes);
+
+            return $this->typeSpecifier->create($expr, $nonFalseyTypes, TypeSpecifierContext::createTruthy());
+        }
+
+        return $this->typeSpecifier->create($expr, $falseyTypes, TypeSpecifierContext::createTruthy());
+    }
+
+    protected function isCalledOnIterable(Type $type): bool
+    {
+        if ($type->isIterable()->yes() && (! $type->isArray()->yes())) {
+            return true;
+        }
+
+        if ($type instanceof UnionType) {
+            return (bool) collect($type->getTypes())->first(function ($innerType) {
+                if ($innerType->isIterable()->yes() && (! $innerType->isArray()->yes())) {
+                    return true;
+                }
+
+                return false;
+            });
+        }
+
+        return false;
+    }
+
+    private function getFalseyTypes(): UnionType
+    {
+        return new UnionType([
+            new NullType(),
+            new ConstantBooleanType(false),
+            new ConstantStringType(''),
+            new ConstantStringType(' '),
+            new ConstantArrayType([], []),
+        ]);
+    }
+
+    public function setTypeSpecifier(TypeSpecifier $typeSpecifier): void
+    {
+        $this->typeSpecifier = $typeSpecifier;
+    }
+}

--- a/src/Types/BlankFunctionTypeSpecifyingExtension.php
+++ b/src/Types/BlankFunctionTypeSpecifyingExtension.php
@@ -70,11 +70,7 @@ final class BlankFunctionTypeSpecifyingExtension implements FunctionTypeSpecifyi
 
         if ($type instanceof UnionType) {
             return (bool) collect($type->getTypes())->first(function ($innerType) {
-                if ($innerType->isIterable()->yes() && (! $innerType->isArray()->yes())) {
-                    return true;
-                }
-
-                return false;
+                return $innerType->isIterable()->yes() && (! $innerType->isArray()->yes());
             });
         }
 

--- a/src/Types/BlankFunctionTypeSpecifyingExtension.php
+++ b/src/Types/BlankFunctionTypeSpecifyingExtension.php
@@ -47,7 +47,7 @@ final class BlankFunctionTypeSpecifyingExtension implements FunctionTypeSpecifyi
 
         if ($this->isCalledOnIterable($typeBefore)) {
             if ($context->falsey()) {
-                $typeBefore = TypeCombinator::remove($typeBefore, new NullType());
+                $typeBefore = TypeCombinator::removeNull($typeBefore);
             }
 
             return $this->typeSpecifier->create($expr, $typeBefore, TypeSpecifierContext::createTruthy());

--- a/src/Types/BlankFunctionTypeSpecifyingExtension.php
+++ b/src/Types/BlankFunctionTypeSpecifyingExtension.php
@@ -30,7 +30,7 @@ final class BlankFunctionTypeSpecifyingExtension implements FunctionTypeSpecifyi
         FuncCall $node,
         TypeSpecifierContext $context
     ): bool {
-        return $functionReflection->getName() === 'blank' && ! $context->null() && isset($node->getArgs()[0]);
+        return $functionReflection->getName() === 'blank';
     }
 
     public function specifyTypes(
@@ -43,6 +43,10 @@ final class BlankFunctionTypeSpecifyingExtension implements FunctionTypeSpecifyi
         $typeBefore = $scope->getType($expr);
 
         $falseyTypes = $this->getFalseyTypes();
+
+        if ($context->null()) {
+            return $this->typeSpecifier->create($expr, $typeBefore, TypeSpecifierContext::createTruthy());
+        }
 
         if ($this->isCalledOnIterable($typeBefore)) {
             if ($context->falsey()) {

--- a/src/Types/BlankFunctionTypeSpecifyingExtension.php
+++ b/src/Types/BlankFunctionTypeSpecifyingExtension.php
@@ -11,7 +11,6 @@ use PHPStan\Analyser\TypeSpecifier;
 use PHPStan\Analyser\TypeSpecifierAwareExtension;
 use PHPStan\Analyser\TypeSpecifierContext;
 use PHPStan\Reflection\FunctionReflection;
-use PHPStan\Type\ArrayType;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\Constant\ConstantStringType;

--- a/tests/Type/GeneralTypeTest.php
+++ b/tests/Type/GeneralTypeTest.php
@@ -63,7 +63,6 @@ class GeneralTypeTest extends TypeInferenceTestCase
         yield from $this->gatherAssertTypes(__DIR__.'/../application/app/Console/Commands/FooCommand.php');
         yield from $this->gatherAssertTypes(__DIR__.'/../application/app/Console/Commands/BarCommand.php');
         yield from $this->gatherAssertTypes(__DIR__.'/../application/app/Console/Commands/BazCommand.php');
-        
     }
 
     /**

--- a/tests/Type/GeneralTypeTest.php
+++ b/tests/Type/GeneralTypeTest.php
@@ -55,6 +55,7 @@ class GeneralTypeTest extends TypeInferenceTestCase
         yield from $this->gatherAssertTypes(__DIR__.'/data/helpers.php');
         yield from $this->gatherAssertTypes(__DIR__.'/data/custom-eloquent-collection.php');
         yield from $this->gatherAssertTypes(__DIR__.'/data/translator.php');
+        yield from $this->gatherAssertTypes(__DIR__.'/data/blank_helper.php');
 
         //##############################################################################################################
 
@@ -62,6 +63,7 @@ class GeneralTypeTest extends TypeInferenceTestCase
         yield from $this->gatherAssertTypes(__DIR__.'/../application/app/Console/Commands/FooCommand.php');
         yield from $this->gatherAssertTypes(__DIR__.'/../application/app/Console/Commands/BarCommand.php');
         yield from $this->gatherAssertTypes(__DIR__.'/../application/app/Console/Commands/BazCommand.php');
+        
     }
 
     /**

--- a/tests/Type/data/blank_helper.php
+++ b/tests/Type/data/blank_helper.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace BlankHelper;
+
+use Illuminate\Support\Collection;
+use function PHPStan\Testing\assertType;
+use stdClass;
+
+function asString(?string $foo)
+{
+    if (blank($foo)) {
+        assertType("''|' '|null", $foo);
+
+        return;
+    }
+    assertType('non-empty-string', $foo);
+}
+
+/**
+ * @param  array<int>  $foo
+ */
+function asArray(?array $foo)
+{
+    if (blank($foo)) {
+        assertType('array{}|null', $foo);
+
+        return;
+    }
+    assertType('non-empty-array<int>', $foo);
+}
+
+function asInt(?int $foo)
+{
+    if (blank($foo)) {
+        assertType('null', $foo);
+
+        return;
+    }
+    assertType('int', $foo);
+}
+
+function asBooleanWithNull(?bool $foo)
+{
+    if (blank($foo)) {
+        assertType('false|null', $foo);
+
+        return;
+    }
+    assertType('true', $foo);
+}
+
+function asBoolean(bool $foo)
+{
+    if (blank($foo)) {
+        assertType('false', $foo);
+
+        return;
+    }
+    assertType('true', $foo);
+}
+
+/**
+ * @param  Collection<int, int>  $foo
+ */
+function asCollectionWithType(Collection $foo)
+{
+    if (blank($foo)) {
+        assertType("Illuminate\Support\Collection<int, int>", $foo);
+
+        return;
+    }
+    assertType("Illuminate\Support\Collection<int, int>", $foo);
+}
+
+/**
+ * @param  Collection<int, int>|null  $foo
+ */
+function asCollectionWithNull(?Collection $foo)
+{
+    if (blank($foo)) {
+        assertType("Illuminate\Support\Collection<int, int>|null", $foo);
+
+        return;
+    }
+
+    assertType("Illuminate\Support\Collection<int, int>", $foo);
+}
+
+function asStdClass(?stdClass $foo)
+{
+    if (blank($foo)) {
+        assertType('null', $foo);
+
+        return;
+    }
+    assertType('stdClass', $foo);
+}
+
+function asIterable(?iterable $foo)
+{
+    if (blank($foo)) {
+        assertType('iterable|null', $foo);
+
+        return;
+    }
+    assertType('iterable', $foo);
+}

--- a/tests/Type/data/blank_helper.php
+++ b/tests/Type/data/blank_helper.php
@@ -3,8 +3,10 @@
 namespace BlankHelper;
 
 use Illuminate\Support\Collection;
-use function PHPStan\Testing\assertType;
+
 use stdClass;
+
+use function PHPStan\Testing\assertType;
 
 function asString(?string $foo)
 {

--- a/tests/Type/data/blank_helper.php
+++ b/tests/Type/data/blank_helper.php
@@ -3,7 +3,6 @@
 namespace BlankHelper;
 
 use Illuminate\Support\Collection;
-
 use stdClass;
 
 use function PHPStan\Testing\assertType;


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Updated CHANGELOG.md

Resolves #1290

**Changes**

fixes type specification for blank helper

This implementation is not complete, since blank support infinite whitespace, I chosen to support one blank space.