### PR TITLE
Support schema variable

### DIFF
--- a/src/Properties/SchemaAggregator.php
+++ b/src/Properties/SchemaAggregator.php
@@ -83,6 +83,28 @@ final class SchemaAggregator
                 && ($stmt->expr->class->toCodeString() === '\Schema' || (new ObjectType('Illuminate\Support\Facades\Schema'))->isSuperTypeOf(new ObjectType($stmt->expr->class->toCodeString()))->yes())
             ) {
                 $statement = $stmt->expr;
+            } elseif (
+                $stmt instanceof PhpParser\Node\Stmt\Expression
+                && $stmt->expr instanceof PhpParser\Node\Expr\Assign
+                && $stmt->expr->var instanceof PhpParser\Node\Expr\Variable
+                && is_string($stmt->expr->var->name)
+                && $stmt->expr->expr instanceof PhpParser\Node\Expr\StaticCall
+                && $stmt->expr->expr->class instanceof PhpParser\Node\Name
+                && $stmt->expr->expr->name instanceof PhpParser\Node\Identifier
+                && ($stmt->expr->expr->name->toString() === 'connection' || $stmt->expr->expr->name->toString() === 'setConnection')
+                && ($stmt->expr->expr->class->toCodeString() === '\Schema' || (new ObjectType('Illuminate\Support\Facades\Schema'))->isSuperTypeOf(new ObjectType($stmt->expr->expr->class->toCodeString()))->yes())
+            ) {
+                $variable = $stmt->expr->var->name;
+
+                continue;
+            } elseif (
+                isset($variable)
+                && $stmt instanceof PhpParser\Node\Stmt\Expression
+                && $stmt->expr instanceof PhpParser\Node\Expr\MethodCall
+                && $stmt->expr->var instanceof PhpParser\Node\Expr\Variable
+                && $stmt->expr->var->name === $variable
+            ) {
+                $statement = $stmt->expr;
             } else {
                 continue;
             }

--- a/tests/application/database/migrations/2021_09_10_000000_create_addresses_table.php
+++ b/tests/application/database/migrations/2021_09_10_000000_create_addresses_table.php
@@ -17,7 +17,9 @@ class CreateAddressesTable extends Migration
      */
     public function up(): void
     {
-        Schema::create('addresses', static function (Blueprint $table) {
+        $schema = Schema::connection('configured_connection_name');
+
+        $schema->create('addresses', static function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->uuid();
             $table->foreignIdFor(User::class);


### PR DESCRIPTION
In my project I'm interacting with Laravel Telescope's [EntryModel](https://github.com/laravel/telescope/blob/5.x/src/Storage/EntryModel.php). Because its [migration](https://github.com/laravel/telescope/blob/5.x/database/migrations/2018_08_08_100000_create_telescope_entries_table.php) first assigns the schema builder to a variable and then calls the `create()` method on that variable, Larastan isn't currently able to understand this migration file when adding it to `databaseMigrationsPath`. I get the following error:

```
Access to an undefined property Laravel\Telescope\Storage\EntryModel::$content.
```

I modified one of the migrations to use a variable, to demonstrate that the tests fail, and I provided a possible solution with this pull request. However, I'm not very familiar with this codebase and php-parser, and I'm open to any suggestions/changes. I'm also aware that there is an open PR that touches the same code (#1879), so after that has been merged, this needs to change anyway. 