### PR TITLE
Add stub for Str::replace

### DIFF
--- a/stubs/common/Support/Str.stub
+++ b/stubs/common/Support/Str.stub
@@ -2,7 +2,8 @@
 
 namespace Illuminate\Support;
 
-class Str {
+class Str
+{
     /**
      * @template TSubject of string|iterable<string>
      * @param string|iterable<string> $search
@@ -11,5 +12,5 @@ class Str {
      * @param bool $caseSensitive
      * @return TSubject
      */
-    public static function replace($search, $replace, $subject, $caseSensitive = true) {}
+    public static function replace($search, $replace, $subject, $caseSensitive = true);
 }

--- a/stubs/common/Support/Str.stub
+++ b/stubs/common/Support/Str.stub
@@ -1,0 +1,15 @@
+<?php
+
+namespace Illuminate\Support;
+
+class Str {
+    /**
+     * @template TSubject of string|iterable<string>
+     * @param string|iterable<string> $search
+     * @param string|iterable<string> $replace
+     * @param TSubject $subject
+     * @param bool $caseSensitive
+     * @return TSubject
+     */
+    public static function replace($search, $replace, $subject, $caseSensitive = true) {}
+}


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Documented user facing changes

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

In Laravel 10.16 the signature of the `Str::replace` method has changed, where the return type is now `string|string[]` instead of `string`. This MR will improve this behavior, according to the $subject parameter sets a specific return type.

**Breaking changes**

No breaking changes.
