### PR TITLE
Improve type inference surrounding Arr::get and Arr::pull.

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -178,6 +178,11 @@ services:
             - phpstan.broker.dynamicStaticMethodReturnTypeExtension
 
     -
+        class: Larastan\Larastan\ReturnTypes\ArrGetPullExtension
+        tags:
+            - phpstan.broker.dynamicStaticMethodReturnTypeExtension
+
+    -
         class: Larastan\Larastan\ReturnTypes\ModelDynamicStaticMethodReturnTypeExtension
         tags:
             - phpstan.broker.dynamicStaticMethodReturnTypeExtension
@@ -313,6 +318,11 @@ services:
         class: Larastan\Larastan\ReturnTypes\CollectionGenericStaticMethodDynamicStaticMethodReturnTypeExtension
         tags:
             - phpstan.broker.dynamicStaticMethodReturnTypeExtension
+
+    -
+        class: Larastan\Larastan\Types\ArrPullTypeSpecifyingExtension
+        tags:
+            - phpstan.typeSpecifier.staticMethodTypeSpecifyingExtension
 
     -
         class: Larastan\Larastan\Types\AbortIfFunctionTypeSpecifyingExtension
@@ -559,3 +569,4 @@ rules:
     - Larastan\Larastan\Rules\UselessConstructs\NoUselessValueFunctionCallsRule
     - Larastan\Larastan\Rules\DeferrableServiceProviderMissingProvidesRule
     - Larastan\Larastan\Rules\ConsoleCommand\UndefinedArgumentOrOptionRule
+    - Larastan\Larastan\Rules\ArrGetPullRule

--- a/src/ReturnTypes/ArrGetPullExtension.php
+++ b/src/ReturnTypes/ArrGetPullExtension.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Larastan\Larastan\ReturnTypes;
+
+use ArrayAccess;
+use Illuminate\Support\Arr;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\DynamicStaticMethodReturnTypeExtension;
+use PHPStan\Type\Generic\GenericObjectType;
+use PHPStan\Type\NullType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+use PhpParser\Node\Expr\StaticCall;
+
+/**
+ * @internal
+ */
+final class ArrGetPullExtension implements DynamicStaticMethodReturnTypeExtension
+{
+    public function getClass(): string
+    {
+        return Arr::class;
+    }
+
+    public function isStaticMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return $methodReflection->getName() === 'get' || $methodReflection->getName() === 'pull';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTypeFromStaticMethodCall(
+        MethodReflection $methodReflection,
+        StaticCall $methodCall,
+        Scope $scope
+    ): ?Type {
+        if (count($methodCall->getArgs()) <= 1) {
+            return null;
+        }
+
+        $arrayType = $scope->getType($methodCall->getArgs()[0]->value);
+        $offsetType = $scope->getType($methodCall->getArgs()[1]->value);
+
+        if ($offsetType->isNull()->yes()) {
+            return $arrayType;
+        }
+
+        $hasOffsetValue = $arrayType->hasOffsetValueType($offsetType);
+
+        if ($hasOffsetValue->yes()) {
+            return $arrayType->getOffsetValueType($offsetType);
+        }
+
+        $defaultType = new NullType();
+
+        if (count($methodCall->getArgs()) === 3) {
+            $defaultType = $scope->getType($methodCall->getArgs()[2]->value);
+        }
+
+        if ($hasOffsetValue->no()) {
+            return $defaultType;
+        }
+
+        $returnTypes = [$defaultType];
+
+        $arrayAccessType = new ObjectType(ArrayAccess::class);
+        if ($arrayType->isObject()->yes() && $arrayAccessType->isSuperTypeOf($arrayType)->yes()) {
+            $returnTypes[] = $arrayType->getTemplateType(ArrayAccess::class, 'TValue');
+        } else {
+            $returnTypes[] = $arrayType->getOffsetValueType($offsetType);
+        }
+
+        if ($offsetType->isNull()->maybe()) {
+            $returnTypes[] = $arrayType;
+        }
+
+        return TypeCombinator::union(...$returnTypes);
+    }
+}

--- a/src/Rules/ArrGetPullRule.php
+++ b/src/Rules/ArrGetPullRule.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Larastan\Larastan\Rules;
+
+use Illuminate\Support\Arr;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\VerbosityLevel;
+use PHPStan\Type\MixedType;
+use PhpParser\Node;
+use PhpParser\Node\Expr\StaticCall;
+
+use function in_array;
+
+/** @implements Rule<StaticCall> */
+class ArrGetPullRule implements Rule
+{
+    public function __construct(
+        private ReflectionProvider $reflectionProvider,
+    ) {
+    }
+
+    public function getNodeType(): string
+    {
+        return StaticCall::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (! $node->name instanceof Node\Identifier) {
+            return [];
+        }
+
+        if (! $node->class instanceof Node\Name) {
+            return [];
+        }
+
+        $methodName = strtolower($node->name->name);
+
+        if (! in_array($methodName, ['get', 'pull'], true)) {
+            return [];
+        }
+
+        if (count($node->getArgs()) < 2) {
+            return [];
+        }
+
+        $classReflection = $this->reflectionProvider->getClass($scope->resolveName($node->class));
+
+        if (!$classReflection->is(Arr::class)) {
+            return [];
+        }
+
+        [$array, $key] = $node->getArgs();
+
+        $keyType = $scope->getType($key->value);
+
+        if ($keyType instanceof MixedType) {
+            return [];
+        }
+
+        $arrayType = $scope->getType($array->value);
+
+        if ($arrayType instanceof MixedType) {
+            return [];
+        }
+
+        if ($arrayType->getIterableKeyType()->isSuperTypeOf($keyType)->yes()) {
+            return [];
+        }
+
+        $keyString = $keyType->describe(VerbosityLevel::precise());
+        $arrayString = $arrayType->describe(VerbosityLevel::precise());
+
+        return [
+            RuleErrorBuilder::message("Key {$keyString} does not exist in {$arrayString}.")
+                ->identifier('rules.arrGetPullInvalidKey')
+                ->build()
+        ];
+    }
+}

--- a/src/Types/ArrPullTypeSpecifyingExtension.php
+++ b/src/Types/ArrPullTypeSpecifyingExtension.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Larastan\Larastan\Types;
+
+use Illuminate\Support\Arr;
+use PHPStan\Analyser\Scope;
+use PHPStan\Analyser\SpecifiedTypes;
+use PHPStan\Analyser\TypeSpecifier;
+use PHPStan\Analyser\TypeSpecifierAwareExtension;
+use PHPStan\Analyser\TypeSpecifierContext;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\StaticMethodTypeSpecifyingExtension;
+use PhpParser\Node\Expr\StaticCall;
+
+class ArrPullTypeSpecifyingExtension implements StaticMethodTypeSpecifyingExtension, TypeSpecifierAwareExtension
+{
+    private TypeSpecifier $typeSpecifier;
+
+    public function setTypeSpecifier(TypeSpecifier $typeSpecifier): void
+    {
+        $this->typeSpecifier = $typeSpecifier;
+    }
+
+    public function getClass(): string
+    {
+        return Arr::class;
+    }
+
+    public function isStaticMethodSupported(
+        MethodReflection $staticMethodReflection,
+        StaticCall $node,
+        TypeSpecifierContext $context
+    ): bool {
+        return $staticMethodReflection->getName() === 'pull' && $context->null() && count($node->getArgs()) > 1;
+    }
+
+    public function specifyTypes(
+        MethodReflection $staticMethodReflection,
+        StaticCall $node,
+        Scope $scope,
+        TypeSpecifierContext $context
+    ): SpecifiedTypes {
+        $offsetType = $scope->getType($node->getArgs()[1]->value);
+
+        if ($offsetType->isConstantValue()->no()) {
+            return new SpecifiedTypes();
+        }
+
+        $arrayType = $scope->getType($node->getArgs()[0]->value);
+
+        if (!$arrayType->isArray()->yes()) {
+            return new SpecifiedTypes();
+        }
+
+        return $this->typeSpecifier->create(
+            $node->getArgs()[0]->value,
+            $arrayType->unsetOffset($offsetType),
+            TypeSpecifierContext::createTruthy(),
+            true
+        );
+    }
+}

--- a/stubs/common/Support/Arr.stub
+++ b/stubs/common/Support/Arr.stub
@@ -1,0 +1,18 @@
+<?php
+
+namespace Illuminate\Support;
+
+class Arr
+{
+    /**
+     * Get a value from the array, and remove it.
+     *
+     * @template TArray of array
+     * @param  TArray  $array
+     * @param  string|int  $key
+     * @param  mixed  $default
+     * @return mixed
+     * @param-out TArray $array
+     */
+    public static function pull(&$array, $key, $default = null) {}
+}

--- a/tests/Rules/ArrGetPullRuleTest.php
+++ b/tests/Rules/ArrGetPullRuleTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Rules;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use Larastan\Larastan\Rules\ArrGetPullRule;
+
+/** @extends RuleTestCase<ArrGetPullRule> */
+class ArrGetPullRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(ArrGetPullRule::class);
+    }
+
+    public function testRule(): void
+    {
+        $this->analyse([__DIR__.'/data/arr-get-pull.php'], [
+            ["Key 'bar' does not exist in array{foo: 1}.", 13],
+            ["Key 'bar' does not exist in array{foo: 1}.", 16],
+            ["Key 'bar' does not exist in array<'foo', mixed>.", 18],
+            ["Key 'bar' does not exist in array<'foo', mixed>.", 19],
+            ["Key 3 does not exist in array{1, 2, 3}.", 27],
+            ["Key 3 does not exist in array{1, 2, 3}.", 29],
+            ["Key 'invalid' does not exist in array{foo: 1, bar: 2}.", 41],
+            ["Key 'invalid' does not exist in array{foo: 1, bar: 2}.", 42],
+        ]);
+    }
+
+	public static function getAdditionalConfigFiles(): array
+	{
+		return [
+			__DIR__ . '/phpstan-rules.neon',
+		];
+	}
+}

--- a/tests/Rules/data/arr-get-pull.php
+++ b/tests/Rules/data/arr-get-pull.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Arr;
+
+/**
+ * @param array<string, mixed> $mixedArray
+ * @param array<'foo', mixed> $specificKeys
+ */
+function test(array $mixedArray, array $specificKeys, array $unspecified, mixed $key): void
+{
+    Arr::get(['foo' => 1], 'bar');
+    Arr::get(['foo' => 1], 'foo');
+    Arr::pull(['foo' => 1], 'foo');
+    Arr::pull(['foo' => 1], 'bar');
+
+    Arr::get($specificKeys, 'bar');
+    Arr::pull($specificKeys, 'bar');
+
+    Arr::get($mixedArray, 'any');
+    Arr::pull($mixedArray, 'any');
+
+    Arr::get($unspecified, $key);
+
+    Arr::get([1,2,3], 2);
+    Arr::get([1,2,3], 3);
+    Arr::pull([1,2,3], 2);
+    Arr::pull([1,2,3], 3);
+}
+
+/**
+ * @param array{foo: 1, bar: 2} $shaped1
+ * @param array{foo: 1, bar: 2} $shaped2
+ */
+function testShape(array $shaped1, array $shaped2): void
+{
+    Arr::get($shaped1, 'foo');
+    Arr::pull($shaped1, 'foo');
+
+    Arr::get($shaped2, 'invalid');
+    Arr::pull($shaped2, 'invalid');
+}

--- a/tests/Type/GeneralTypeTest.php
+++ b/tests/Type/GeneralTypeTest.php
@@ -59,6 +59,7 @@ class GeneralTypeTest extends TypeInferenceTestCase
         yield from self::gatherAssertTypes(__DIR__.'/data/view-exists.php');
         yield from self::gatherAssertTypes(__DIR__.'/data/view.php');
         yield from self::gatherAssertTypes(__DIR__.'/data/where-relation.php');
+        yield from self::gatherAssertTypes(__DIR__.'/data/arr-get.php');
 
         if (version_compare(LARAVEL_VERSION, '10.15.0', '>=')) {
             yield from self::gatherAssertTypes(__DIR__.'/data/model-l10-15.php');

--- a/tests/Type/data/arr-get.php
+++ b/tests/Type/data/arr-get.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace ArrGet;
+
+use ArrayAccess;
+use Illuminate\Support\Arr;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * @param ArrayAccess $arrayAccessMixed
+ * @param ArrayAccess<string, int<1, max>> $arrayAccess
+ * @param array{foo: 1}|array{bar: 2} $union
+ * @param array<string, string> $iterable
+ */
+function test(
+    ArrayAccess $arrayAccessMixed,
+    ArrayAccess $arrayAccess,
+    array $union,
+    array $iterable,
+    ?string $nullableKey,
+): void
+{
+    assertType('mixed', Arr::get($arrayAccessMixed, 1, []));
+    assertType('array{}', Arr::get($arrayAccess, 1, []));
+    assertType('array{}|ArrayAccess<string, int<1, max>>|int<1, max>', Arr::get($arrayAccess, $nullableKey, []));
+    assertType('int<0, max>', Arr::get($arrayAccess, 'key', 0));
+    assertType('array{foo: 1}', Arr::get(['foo' => 1], null));
+    assertType('1|array{foo: 1}|null', Arr::get(['foo' => 1], $nullableKey));
+    assertType('2', Arr::get(['foo' => 1], 'bar', 2));
+    assertType('null', Arr::get(['foo' => 1], 'bar'));
+    assertType('2|3', Arr::get($union, 'bar', 3));
+    assertType('array{foo: 1}', Arr::pull(['foo' => 1], null));
+    assertType('2', Arr::pull(['foo' => 1], 'bar', 2));
+    assertType('null', Arr::pull(['foo' => 1], 'bar'));
+    assertType('2|3', Arr::pull($union, 'bar', 3));
+    assertType('3|string', Arr::get($iterable, 'bar', 3));
+    assertType('string|null', Arr::get($iterable, 'bar'));
+    assertType('null', Arr::get($iterable, 1));
+    assertType('null', Arr::pull($iterable, 1));
+}
+
+/**
+ * @param array{foo: 1, bar: 2} $arr
+ */
+function testPull(array $arr): void
+{
+    $pulled = Arr::pull($arr, 'foo');
+
+    assertType('1', $pulled);
+    assertType('array{bar: 2}', $arr);
+}


### PR DESCRIPTION
**Changes**

Improves type inference surrounding `Arr::get` and `Arr::pull`, such as return types and type-specifying the `Arr::pull` `$array` argument. 

Also provides a rule to alert when the `$key` is not present on the `$array` for both `Arr::get` and `Arr::pull`, closing: https://github.com/larastan/larastan/issues/1727