### PR TITLE
Add MailMessage stub to work well with Mailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+* Add MailMessage stub to work well with Mailable
+
 ## [2.2.0] - 2022-08-31
 
 ### Added

--- a/stubs/Notifications/Messages/MailMessage.stub
+++ b/stubs/Notifications/Messages/MailMessage.stub
@@ -1,0 +1,29 @@
+<?php
+
+namespace Illuminate\Notifications\Messages;
+
+class MailMessage
+{
+    /**
+     * The Markdown template to render (if applicable).
+     *
+     * @var view-string
+     */
+    public $markdown = 'notifications::email';
+    
+    /**
+     * @param view-string $view
+     * @param  array<string, mixed>  $data
+     * @return $this
+     */
+    public function markdown($view, array $data = [])
+    {}
+
+    /**
+     * @param  view-string  $view
+     * @param  array<string, mixed>  $data
+     * @return $this
+     */
+    public function view($view, array $data = [])
+    {}
+}

--- a/tests/Application/app/Mail.php
+++ b/tests/Application/app/Mail.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App;
+
+use Illuminate\Mail\Mailable;
+use Illuminate\Notifications\Messages\MailMessage;
+
+class Mail extends Mailable
+{
+    public function __construct(
+        private string $test,
+    ) {
+    }
+
+    public function build(): self
+    {
+        $message = new MailMessage();
+        $message->line('Test line '.$this->test);
+
+        return $this
+            ->subject('Test '.$this->test)
+            ->markdown($message->markdown, $message->data());
+    }
+}


### PR DESCRIPTION
👋

- [x] Added or updated tests
- [ ] Documented user facing changes
- [x] Updated CHANGELOG.md

This changes allows using MailMessage with mailable `$mailable->markdown($mailMessage->markdown, $mailMessage->data())`

```
Parameter #1 $view of method Illuminate\Mail\Mailable::markdown() expects view-string, string|null given.  
```

```php
class Mail extends Mailable
{
    public function __construct(
        private string $test,
    ) {
    }

    public function build(): self
    {
        $message = new MailMessage();
        $message->line('Test line ' . $this->test);

        return $this
            ->subject('Test ' . $this->test)
            ->markdown($message->markdown, $message->data()); 👈🏻 
    }
}
```
