### PR TITLE
Fix collection methods unwrapping outer generic

### DIFF
--- a/src/ReturnTypes/CollectionGenericStaticMethodDynamicMethodReturnTypeExtension.php
+++ b/src/ReturnTypes/CollectionGenericStaticMethodDynamicMethodReturnTypeExtension.php
@@ -123,7 +123,9 @@ class CollectionGenericStaticMethodDynamicMethodReturnTypeExtension implements D
                 if ($type instanceof GenericObjectType && (($innerTypeReflection = $type->getClassReflection()) !== null)) {
                     $genericTypes = $innerTypeReflection->typeMapToList($innerTypeReflection->getActiveTemplateTypeMap());
 
-                    return new GenericObjectType($classReflection->getName(), $genericTypes);
+                    if ($classReflection->isSubclassOf($type->getClassName())) {
+                        return new GenericObjectType($classReflection->getName(), $genericTypes);
+                    }
                 }
 
                 return $traverse($type);

--- a/tests/Type/GeneralTypeTest.php
+++ b/tests/Type/GeneralTypeTest.php
@@ -55,6 +55,7 @@ class GeneralTypeTest extends TypeInferenceTestCase
         yield from $this->gatherAssertTypes(__DIR__.'/data/helpers.php');
         yield from $this->gatherAssertTypes(__DIR__.'/data/custom-eloquent-collection.php');
         yield from $this->gatherAssertTypes(__DIR__.'/data/translator.php');
+        yield from $this->gatherAssertTypes(__DIR__.'/data/bug-1760.php');
 
         //##############################################################################################################
 

--- a/tests/Type/data/bug-1760.php
+++ b/tests/Type/data/bug-1760.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace CollectionHelper;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * @template T
+ */
+class Ok
+{
+    /**
+     * @param  T  $value
+     */
+    public function __construct(public mixed $value)
+    {
+    }
+}
+
+/**
+ * @template T
+ */
+class Some
+{
+    /**
+     * @param  T  $value
+     */
+    public function __construct(public mixed $value)
+    {
+    }
+}
+
+assertType('Illuminate\Support\Collection<int, CollectionHelper\Ok<CollectionHelper\Some<int>>>', collect([new Ok(new Some(42))]));
+assertType('Illuminate\Support\Collection<int, CollectionHelper\Ok<CollectionHelper\Some<int>>>', collect([42])->map(fn (int $i) => new Ok(new Some($i))));

--- a/tests/Type/data/collection-helper.php
+++ b/tests/Type/data/collection-helper.php
@@ -44,3 +44,31 @@ function testIterable(\Traversable $foo): void
 {
     assertType('Illuminate\Support\Collection<int, int>', collect($foo));
 }
+
+// Something with generics
+/**
+ * @template T
+ */
+class Ok {
+    /**
+     * @param T $value
+     */
+    public function __construct(public mixed $value) {
+    }
+}
+
+/**
+ * @template T
+ */
+class Some
+{
+    /**
+     * @param T $value
+     */
+    public function __construct(public mixed $value)
+    {
+    }
+}
+
+assertType('Illuminate\Support\Collection<int, CollectionHelper\Ok<CollectionHelper\Some<int>>>', collect([new Ok(new Some(42))]));
+assertType('Illuminate\Support\Collection<int, CollectionHelper\Ok<CollectionHelper\Some<int>>>', collect([42])->map(fn (int $i) => new Ok(new Some($i))));

--- a/tests/Type/data/collection-helper.php
+++ b/tests/Type/data/collection-helper.php
@@ -44,31 +44,3 @@ function testIterable(\Traversable $foo): void
 {
     assertType('Illuminate\Support\Collection<int, int>', collect($foo));
 }
-
-// Something with generics
-/**
- * @template T
- */
-class Ok {
-    /**
-     * @param T $value
-     */
-    public function __construct(public mixed $value) {
-    }
-}
-
-/**
- * @template T
- */
-class Some
-{
-    /**
-     * @param T $value
-     */
-    public function __construct(public mixed $value)
-    {
-    }
-}
-
-assertType('Illuminate\Support\Collection<int, CollectionHelper\Ok<CollectionHelper\Some<int>>>', collect([new Ok(new Some(42))]));
-assertType('Illuminate\Support\Collection<int, CollectionHelper\Ok<CollectionHelper\Some<int>>>', collect([42])->map(fn (int $i) => new Ok(new Some($i))));


### PR DESCRIPTION
- [X] Added or updated tests
- [ ] Documented user facing changes

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->
Found an issue with working with multiple layers of generics in combination with collections. 

**Changes**
<!-- Detail the changes in behaviour this PR introduces. -->
This PR fixes an issue while working with a `Collection<X<Y>>` where it makes the wrong assumption that X is a Collection and transforms it in `Collection<Collection<Y>>`. Adding an explicit check for the type before transforming it fixes it.

**Breaking changes**
—

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
