### PR TITLE
feat: support generic eloquent casts

### DIFF
--- a/src/Properties/EloquentCast.php
+++ b/src/Properties/EloquentCast.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace NunoMaduro\Larastan\Properties;
+
+use LogicException;
+
+final class EloquentCast
+{
+    public function __construct(
+        public string $type,
+        /** @var list<string> */
+        public array $parameters,
+    ) {
+    }
+
+    public static function fromString(string $string): self
+    {
+        $parts = explode(':', $string);
+
+        // If the cast is prefixed with `encrypted:` we need to skip to the next
+        if (($parts[0] ?? null) === 'encrypted') {
+            array_shift($parts);
+        }
+
+        if (empty($parts)) {
+            throw new LogicException('Invalid cast provided.');
+        }
+
+        return new self(
+            type: array_shift($parts),
+            parameters: $parts,
+        );
+    }
+}

--- a/src/Properties/ModelCastHelper.php
+++ b/src/Properties/ModelCastHelper.php
@@ -140,7 +140,7 @@ class ModelCastHelper
             $methodReflection = $classReflection->getNativeMethod('set');
             $parameters = ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getParameters();
 
-            $valueParameter = Arr::first($parameters, fn(ParameterReflection $parameterReflection) => $parameterReflection->getName() === 'value');
+            $valueParameter = Arr::first($parameters, fn (ParameterReflection $parameterReflection) => $parameterReflection->getName() === 'value');
             $valueParameterType = $valueParameter->getType();
 
             // If the caster is generic and the first supplied parameter is a class, we will bind that in the template type map.
@@ -164,8 +164,8 @@ class ModelCastHelper
     }
 
     /**
-     * @param Type $valueParameterType
-     * @param EloquentCast $cast
+     * @param  Type  $valueParameterType
+     * @param  EloquentCast  $cast
      * @return Type
      */
     private function resolveTemplateTypes(Type $valueParameterType, EloquentCast $cast): Type

--- a/src/Properties/ModelCastHelper.php
+++ b/src/Properties/ModelCastHelper.php
@@ -15,6 +15,7 @@ use PHPStan\Type\BenevolentUnionType;
 use PHPStan\Type\BooleanType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\FloatType;
+use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\Generic\TemplateTypeHelper;
 use PHPStan\Type\Generic\TemplateTypeMap;
 use PHPStan\Type\Generic\TemplateTypeVariance;
@@ -47,6 +48,9 @@ class ModelCastHelper
             'collection' => new ObjectType('Illuminate\Support\Collection'),
             'date', 'datetime' => $this->getDateType(),
             'immutable_date', 'immutable_datetime' => new ObjectType('Carbon\CarbonImmutable'),
+            'Illuminate\Database\Eloquent\Casts\AsArrayObject', 'Illuminate\Database\Eloquent\Casts\AsEncryptedArrayObject' => new GenericObjectType('Illuminate\Database\Eloquent\Casts\ArrayObject', [new BenevolentUnionType([new IntegerType(), new StringType()]), new MixedType()]),
+            'Illuminate\Database\Eloquent\Casts\AsCollection', 'Illuminate\Database\Eloquent\Casts\AsEncryptedCollection' => new GenericObjectType('Illuminate\Support\Collection', [new BenevolentUnionType([new IntegerType(), new StringType()]), new MixedType()]),
+            'Illuminate\Database\Eloquent\Casts\AsStringable' => new ObjectType('Illuminate\Support\Stringable'),
             default => null,
         };
 

--- a/src/Properties/ModelCastHelper.php
+++ b/src/Properties/ModelCastHelper.php
@@ -83,7 +83,7 @@ class ModelCastHelper
             $methodReturnType = ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
 
             // If the caster is generic and the first supplied parameter is a class, we will bind that in the template type map.
-            return $this->resolveTemplateTypes($methodReturnType, $cast);
+            return TypeCombinator::removeNull($this->resolveTemplateTypes($methodReturnType, $cast));
         }
 
         if ($classReflection->isSubclassOf(CastsInboundAttributes::class)) {
@@ -148,7 +148,7 @@ class ModelCastHelper
             $valueParameterType = $valueParameter->getType();
 
             // If the caster is generic and the first supplied parameter is a class, we will bind that in the template type map.
-            return $this->resolveTemplateTypes($valueParameterType, $cast);
+            return TypeCombinator::removeNull($this->resolveTemplateTypes($valueParameterType, $cast));
         }
 
         return new MixedType();

--- a/src/Properties/ModelPropertyExtension.php
+++ b/src/Properties/ModelPropertyExtension.php
@@ -171,6 +171,9 @@ final class ModelPropertyExtension implements PropertiesClassReflectionExtension
         if ($column->nullable) {
             $readableType = TypeCombinator::addNull($readableType);
             $writableType = TypeCombinator::addNull($writableType);
+        } else {
+            $readableType = TypeCombinator::removeNull($readableType);
+            $writableType = TypeCombinator::removeNull($writableType);
         }
 
         return new ModelProperty(

--- a/tests/Type/data/model-properties.php
+++ b/tests/Type/data/model-properties.php
@@ -66,7 +66,7 @@ function foo(User $user, Account $account, Role $role, Group $group, Team $team,
     assertType('int', $group->id);
     assertType('string', $guardedModel->name);
     assertType('string', $thread->custom_property);
-    assertType('Illuminate\Database\Eloquent\Casts\ArrayObject', $user->options);
+    assertType('Illuminate\Database\Eloquent\Casts\ArrayObject<(int|string), mixed>', $user->options);
     assertType('int<0, max>', count($user->options));
     assertType('Illuminate\Support\Collection<(int|string), mixed>', $user->properties);
     assertType('int<0, max>', count($user->properties));

--- a/tests/Unit/ModelCastHelperTest.php
+++ b/tests/Unit/ModelCastHelperTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Unit;
+
+use NunoMaduro\Larastan\Properties\ModelCastHelper;
+use PHPStan\Testing\PHPStanTestCase;
+use PHPStan\Type\BenevolentUnionType;
+use PHPStan\Type\Generic\GenericObjectType;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\StringType;
+use PHPStan\Type\TypeCombinator;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Type;
+
+class ModelCastHelperTest extends PHPStanTestCase
+{
+    /**
+     * @var mixed|ReflectionProvider
+     */
+    private ReflectionProvider $reflectionProvider;
+
+    protected function setUp(): void
+    {
+        $this->registerComparator(new PHPStanTypeComparator());
+
+        $this->reflectionProvider = self::getContainer()->getByType(ReflectionProvider::class);
+    }
+
+    /**
+     * @dataProvider testGetReadableTypeCases
+     */
+    public function testGetReadableType($cast, Type\Type $expected): void
+    {
+        $helper = new ModelCastHelper($this->reflectionProvider);
+
+        $this->assertEquals($expected, $helper->getReadableType($cast, new Type\StringType()));
+    }
+
+    protected function testGetReadableTypeCases(): \Generator
+    {
+        yield ['int', new Type\IntegerType()];
+        yield ['integer', new Type\IntegerType()];
+        yield ['timestamp', new Type\IntegerType()];
+        yield ['decimal', new Type\IntersectionType([new Type\StringType(), new Type\Accessory\AccessoryNumericStringType()])];
+        yield ['string', new Type\StringType()];
+        yield ['bool', new Type\BooleanType()];
+        yield ['boolean', new Type\BooleanType()];
+        yield ['object', new Type\ObjectType('stdClass')];
+        yield ['array', new Type\ArrayType(new Type\BenevolentUnionType([new Type\IntegerType(), new Type\StringType()]), new Type\MixedType())];
+        yield ['collection', new Type\ObjectType('Illuminate\Support\Collection')];
+        yield ['date', new Type\ObjectType('Carbon\Carbon')];
+        yield ['datetime', new Type\ObjectType('Carbon\Carbon')];
+        yield ['immutable_date', new Type\ObjectType('Carbon\CarbonImmutable')];
+        yield ['immutable_datetime', new Type\ObjectType('Carbon\CarbonImmutable')];
+        yield ['Illuminate\Database\Eloquent\Casts\AsArrayObject', TypeCombinator::addNull(new Type\ObjectType('Illuminate\Database\Eloquent\Casts\ArrayObject'))];
+        yield ['Illuminate\Database\Eloquent\Casts\AsEncryptedArrayObject', TypeCombinator::addNull(new Type\ObjectType('Illuminate\Database\Eloquent\Casts\ArrayObject'))];
+        yield ['Illuminate\Database\Eloquent\Casts\AsCollection', TypeCombinator::addNull(new GenericObjectType('Illuminate\Support\Collection', [new BenevolentUnionType([new IntegerType(), new StringType()]), new MixedType()]))];
+        yield ['Illuminate\Database\Eloquent\Casts\AsEncryptedCollection', TypeCombinator::addNull(new GenericObjectType('Illuminate\Support\Collection', [new BenevolentUnionType([new IntegerType(), new StringType()]), new MixedType()]))];
+        yield ['Illuminate\Database\Eloquent\Casts\AsStringable', TypeCombinator::addNull(new Type\ObjectType('Illuminate\Support\Stringable'))];
+
+        yield [
+            'Illuminate\Database\Eloquent\Casts\AsEnumArrayObject:App\Casts\BackedEnumeration',
+            TypeCombinator::addNull(
+                new Type\Generic\GenericObjectType(
+                    'Illuminate\Database\Eloquent\Casts\ArrayObject', [
+                        new Type\BenevolentUnionType([new Type\IntegerType(), new Type\StringType()]),
+                        new Type\ObjectType('App\Casts\BackedEnumeration')
+                    ]
+                )
+            )];
+
+        yield [
+            'Illuminate\Database\Eloquent\Casts\AsEnumCollection:App\Casts\BackedEnumeration',
+            TypeCombinator::addNull(
+                new Type\Generic\GenericObjectType(
+                    'Illuminate\Support\Collection', [
+                        new Type\BenevolentUnionType([new Type\IntegerType(), new Type\StringType()]),
+                        new Type\ObjectType('App\Casts\BackedEnumeration')
+                    ]
+                )
+            )];
+    }
+}

--- a/tests/Unit/ModelCastHelperTest.php
+++ b/tests/Unit/ModelCastHelperTest.php
@@ -37,7 +37,7 @@ class ModelCastHelperTest extends PHPStanTestCase
         $this->assertEquals($expected, $helper->getReadableType($cast, new Type\StringType()));
     }
 
-    protected function testGetReadableTypeCases(): \Generator
+    public function testGetReadableTypeCases(): \Generator
     {
         yield ['int', new Type\IntegerType()];
         yield ['integer', new Type\IntegerType()];

--- a/tests/Unit/ModelCastHelperTest.php
+++ b/tests/Unit/ModelCastHelperTest.php
@@ -3,15 +3,15 @@
 namespace Unit;
 
 use NunoMaduro\Larastan\Properties\ModelCastHelper;
+use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Testing\PHPStanTestCase;
+use PHPStan\Type;
 use PHPStan\Type\BenevolentUnionType;
 use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\TypeCombinator;
-use PHPStan\Reflection\ReflectionProvider;
-use PHPStan\Type;
 
 class ModelCastHelperTest extends PHPStanTestCase
 {
@@ -65,7 +65,7 @@ class ModelCastHelperTest extends PHPStanTestCase
                 new Type\Generic\GenericObjectType(
                     'Illuminate\Database\Eloquent\Casts\ArrayObject', [
                         new Type\BenevolentUnionType([new Type\IntegerType(), new Type\StringType()]),
-                        new Type\ObjectType('App\Casts\BackedEnumeration')
+                        new Type\ObjectType('App\Casts\BackedEnumeration'),
                     ]
                 )
             )];
@@ -76,7 +76,7 @@ class ModelCastHelperTest extends PHPStanTestCase
                 new Type\Generic\GenericObjectType(
                     'Illuminate\Support\Collection', [
                         new Type\BenevolentUnionType([new Type\IntegerType(), new Type\StringType()]),
-                        new Type\ObjectType('App\Casts\BackedEnumeration')
+                        new Type\ObjectType('App\Casts\BackedEnumeration'),
                     ]
                 )
             )];

--- a/tests/Unit/ModelCastHelperTest.php
+++ b/tests/Unit/ModelCastHelperTest.php
@@ -28,7 +28,7 @@ class ModelCastHelperTest extends PHPStanTestCase
     }
 
     /**
-     * @dataProvider testGetReadableTypeCases
+     * @dataProvider getReadableTypeCases
      */
     public function testGetReadableType($cast, Type\Type $expected): void
     {
@@ -37,7 +37,7 @@ class ModelCastHelperTest extends PHPStanTestCase
         $this->assertEquals($expected, $helper->getReadableType($cast, new Type\StringType()));
     }
 
-    public function testGetReadableTypeCases(): \Generator
+    public function getReadableTypeCases(): \Generator
     {
         yield ['int', new Type\IntegerType()];
         yield ['integer', new Type\IntegerType()];
@@ -53,32 +53,28 @@ class ModelCastHelperTest extends PHPStanTestCase
         yield ['datetime', new Type\ObjectType('Carbon\Carbon')];
         yield ['immutable_date', new Type\ObjectType('Carbon\CarbonImmutable')];
         yield ['immutable_datetime', new Type\ObjectType('Carbon\CarbonImmutable')];
-        yield ['Illuminate\Database\Eloquent\Casts\AsArrayObject', TypeCombinator::addNull(new Type\ObjectType('Illuminate\Database\Eloquent\Casts\ArrayObject'))];
-        yield ['Illuminate\Database\Eloquent\Casts\AsEncryptedArrayObject', TypeCombinator::addNull(new Type\ObjectType('Illuminate\Database\Eloquent\Casts\ArrayObject'))];
-        yield ['Illuminate\Database\Eloquent\Casts\AsCollection', TypeCombinator::addNull(new GenericObjectType('Illuminate\Support\Collection', [new BenevolentUnionType([new IntegerType(), new StringType()]), new MixedType()]))];
-        yield ['Illuminate\Database\Eloquent\Casts\AsEncryptedCollection', TypeCombinator::addNull(new GenericObjectType('Illuminate\Support\Collection', [new BenevolentUnionType([new IntegerType(), new StringType()]), new MixedType()]))];
-        yield ['Illuminate\Database\Eloquent\Casts\AsStringable', TypeCombinator::addNull(new Type\ObjectType('Illuminate\Support\Stringable'))];
+        yield ['Illuminate\Database\Eloquent\Casts\AsArrayObject', new Type\ObjectType('Illuminate\Database\Eloquent\Casts\ArrayObject')];
+        yield ['Illuminate\Database\Eloquent\Casts\AsEncryptedArrayObject', new Type\ObjectType('Illuminate\Database\Eloquent\Casts\ArrayObject')];
+        yield ['Illuminate\Database\Eloquent\Casts\AsCollection', new GenericObjectType('Illuminate\Support\Collection', [new BenevolentUnionType([new IntegerType(), new StringType()]), new MixedType()])];
+        yield ['Illuminate\Database\Eloquent\Casts\AsEncryptedCollection', new GenericObjectType('Illuminate\Support\Collection', [new BenevolentUnionType([new IntegerType(), new StringType()]), new MixedType()])];
+        yield ['Illuminate\Database\Eloquent\Casts\AsStringable', new Type\ObjectType('Illuminate\Support\Stringable')];
 
         yield [
             'Illuminate\Database\Eloquent\Casts\AsEnumArrayObject:App\Casts\BackedEnumeration',
-            TypeCombinator::addNull(
-                new Type\Generic\GenericObjectType(
-                    'Illuminate\Database\Eloquent\Casts\ArrayObject', [
-                        new Type\BenevolentUnionType([new Type\IntegerType(), new Type\StringType()]),
-                        new Type\ObjectType('App\Casts\BackedEnumeration'),
-                    ]
-                )
+            new Type\Generic\GenericObjectType(
+                'Illuminate\Database\Eloquent\Casts\ArrayObject', [
+                    new Type\BenevolentUnionType([new Type\IntegerType(), new Type\StringType()]),
+                    new Type\ObjectType('App\Casts\BackedEnumeration'),
+                ]
             )];
 
         yield [
             'Illuminate\Database\Eloquent\Casts\AsEnumCollection:App\Casts\BackedEnumeration',
-            TypeCombinator::addNull(
-                new Type\Generic\GenericObjectType(
-                    'Illuminate\Support\Collection', [
-                        new Type\BenevolentUnionType([new Type\IntegerType(), new Type\StringType()]),
-                        new Type\ObjectType('App\Casts\BackedEnumeration'),
-                    ]
-                )
+            new Type\Generic\GenericObjectType(
+                'Illuminate\Support\Collection', [
+                    new Type\BenevolentUnionType([new Type\IntegerType(), new Type\StringType()]),
+                    new Type\ObjectType('App\Casts\BackedEnumeration'),
+                ]
             )];
     }
 }

--- a/tests/Unit/PHPStanTypeComparator.php
+++ b/tests/Unit/PHPStanTypeComparator.php
@@ -14,8 +14,8 @@ class PHPStanTypeComparator extends Comparator
     }
 
     /**
-     * @param Type $expected
-     * @param Type $actual
+     * @param  Type  $expected
+     * @param  Type  $actual
      */
     public function assertEquals($expected, $actual, $delta = 0.0, $canonicalize = false, $ignoreCase = false): void
     {

--- a/tests/Unit/PHPStanTypeComparator.php
+++ b/tests/Unit/PHPStanTypeComparator.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Unit;
+
+use PHPStan\Type\Type;
+use SebastianBergmann\Comparator\Comparator;
+use SebastianBergmann\Comparator\ComparisonFailure;
+
+class PHPStanTypeComparator extends Comparator
+{
+    public function accepts($expected, $actual): bool
+    {
+        return $expected instanceof Type && $actual instanceof Type;
+    }
+
+    /**
+     * @param Type $expected
+     * @param Type $actual
+     */
+    public function assertEquals($expected, $actual, $delta = 0.0, $canonicalize = false, $ignoreCase = false): void
+    {
+        if (! $expected->equals($actual)) {
+            throw new ComparisonFailure(
+                $expected,
+                $actual,
+                $this->exporter->export($expected),
+                $this->exporter->export($actual),
+                false,
+                'Failed asserting that two Type objects are equal.',
+            );
+        }
+    }
+}


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Documented user facing changes

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

1. Extracted a `EloquentCast` value object that is used to parse a cast string to it's type and parameters.
2. Added a helper that extracts the template tags from a class implementing `CastsAttributes` and then tries to resolve the template types using the paramater provided to the cast.
3. Added an extra unit test that covers `ModelCastHelper`.

<!-- Detail the changes in behaviour this PR introduces. -->

**Breaking changes**

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
