### PR TITLE
feat: support relation `withDefault`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -72,6 +72,7 @@
         }
     },
     "scripts": {
+        "cs:fix": "phpcbf",
         "test:cs": "phpcs",
         "test:types": "phpstan analyse --ansi --memory-limit 256M",
         "test:unit": "phpunit --colors=always -d memory_limit=1408M",

--- a/tests/Type/data/model-relations.php
+++ b/tests/Type/data/model-relations.php
@@ -15,6 +15,7 @@ use function PHPStan\Testing\assertType;
 
 function test(User $user, \App\Address $address, Account $account, ExtendsModelWithPropertyAnnotations $model, Tag $tag, User|Account $union)
 {
+    assertType('App\Group', $account->group);
     assertType('App\Account', $user->accounts()->firstOrCreate([]));
     assertType(Post::class, $user->posts()->create());
     assertType('App\Account', $user->accounts()->create());

--- a/tests/application/app/Account.php
+++ b/tests/application/app/Account.php
@@ -28,7 +28,7 @@ class Account extends Model
     /** @phpstan-return BelongsTo<Group, Account> */
     public function group(): BelongsTo
     {
-        return $this->belongsTo(Group::class);
+        return $this->belongsTo(Group::class)->withDefault();
     }
 
     public function posts(): BelongsToMany


### PR DESCRIPTION
- [x] Added or updated tests

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->
Closes #1669 

**Changes**

This checks every relation to see if `withDefault` is called, and if so, returns the relation type without the null union.

Note, this is now (potentially) parsing the file twice for each relation: once for the related model name and then again to check for the default method. It might be worth trying to only parse once.

Thanks!
