### PR TITLE
Fix for #1607

### DIFF
--- a/src/Types/ViewStringType.php
+++ b/src/Types/ViewStringType.php
@@ -26,7 +26,7 @@ class ViewStringType extends StringType
     public function acceptsWithReason(Type $type, bool $strictTypes): AcceptsResult
     {
         if ($type instanceof CompoundType) {
-            return $type->isAcceptedBy($this, $strictTypes);
+            return $type->isAcceptedWithReasonBy($this, $strictTypes);
         }
 
         $constantStrings = $type->getConstantStrings();

--- a/src/Types/ViewStringType.php
+++ b/src/Types/ViewStringType.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NunoMaduro\Larastan\Types;
 
 use PHPStan\TrinaryLogic;
+use PHPStan\Type\AcceptsResult;
 use PHPStan\Type\CompoundType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
@@ -22,7 +23,7 @@ class ViewStringType extends StringType
         return 'view-string';
     }
 
-    public function accepts(Type $type, bool $strictTypes): TrinaryLogic
+    public function acceptsWithReason(Type $type, bool $strictTypes): AcceptsResult
     {
         if ($type instanceof CompoundType) {
             return $type->isAcceptedBy($this, $strictTypes);
@@ -34,18 +35,18 @@ class ViewStringType extends StringType
             /** @var \Illuminate\View\Factory $view */
             $view = view();
 
-            return TrinaryLogic::createFromBoolean($view->exists($constantStrings[0]->getValue()));
+            return AcceptsResult::createFromBoolean($view->exists($constantStrings[0]->getValue()));
         }
 
         if ($type instanceof self) {
-            return TrinaryLogic::createYes();
+            return AcceptsResult::createYes();
         }
 
         if ($type->isString()->yes()) {
-            return TrinaryLogic::createMaybe();
+            return AcceptsResult::createMaybe();
         }
 
-        return TrinaryLogic::createNo();
+        return AcceptsResult::createNo();
     }
 
     public function isSuperTypeOf(Type $type): TrinaryLogic


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Documented user facing changes

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

Implements the fix mentioned in [my comment](https://github.com/nunomaduro/larastan/issues/1607#issuecomment-1712520487) on #1607. Tested it with a fresh Laravel app and the following controller

```php
<?php

namespace App\Http\Controllers;

class NonExistingViewController
{
    public function __invoke(): \Illuminate\View\View
    {
        return \view('non-existing');
    }
}
```

and now phpstan properly complains about it:

```
phpstan --no-progress
Note: Using configuration file /private/tmp/laravel/larastan-routes-test/phpstan.neon.dist.
 ------ -----------------------------------------------------------------------------
  Line   Http/Controllers/NonExistingViewController.php
 ------ -----------------------------------------------------------------------------
  9      Parameter #1 $view of function view expects view-string|null, string given.
 ------ -----------------------------------------------------------------------------

 [ERROR] Found 1 error
```

If desired, I could also implement a test similar to the one in #1734, since the current one does not seem to catch all types of issues.

**Breaking changes**

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
