### PR TITLE
Support `@mixin` on custom Eloquent Model

### DIFF
--- a/src/ReturnTypes/ModelDynamicStaticMethodReturnTypeExtension.php
+++ b/src/ReturnTypes/ModelDynamicStaticMethodReturnTypeExtension.php
@@ -64,11 +64,11 @@ final class ModelDynamicStaticMethodReturnTypeExtension implements DynamicStatic
             return true;
         }
 
-        if (! $methodReflection->getDeclaringClass()->hasNativeMethod($name)) {
+        if (! $methodReflection->getDeclaringClass()->hasMethod($name)) {
             return false;
         }
 
-        $method = $methodReflection->getDeclaringClass()->getNativeMethod($methodReflection->getName());
+        $method = $methodReflection->getDeclaringClass()->getMethod($methodReflection->getName(), new OutOfClassScope());
 
         $returnType = ParametersAcceptorSelector::selectSingle($method->getVariants())->getReturnType();
 

--- a/src/ReturnTypes/ModelDynamicStaticMethodReturnTypeExtension.php
+++ b/src/ReturnTypes/ModelDynamicStaticMethodReturnTypeExtension.php
@@ -119,8 +119,8 @@ final class ModelDynamicStaticMethodReturnTypeExtension implements DynamicStatic
     }
 
     /**
-     * @param array<string> $givenClassNames
-     * @param array<class-string> $neededClassNames
+     * @param  array<string>  $givenClassNames
+     * @param  array<class-string>  $neededClassNames
      * @return bool
      */
     private function doesClassesContainTypeOrSubType(array $givenClassNames, array $neededClassNames): bool

--- a/tests/Type/GeneralTypeTest.php
+++ b/tests/Type/GeneralTypeTest.php
@@ -52,6 +52,7 @@ class GeneralTypeTest extends TypeInferenceTestCase
         yield from $this->gatherAssertTypes(__DIR__.'/data/gate-facade.php');
         yield from $this->gatherAssertTypes(__DIR__.'/data/helpers.php');
         yield from $this->gatherAssertTypes(__DIR__.'/data/custom-eloquent-collection.php');
+        yield from $this->gatherAssertTypes(__DIR__.'/data/custom-eloquent-model.php');
     }
 
     /**

--- a/tests/Type/data/custom-eloquent-model.php
+++ b/tests/Type/data/custom-eloquent-model.php
@@ -29,12 +29,11 @@ function testAccessProperty()
 
 /**
  * @template TModelClass of CustomEloquentModel
-
+ *
  * @extends \Illuminate\Database\Eloquent\Builder<TModelClass>
  */
 class CustomEloquentBuilder extends EloquentBuilder
 {
-
 }
 
 /**
@@ -43,7 +42,7 @@ class CustomEloquentBuilder extends EloquentBuilder
 class CustomEloquentModel extends Model
 {
     /**
-     * @param Builder $query
+     * @param  Builder  $query
      * @return CustomEloquentBuilder
      */
     public function newEloquentBuilder($query): CustomEloquentBuilder

--- a/tests/Type/data/custom-eloquent-model.php
+++ b/tests/Type/data/custom-eloquent-model.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace CustomEloquentModelTests;
+
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Query\Builder;
+use function PHPStan\Testing\assertType;
+
+function testPassthroughEloquentBuilder()
+{
+    assertType('CustomEloquentModelTests\City|null', City::where('email', 'bar')->first());
+}
+
+function testPassthroughQueryBuilder()
+{
+    assertType('CustomEloquentModelTests\CustomEloquentBuilder<CustomEloquentModelTests\City>', City::whereIntegerInRaw('id', [1, 2, 3]));
+}
+
+function testAccessModel()
+{
+    assertType('Illuminate\Database\Eloquent\Collection<int, CustomEloquentModelTests\City>', City::all()->filter());
+}
+
+function testAccessProperty()
+{
+    assertType('string', City::all()->filter()->first()->name);
+}
+
+/**
+ * @template TModelClass of CustomEloquentModel
+
+ * @extends \Illuminate\Database\Eloquent\Builder<TModelClass>
+ */
+class CustomEloquentBuilder extends EloquentBuilder
+{
+
+}
+
+/**
+ * @mixin CustomEloquentBuilder<static>
+ */
+class CustomEloquentModel extends Model
+{
+    /**
+     * @param Builder $query
+     * @return CustomEloquentBuilder
+     */
+    public function newEloquentBuilder($query): CustomEloquentBuilder
+    {
+        return new CustomEloquentBuilder($query);
+    }
+}
+
+final class City extends CustomEloquentModel
+{
+    public string $name;
+}


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes

**Changes**
Add support for `@mixin CustomEloquentBuilder<static>` on a custom Model base class. Adding the mixin greatly improves autocompletion inside IDE's.

```php
/**
 * @mixin CustomEloquentBuilder<static>
 */
class CustomEloquentModel extends Model
{
    /**
     * @param Builder $query
     * @return CustomEloquentBuilder
     */
    public function newEloquentBuilder($query): CustomEloquentBuilder
    {
        return new CustomEloquentBuilder($query);
    }
}
```
_Why?_
We have a big application (500+ models) and use a custom Eloquent Model, Query Builder and Eloquent Builder. Larastan handles this fantastic (for which we thank you very much!!). To make PhpStorm regonize all pieces together we needed to add the mixin. Unfortunally this broke Larastan, so I decided to propose an upstream fix so others can take advantage of it too. I think it is a pattern which is usable for others too.

**Breaking changes**
None.


**Note**
Some checks fail, they also fail on the master branch and are (if I'm right) therefore out of scope for this PR.
