### PR TITLE
Test default enum value to Builder::macro('globalCustomMacro') for issue #1749

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -8,7 +8,12 @@ Carbon::macro('foo', static function (): string {
     return 'foo';
 });
 
-\Illuminate\Database\Eloquent\Builder::macro('globalCustomMacro', function (string $arg = 'foobar', int $b = 5): string {
+enum SomeEnum {
+    case A;
+    case B;
+}
+
+\Illuminate\Database\Eloquent\Builder::macro('globalCustomMacro', function (string $arg = 'foobar', int $b = 5, SomeEnum $enum = SomeEnum::A): string {
     return $arg;
 });
 


### PR DESCRIPTION
- [X] Added or updated tests
- [ ] Documented user facing changes

This is the PR with the failing test for issue #1749
<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

Introduces a default parameter of an enum to the Builder macro test