### PR TITLE
chore: make e2e-tests workflow configuration shorter

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -28,29 +28,18 @@ jobs:
             repository: monicahq/chandler
             ref: f57c49400dfa419e78bad240f018bce2949dcac2
             php-version: "8.1"
-            config: monicahq-chandler.neon
-            baseline: monicahq-chandler.baseline.neon
-
           -
             repository: koel/koel
             ref: 22946a6413546a1c97ddf7bb4f5254bc6d129dd7
             php-version: "8.1"
-            config: koel-koel.neon
-            baseline: koel-koel.baseline.neon
-
           -
             repository: canvural/larastan-test
             ref: 686828b76a2e300b1a3cc99fdd8be9af3a3e7e60
             php-version: "8.1"
-            config: canvural-larastan-test.neon
-            baseline: canvural-larastan-test.baseline.neon
-
           -
             repository: canvural/larastan-strict-rules
             ref: 16ceaa41a54aacc5481d957dd625590e6acd321c
             php-version: "8.1"
-            config: canvural-larastan-strict-rules.neon
-            baseline: canvural-larastan-strict-rules.baseline.neon
 
     steps:
       - name: "Checkout"
@@ -80,17 +69,8 @@ jobs:
           composer require --dev --update-with-all-dependencies "nunomaduro/larastan:*"
 
       - name: "Perform static analysis"
-        working-directory: e2e
-        run: composer exec phpstan analyse -- -c "../larastan/e2e/${{ matrix.config }}"
-
-      - name: "Generate baseline"
-        if: ${{ failure() }}
-        working-directory: e2e
-        run: composer exec phpstan analyse -- -c ../larastan/e2e/${{ matrix.config }} -b ../larastan/e2e/${{ matrix.baseline }}
-
-      - uses: actions/upload-artifact@v3
-        if: ${{ failure() }}
-        with:
-          name: baselines
-          path: "larastan/e2e/${{ matrix.baseline }}"
-
+        working-directory: "e2e"
+        env:
+          REPOSITORY: "${{ matrix.repository }}"
+        run: |
+          composer exec -- phpstan analyse -- -c "../larastan/e2e/${REPOSITORY/\//-}.neon"

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -73,4 +73,4 @@ jobs:
         env:
           REPOSITORY: "${{ matrix.repository }}"
         run: |
-          composer exec -- phpstan analyse -- -c "../larastan/e2e/${REPOSITORY/\//-}.neon"
+          composer exec -- phpstan analyse -c "../larastan/e2e/${REPOSITORY/\//-}.neon"


### PR DESCRIPTION
- Get neon file names of tested repos from `matrix.repository`
- Remove baseline generation/uploading 👉🏻 if we do our job well baselines will only shrink

😢 GitHub Actions has no string replace function 😿 
