### PR TITLE
Fix toRawSql return type

### DIFF
--- a/src/Methods/BuilderHelper.php
+++ b/src/Methods/BuilderHelper.php
@@ -53,7 +53,7 @@ class BuilderHelper
         'max', 'min',
         'raw',
         'sum',
-        'toSql',
+        'toSql', 'toRawSql',
     ];
 
     /** @var ReflectionProvider */


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Documented user facing changes

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

QueryBuilder method toRawSQL should return a string. Currently it is incorrectly declaring returns the builder instance  again.

**Example**

```php
$sql = User::query()->toRawSql();
is_string($sql)
```

leads to

```
  5    Call to function is_string() with Illuminate\Database\Eloquent\Builder<App\Model\User> will always evaluate to false.    
         💡 Because the type is coming from a PHPDoc, you can turn off this check by setting treatPhpDocTypesAsCertain: false in your phpstan.neon.
```

**Breaking changes**

No breaking changes.
