### PR TITLE
Fix Rescue param $report

### DIFF
--- a/stubs/common/Helpers.stub
+++ b/stubs/common/Helpers.stub
@@ -91,7 +91,7 @@ function url($path = null, $parameters = [], $secure = null) {}
  *
  * @param callable(): TValue $callback
  * @param TDefault|(callable(\Throwable): TDefault) $rescue
- * @param bool $report
+ * @param bool|(callable(\Throwable): TDefault) $report
  * @return TValue|TDefault
  */
 function rescue(callable $callback, $rescue = null, $report = true) {}


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Documented user facing changes

**Changes**

Larastan's stub for the `rescue()` helper does not accept a Closure on the `$report` param and give the following error.
```
 ------ -------------------------------------------------------------------
  41     Parameter $report of function rescue expects bool, Closure given.
 ------ -------------------------------------------------------------------
```

This an example from the Laravel Docs, to use a Closure on the mentioned param.

```php
return rescue(function () {
    return $this->method();
}, report: function (Throwable $throwable) {
    return $throwable instanceof InvalidArgumentException;
});
```

**Breaking changes**