### PR TITLE
feat: add support for one() on HasMany, MorphMany and HasManyThrough

### DIFF
--- a/stubs/HasMany.stub
+++ b/stubs/HasMany.stub
@@ -14,4 +14,11 @@ class HasMany extends HasOneOrMany
      * @phpstan-return \Traversable<int, TRelatedModel>
      */
     public function getResults();
+
+    /**
+     * Convert the relationship to a "has one" relationship.
+     *
+     * @phpstan-return \Illuminate\Database\Eloquent\Relations\HasOne<TRelatedModel>
+     */
+    public function one();
 }

--- a/stubs/HasManyThrough.stub
+++ b/stubs/HasManyThrough.stub
@@ -65,4 +65,9 @@ class HasManyThrough extends Relation
      * @return TRelatedModel|\Illuminate\Database\Eloquent\Collection<int, TRelatedModel>
      */
     public function findOrFail($id, $columns = ['*']);
+
+    /**
+     * @phpstan-return \Illuminate\Database\Eloquent\Relations\HasOneThrough<TRelatedModel>
+     */
+    public function one();
 }

--- a/stubs/MorphMany.stub
+++ b/stubs/MorphMany.stub
@@ -21,4 +21,11 @@ class MorphMany extends MorphOneOrMany
      * @phpstan-return \Traversable<int, TRelatedModel>
      */
     public function getResults();
+
+    /**
+     * Convert the relationship to a "morph one" relationship.
+     *
+     * @phpstan-return \Illuminate\Database\Eloquent\Relations\MorphOne<TRelatedModel>
+     */
+     public function one();
 }

--- a/tests/Type/data/model-relations.php
+++ b/tests/Type/data/model-relations.php
@@ -28,6 +28,7 @@ function test(User $user, \App\Address $address, Account $account, ExtendsModelW
         $address->addressable()->where('name', 'bar')
     );
     assertType('Illuminate\Database\Eloquent\Relations\MorphMany<App\Address>', $user->address()->where('name', 'bar'));
+    assertType('Illuminate\Database\Eloquent\Relations\MorphOne<App\Address>', $user->address()->one());
     assertType('Illuminate\Database\Eloquent\Relations\HasMany<App\Account>', $user->accounts()->active());
     assertType('App\RoleCollection<int, App\Role>', $user->roles()->get());
     /** @var Group $group */
@@ -38,6 +39,9 @@ function test(User $user, \App\Address $address, Account $account, ExtendsModelW
     assertType('Illuminate\Database\Eloquent\Relations\HasMany<App\Account>', (new User())->accounts()->where('name', 'bar'));
     assertType('Illuminate\Database\Eloquent\Relations\HasMany<App\Account>', (new User())->accounts()->whereIn('id', [1, 2, 3]));
     assertType('Illuminate\Database\Eloquent\Relations\HasMany<App\Account>', (new User())->accounts()->whereActive(true));
+    assertType('Illuminate\Database\Eloquent\Relations\HasOne<App\Account>', (new User())->accounts()->one());
+    assertType('Illuminate\Database\Eloquent\Relations\HasManyThrough<App\Transaction>', (new User())->transactions());
+    assertType('Illuminate\Database\Eloquent\Relations\HasOneThrough<App\Transaction>', (new User())->transactions()->one());
     assertType('App\Account', getUser()->accounts()->create());
     assertType('App\Account|null', (new User())->accounts()->where('name', 'bar')->first());
     assertType('App\User', User::with('accounts')->whereHas('accounts')->firstOrFail());

--- a/tests/Type/data/model-relations.php
+++ b/tests/Type/data/model-relations.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
+
 use function PHPStan\Testing\assertType;
 
 function test(User $user, \App\Address $address, Account $account, ExtendsModelWithPropertyAnnotations $model, Tag $tag)


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

* Adds support for the `one()` methods on `HasMany`, `MorphMany` and `HasManyThrough` relationships as [added to the framework](https://github.com/laravel/framework/pull/46443).

**Breaking changes**

None.
