### PR TITLE
Fix type of Attribute::make's callable

### DIFF
--- a/stubs/Attribute.stub
+++ b/stubs/Attribute.stub
@@ -27,7 +27,7 @@ class Attribute
      *
      * @template TMakeGet
      * @template TMakeSet
-     * @param  (callable(mixed, mixed): TMakeGet)|null  $get
+     * @param  (callable(mixed, array<string, mixed>): TMakeGet)|null  $get
      * @param  (callable(TMakeSet, mixed=): mixed)|null  $set
      * @return Attribute<TMakeGet, TMakeSet>
      */


### PR DESCRIPTION
I encountered the following error:
```
Type array of parameter #2 $attributes of passed callable needs to be same or wider than parameter type mixed of accepting callable.
```

However, based on Laravel's documentation and [code](https://github.com/laravel/framework/blob/921e956576aba9655da1f6667fbdbe97394d3cf3/src/Illuminate/Database/Eloquent/Casts/Attribute.php#L48-L55), I believe that this second parameter should be typed as an array<string, mixed> and not fully mixed.

- [ ] Added or updated tests
- [ ] Documented user facing changes

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

<!-- Detail the changes in behaviour this PR introduces. -->

**Breaking changes**

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
