### PR TITLE
test: regression test for mapping custom simple collections

### DIFF
--- a/tests/Type/data/collection-generic-static-methods-l948.php
+++ b/tests/Type/data/collection-generic-static-methods-l948.php
@@ -4,6 +4,7 @@ use App\Group;
 use App\Transaction;
 use App\TransactionCollection;
 use App\User;
+use App\ValueObjects\Favorites;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Support\Collection as SupportCollection;
 
@@ -13,6 +14,7 @@ use function PHPStan\Testing\assertType;
 /** @var SupportCollection<string, int> $items */
 /** @var App\TransactionCollection<int, Transaction> $customEloquentCollection */
 /** @var App\UserCollection $secondCustomEloquentCollection */
+/** @var App\FavoritesCollection $customCollection */
 /** @var User $user */
 assertType('Illuminate\Database\Eloquent\Collection<int, int>', EloquentCollection::range(1, 10));
 
@@ -198,3 +200,7 @@ assertType('Illuminate\Support\Collection<(int|string), Illuminate\Support\Colle
         'type' => 'B',
     ],
 ])->groupBy('type'));
+
+// Regression test for mapping custom simple Collections
+assertType('App\FavoritesCollection', $customCollection->map(fn (Favorites $favorites) => $favorites));
+assertType('App\FavoritesCollection', $customCollection->mapWithKeys(fn (Favorites $favorites, int|string $key) => [$key => $favorites]));

--- a/tests/application/app/FavoritesCollection.php
+++ b/tests/application/app/FavoritesCollection.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+namespace App;
+
+use App\ValueObjects\Favorites;
+use Illuminate\Support\Collection;
+
+/**
+ * @extends Collection<array-key, Favorites>
+ */
+class FavoritesCollection extends Collection
+{
+}


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

Since `2.9.1` a change was introduced to Collections where calling `map` or `mapWithKeys` on a custom `\Illuminate\Support\Collection` would make PHPStan report returning a basic `Collection`, even though the custom Collection was actually returned.

On `a79b46b9` running this testcase results in the following failure:

```
1) Tests\Type\CollectionDynamicReturnTypeExtensionsTest::testFileAsserts with data set "/Users/erikgaal/Dev/larastan/tests/Type/data/collection-generic-static-methods-l948.php:204" ('type', '/Users/erikgaal/Dev/larastan...48.php', 'App\FavoritesCollection', 'Illuminate\Support\Collection...rites>', 204)
Expected type App\FavoritesCollection, got type Illuminate\Support\Collection<(int|string), App\ValueObjects\Favorites> in /Users/erik.gaal/Dev/larastan/tests/Type/data/collection-generic-static-methods-l948.php on line 204.
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'App\FavoritesCollection'
+'Illuminate\Support\Collection<(int|string), App\ValueObjects\Favorites>'
```

**Changes**

This has since been fixed in trunk, but no tests exist for this scenario. This PR adds regression tests for these two scenario's.

<!-- Detail the changes in behaviour this PR introduces. -->

**Breaking changes**

None.

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
