### PR TITLE
fix: eloquent collection generics

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -299,7 +299,7 @@ services:
             - phpstan.broker.dynamicMethodReturnTypeExtension
 
     -
-        class: Larastan\Larastan\ReturnTypes\EnumerableGenericStaticMethodDynamicMethodReturnTypeExtension
+        class: Larastan\Larastan\ReturnTypes\EnumerableGenericDynamicMethodReturnTypeExtension
         tags:
             - phpstan.broker.dynamicMethodReturnTypeExtension
 
@@ -314,7 +314,7 @@ services:
             - phpstan.broker.dynamicMethodReturnTypeExtension
 
     -
-        class: Larastan\Larastan\ReturnTypes\EnumerableGenericStaticMethodDynamicStaticMethodReturnTypeExtension
+        class: Larastan\Larastan\ReturnTypes\EnumerableGenericDynamicStaticMethodReturnTypeExtension
         tags:
             - phpstan.broker.dynamicStaticMethodReturnTypeExtension
 

--- a/src/ReturnTypes/EnumerableGenericDynamicMethodReturnTypeExtension.php
+++ b/src/ReturnTypes/EnumerableGenericDynamicMethodReturnTypeExtension.php
@@ -26,7 +26,7 @@ use function array_map;
 use function array_merge;
 use function in_array;
 
-class EnumerableGenericStaticMethodDynamicMethodReturnTypeExtension implements DynamicMethodReturnTypeExtension
+class EnumerableGenericDynamicMethodReturnTypeExtension implements DynamicMethodReturnTypeExtension
 {
     public function getClass(): string
     {

--- a/src/ReturnTypes/EnumerableGenericDynamicStaticMethodReturnTypeExtension.php
+++ b/src/ReturnTypes/EnumerableGenericDynamicStaticMethodReturnTypeExtension.php
@@ -25,7 +25,7 @@ use PHPStan\Type\UnionType;
 use function array_map;
 use function in_array;
 
-class EnumerableGenericStaticMethodDynamicStaticMethodReturnTypeExtension implements DynamicStaticMethodReturnTypeExtension
+class EnumerableGenericDynamicStaticMethodReturnTypeExtension implements DynamicStaticMethodReturnTypeExtension
 {
     public function __construct(private ReflectionProvider $reflectionProvider)
     {

--- a/src/ReturnTypes/EnumerableGenericStaticMethodDynamicMethodReturnTypeExtension.php
+++ b/src/ReturnTypes/EnumerableGenericStaticMethodDynamicMethodReturnTypeExtension.php
@@ -36,7 +36,12 @@ class EnumerableGenericStaticMethodDynamicMethodReturnTypeExtension implements D
     public function isMethodSupported(MethodReflection $methodReflection): bool
     {
         if ($methodReflection->getDeclaringClass()->getName() === EloquentCollection::class) {
-            return $methodReflection->getName() === 'find';
+            return in_array($methodReflection->getName(), [
+                'except',
+                'find',
+                'only',
+                'unique',
+            ], true);
         }
 
         $methods = [

--- a/tests/Type/data/collection-generic-static-methods.php
+++ b/tests/Type/data/collection-generic-static-methods.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Role;
 use App\Transaction;
 use App\TransactionCollection;
 use App\User;
@@ -21,7 +22,7 @@ assertType('Illuminate\Support\LazyCollection<int, int>', LazyCollection::range(
 assertType('Illuminate\Support\Collection<int, mixed>', $collection->collapse());
 assertType('Illuminate\Support\Collection<int, mixed>', $items->collapse());
 
-assertType('Illuminate\Database\Eloquent\Collection<int, array<int, App\User|int>>', $collection->crossJoin([1]));
+assertType('Illuminate\Support\Collection<int, array<int, App\User|int>>', $collection->crossJoin([1]));
 
 assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', $collection->find($items));
 assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', $collection->find([1]));
@@ -44,10 +45,10 @@ assertType('App\User|bool', $secondCustomEloquentCollection->find(1, false));
 assertType('Illuminate\Support\Collection<int, mixed>', $collection->flatten());
 assertType('Illuminate\Support\Collection<int, mixed>', $items->flatten());
 
-assertType('Illuminate\Support\Collection<App\User, int>', $collection->flip());
+assertType('Illuminate\Support\Collection<string, int>', $collection->flip());
 assertType('Illuminate\Support\Collection<int, string>', $items->flip());
 
-assertType('Illuminate\Database\Eloquent\Collection<(int|string), Illuminate\Database\Eloquent\Collection<(int|string), App\User>>', $collection->groupBy('id'));
+assertType('Illuminate\Support\Collection<(int|string), Illuminate\Database\Eloquent\Collection<(int|string), App\User>>', $collection->groupBy('id'));
 assertType('Illuminate\Support\Collection<(int|string), Illuminate\Support\Collection<(int|string), int>>', $items->groupBy('id'));
 
 assertType('Illuminate\Database\Eloquent\Collection<(int|string), App\User>', $collection->keyBy(fn (User $user, int $key): string => $user->email));
@@ -63,9 +64,9 @@ assertType('Illuminate\Support\Collection<int, int>', $secondCustomEloquentColle
 assertType('Illuminate\Support\Collection<int, int>', $collection->map(fn (User $user): int => $user->id));
 assertType('Illuminate\Support\Collection<string, int>', $items->map(fn (int $value, string $key): int => $value));
 
-assertType('Illuminate\Database\Eloquent\Collection<int, array<int, int>>', $collection->mapToDictionary(fn (User $u) => [$u->id => $u->id]));
-assertType('App\TransactionCollection<string, array<int, int>>', $customEloquentCollection->mapToDictionary(fn (Transaction $t) => ['foo'=> $t->id]));
-assertType('App\UserCollection', $secondCustomEloquentCollection->mapToDictionary(fn (User $t) => ['foo'=> $t->id]));
+assertType('Illuminate\Support\Collection<int, array<int, int>>', $collection->mapToDictionary(fn (User $u) => [$u->id => $u->id]));
+assertType('Illuminate\Support\Collection<string, array<int, int>>', $customEloquentCollection->mapToDictionary(fn (Transaction $t) => ['foo'=> $t->id]));
+assertType('Illuminate\Support\Collection<string, array<int, int>>', $secondCustomEloquentCollection->mapToDictionary(fn (User $t) => ['foo'=> $t->id]));
 assertType('Illuminate\Support\Collection<string, array<int, int>>', $items->mapToDictionary(fn (int $v) => ['foo' => $v]));
 
 assertType('Illuminate\Support\Collection<int, string>', $customEloquentCollection->mapWithKeys(fn (Transaction $transaction): array => [$transaction->id => 'foo']));
@@ -73,14 +74,14 @@ assertType('Illuminate\Support\Collection<int, string>', $secondCustomEloquentCo
 assertType('Illuminate\Support\Collection<int, int>', $collection->mapWithKeys(fn (User $user): array => [$user->id => $user->id]));
 assertType('Illuminate\Support\Collection<string, int>', $items->mapWithKeys(fn (int $value, string $key): array => ['foo' => $value]));
 
-assertType('Illuminate\Database\Eloquent\Collection<int, App\User|string>', $collection->mergeRecursive([2 => 'foo']));
+assertType('Illuminate\Support\Collection<int, App\User|string>', $collection->mergeRecursive([2 => 'foo']));
 assertType('App\TransactionCollection<int, App\Transaction>', $customEloquentCollection->mergeRecursive([1 => new Transaction()]));
 assertType('App\UserCollection', $secondCustomEloquentCollection->mergeRecursive([1 => new User()]));
 assertType('Illuminate\Support\Collection<string, int>', $items->mergeRecursive(['foo' => 2]));
 
-assertType('Illuminate\Database\Eloquent\Collection<(int|string), int>', $collection->combine([1]));
-assertType('App\TransactionCollection<(int|string), int>', $customEloquentCollection->combine([1]));
-assertType('App\UserCollection', $secondCustomEloquentCollection->combine([1]));
+assertType('Illuminate\Support\Collection<(int|string), int>', $collection->combine([1]));
+assertType('Illuminate\Support\Collection<(int|string), int>', $customEloquentCollection->combine([1]));
+assertType('Illuminate\Support\Collection<(int|string), int>', $secondCustomEloquentCollection->combine([1]));
 assertType('Illuminate\Support\Collection<(int|string), string>', $items->combine(['foo']));
 
 assertType('App\User|null', $collection->pop(1));
@@ -100,29 +101,29 @@ assertType('App\TransactionCollection<int, App\Transaction>', $customEloquentCol
 assertType('App\UserCollection', $secondCustomEloquentCollection->shift(2));
 assertType('Illuminate\Support\Collection<int, int>', $items->shift(3));
 
-assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Eloquent\Collection<int, App\User>>', $collection->sliding(1));
-assertType('App\TransactionCollection<int, App\TransactionCollection<int, App\Transaction>>', $customEloquentCollection->sliding(2));
-assertType('App\UserCollection', $secondCustomEloquentCollection->sliding(2));
+assertType('Illuminate\Support\Collection<int, Illuminate\Database\Eloquent\Collection<int, App\User>>', $collection->sliding(1));
+assertType('Illuminate\Support\Collection<int, App\TransactionCollection<int, App\Transaction>>', $customEloquentCollection->sliding(2));
+assertType('Illuminate\Support\Collection<int, App\UserCollection>', $secondCustomEloquentCollection->sliding(2));
 assertType('Illuminate\Support\Collection<int, Illuminate\Support\Collection<string, int>>', $items->sliding(3));
 
-assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Eloquent\Collection<int, App\User>>', $collection->split(1));
-assertType('App\TransactionCollection<int, App\TransactionCollection<int, App\Transaction>>', $customEloquentCollection->split(2));
-assertType('App\UserCollection', $secondCustomEloquentCollection->split(2));
+assertType('Illuminate\Support\Collection<int, Illuminate\Database\Eloquent\Collection<int, App\User>>', $collection->split(1));
+assertType('Illuminate\Support\Collection<int, App\TransactionCollection<int, App\Transaction>>', $customEloquentCollection->split(2));
+assertType('Illuminate\Support\Collection<int, App\UserCollection>', $secondCustomEloquentCollection->split(2));
 assertType('Illuminate\Support\Collection<int, Illuminate\Support\Collection<string, int>>', $items->split(3));
 
-assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Eloquent\Collection<int, App\User>>', $collection->splitIn(1));
-assertType('App\TransactionCollection<int, App\TransactionCollection<int, App\Transaction>>', $customEloquentCollection->splitIn(2));
-assertType('App\UserCollection', $secondCustomEloquentCollection->splitIn(2));
+assertType('Illuminate\Support\Collection<int, Illuminate\Database\Eloquent\Collection<int, App\User>>', $collection->splitIn(1));
+assertType('Illuminate\Support\Collection<int, App\TransactionCollection<int, App\Transaction>>', $customEloquentCollection->splitIn(2));
+assertType('Illuminate\Support\Collection<int, App\UserCollection>', $secondCustomEloquentCollection->splitIn(2));
 assertType('Illuminate\Support\Collection<int, Illuminate\Support\Collection<string, int>>', $items->splitIn(3));
 
-assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Eloquent\Collection<int, App\User>>', $collection->chunk(1));
-assertType('App\TransactionCollection<int, App\TransactionCollection<int, App\Transaction>>', $customEloquentCollection->chunk(2));
-assertType('App\UserCollection', $secondCustomEloquentCollection->chunk(2));
+assertType('Illuminate\Support\Collection<int, Illuminate\Database\Eloquent\Collection<int, App\User>>', $collection->chunk(1));
+assertType('Illuminate\Support\Collection<int, App\TransactionCollection<int, App\Transaction>>', $customEloquentCollection->chunk(2));
+assertType('Illuminate\Support\Collection<int, App\UserCollection>', $secondCustomEloquentCollection->chunk(2));
 assertType('Illuminate\Support\Collection<int, Illuminate\Support\Collection<string, int>>', $items->chunk(3));
 
-assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Eloquent\Collection<int, App\User>>', $collection->chunkWhile(fn (User $u) => $u->id > 5));
-assertType('App\TransactionCollection<int, App\TransactionCollection<int, App\Transaction>>', $customEloquentCollection->chunkWhile(fn (Transaction $t) => $t->id > 5));
-assertType('App\UserCollection', $secondCustomEloquentCollection->chunkWhile(fn (User $t) => $t->id > 5));
+assertType('Illuminate\Support\Collection<int, Illuminate\Database\Eloquent\Collection<int, App\User>>', $collection->chunkWhile(fn (User $u) => $u->id > 5));
+assertType('Illuminate\Support\Collection<int, App\TransactionCollection<int, App\Transaction>>', $customEloquentCollection->chunkWhile(fn (Transaction $t) => $t->id > 5));
+assertType('Illuminate\Support\Collection<int, App\UserCollection>', $secondCustomEloquentCollection->chunkWhile(fn (User $t) => $t->id > 5));
 assertType('Illuminate\Support\Collection<int, Illuminate\Support\Collection<int, int>>', $items->chunkWhile(fn ($v) => $v > 5));
 
 assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', $collection->values());
@@ -135,9 +136,9 @@ assertType('Illuminate\Support\Collection<int, Illuminate\Support\Collection<int
 assertType('Illuminate\Support\Collection<int, Illuminate\Support\Collection<int, App\User|string>>', $secondCustomEloquentCollection->zip(['foo']));
 assertType('Illuminate\Support\Collection<int, Illuminate\Support\Collection<int, int|string>>', $items->zip(['foo', 'bar']));
 
-assertType('Illuminate\Database\Eloquent\Collection<int<0, 1>, Illuminate\Database\Eloquent\Collection<int, App\User>>', $collection->partition('foo'));
-assertType('App\TransactionCollection<int<0, 1>, App\TransactionCollection<int, App\Transaction>>', $customEloquentCollection->partition('foo'));
-assertType('App\UserCollection', $secondCustomEloquentCollection->partition('foo'));
+assertType('Illuminate\Support\Collection<int<0, 1>, Illuminate\Database\Eloquent\Collection<int, App\User>>', $collection->partition('foo'));
+assertType('Illuminate\Support\Collection<int<0, 1>, App\TransactionCollection<int, App\Transaction>>', $customEloquentCollection->partition('foo'));
+assertType('Illuminate\Support\Collection<int<0, 1>, App\UserCollection>', $secondCustomEloquentCollection->partition('foo'));
 assertType('Illuminate\Support\Collection<int<0, 1>, Illuminate\Support\Collection<string, int>>', $items->partition('foo'));
 
 assertType('Illuminate\Support\Collection<int, App\User|int>', $collection->pad(10, 10));
@@ -154,6 +155,16 @@ assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', $collection
 assertType('App\TransactionCollection<int, App\Transaction|App\User>', $customEloquentCollection->concat([new User()]));
 assertType('App\UserCollection', $secondCustomEloquentCollection->concat([new User()]));
 assertType('Illuminate\Support\Collection<string, App\User|int>', $items->concat([new User()]));
+
+assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', $collection->unique());
+assertType('App\TransactionCollection<int, App\Transaction>', $customEloquentCollection->unique());
+assertType('App\UserCollection', $secondCustomEloquentCollection->unique());
+assertType('Illuminate\Support\Collection<string, int>', $items->unique());
+
+assertType('Illuminate\Database\Eloquent\Collection<int, App\Role>', $collection->map(fn ($v) => new Role()));
+assertType('App\TransactionCollection<int, App\Role>', $customEloquentCollection->map(fn ($v) => new Role()));
+assertType('Illuminate\Database\Eloquent\Collection<int, App\Role>', $secondCustomEloquentCollection->map(fn ($v) => new Role()));
+assertType('Illuminate\Support\Collection<string, App\Role>', $items->map(fn ($v) => new Role()));
 
 ////////////////////////////
 // EnumeratesValues Trait //
@@ -173,14 +184,14 @@ assertType('Illuminate\Support\Collection<int, int>', SupportCollection::times(1
 assertType('Illuminate\Support\LazyCollection<int, int>', LazyCollection::times(10, fn ($int) => 5));
 
 // In runtime it returns `Illuminate\Support\Collection<string, Illuminate\Database\Eloquent\Collection<int, int>>`
-// Might be fixed in Laravel or needs a separate extension
+// Needs to be fixed in Laravel to match
 assertType(
-    'Illuminate\Database\Eloquent\Collection<string, Illuminate\Database\Eloquent\Collection<int, int>>',
+    'Illuminate\Support\Collection<string, Illuminate\Support\Collection<int, int>>',
     $collection->mapToGroups(fn (User $user, int $key): array => ['foo' => $user->id])
 );
 
 assertType(
-    'Illuminate\Database\Eloquent\Collection<int, int>',
+    'Illuminate\Support\Collection<int, int>',
     $collection->flatMap(function (User $user, int $id) {
         return [$user->id];
     })

--- a/tests/Type/data/collection-stubs.php
+++ b/tests/Type/data/collection-stubs.php
@@ -7,7 +7,6 @@ use App\RoleCollection;
 use App\User;
 use App\Role;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection as SupportCollection;
 
 use function PHPStan\Testing\assertType;
@@ -118,4 +117,4 @@ assertType('App\User|null', $collectionOfUsers->shift());
 assertType('Illuminate\Support\Collection<int, App\User>', $collectionOfUsers->shift(5));
 
 assertType('App\BaseCollection<int, int>', $baseCollection->map(fn ($v) => (int) $v));
-assertType('App\RoleCollection<int, User>', $roleCollection->map(fn ($role): Model => null));
+assertType('App\RoleCollection<int, App\User>', $roleCollection->map(fn ($role) => new User()));

--- a/tests/Type/data/collection-stubs.php
+++ b/tests/Type/data/collection-stubs.php
@@ -2,8 +2,12 @@
 
 namespace CollectionStubs;
 
+use App\BaseCollection;
+use App\RoleCollection;
 use App\User;
+use App\Role;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection as SupportCollection;
 
 use function PHPStan\Testing\assertType;
@@ -11,6 +15,8 @@ use function PHPStan\Testing\assertType;
 /** @var EloquentCollection<int, User> $collection */
 /** @var SupportCollection<string, int> $items */
 /** @var SupportCollection<int, User> $collectionOfUsers */
+/** @var BaseCollection<int, string> $baseCollection */
+/** @var RoleCollection<int, Role> $roleCollection */
 /** @var User $user */
 assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', User::all()->each(function (User $user, int $key): void {
 }));
@@ -110,3 +116,6 @@ assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', $collection
 
 assertType('App\User|null', $collectionOfUsers->shift());
 assertType('Illuminate\Support\Collection<int, App\User>', $collectionOfUsers->shift(5));
+
+assertType('App\BaseCollection<int, int>', $baseCollection->map(fn ($v) => (int) $v));
+assertType('App\RoleCollection<int, User>', $roleCollection->map(fn ($role): Model => null));

--- a/tests/Type/data/custom-eloquent-collection.php
+++ b/tests/Type/data/custom-eloquent-collection.php
@@ -8,6 +8,7 @@ use App\ModelWithNonGenericCollection;
 use App\ModelWithOnlyValueGenericCollection;
 use App\Role;
 use App\User;
+use Illuminate\Database\Eloquent\Model;
 
 use function PHPStan\Testing\assertType;
 
@@ -132,4 +133,10 @@ function foo()
     assertType('App\AccountCollection<int, App\Account>', (new User)->accounts->where('active', true));
     assertType('App\AccountCollection<int, App\Account>', (new User)->accounts->filterByActive());
     assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', (new User)->children->where('active', true));
+
+    assertType('App\RoleCollection<int, App\Role>', Role::query()->get());
+    assertType('App\RoleCollection<int, App\Role>', Role::query()->get()->unique());
+    assertType('App\RoleCollection<int, App\Role>', Role::query()->get()->only());
+    assertType('App\RoleCollection<int, App\Role>', Role::query()->get()->except());
+    assertType('App\RoleCollection<int, App\User>', Role::query()->get()->map(fn ($role): Model => new User()));
 }

--- a/tests/application/app/AccountCollection.php
+++ b/tests/application/app/AccountCollection.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Eloquent\Collection;
 
 /**
  * @template TKey of array-key
- * @template TModel
+ * @template TModel of \Illuminate\Database\Eloquent\Model
  *
  * @extends Collection<TKey, TModel>
  */

--- a/tests/application/app/BaseCollection.php
+++ b/tests/application/app/BaseCollection.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App;
+
+use Illuminate\Support\Collection;
+
+/**
+ * @template TKey of array-key
+ * @template TValue
+ *
+ * @extends Collection<TKey, TValue>
+ */
+class BaseCollection extends Collection
+{
+    //
+}

--- a/tests/application/app/RoleCollection.php
+++ b/tests/application/app/RoleCollection.php
@@ -6,9 +6,9 @@ use Illuminate\Database\Eloquent\Collection;
 
 /**
  * @template TKey of array-key
- * @template TValue of \Illuminate\Database\Eloquent\Model
+ * @template TModel of \Illuminate\Database\Eloquent\Model
  *
- * @extends Collection<TKey, TValue>
+ * @extends Collection<TKey, TModel>
  */
 class RoleCollection extends Collection
 {

--- a/tests/application/app/TransactionCollection.php
+++ b/tests/application/app/TransactionCollection.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Eloquent\Collection;
 
 /**
  * @template TKey of array-key
- * @template TModel
+ * @template TModel of \Illuminate\Database\Eloquent\Model
  *
  * @extends Collection<TKey, TModel>
  */


### PR DESCRIPTION
- [x] Added or updated tests

Closes #1927 

**Changes**

Hello!

This PR corrects EloquentCollection generics and issues with custom EloquentClasses.

With these changes, a collection can only be an EloquentCollection if Model can be a super type of all the inner types in the collection. If this is not the case, then the collection class is downgraded to the SupportCollection.

Furthermore, if you have a custom collection that narrows the `TModel` generic, and that collection has a wider type, then the collection is downgraded to an EloquentCollection:

```php
/** @extends EloquentCollection<int, User> */
class UserCollection extends EloquentCollection
// ..
$userCollection; // this has type UserCollection
$foo = $userCollection->map(fn ($u) => new Role()); // now a EloquentCollection<int, Role>

```

Thanks!
