### PR TITLE
Allow Backed Enums to be used for the auth provider

### DIFF
--- a/src/Concerns/LoadsAuthModel.php
+++ b/src/Concerns/LoadsAuthModel.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Larastan\Larastan\Concerns;
 
+use BackedEnum;
 use Illuminate\Contracts\Config\Repository as ConfigRepository;
 
 use function array_keys;
@@ -32,7 +33,7 @@ trait LoadsAuthModel
                     return $carry;
                 }
 
-                if ($provider instanceof \BackedEnum) {
+                if ($provider instanceof BackedEnum) {
                     $provider = $provider->value;
                 }
 

--- a/src/Concerns/LoadsAuthModel.php
+++ b/src/Concerns/LoadsAuthModel.php
@@ -32,6 +32,10 @@ trait LoadsAuthModel
                     return $carry;
                 }
 
+                if ($provider instanceof \BackedEnum) {
+                    $provider = $provider->value;
+                }
+
                 $authModel = $providers[$provider]['model'] ?? null;
 
                 if (! $authModel || in_array($authModel, $carry, strict: true)) {

--- a/tests/Type/data/auth.php
+++ b/tests/Type/data/auth.php
@@ -36,6 +36,11 @@ class AuthExtension
         assertType(StatefulGuard::class, Auth::guard('web'));
     }
 
+    public function testGuardEnum(): void
+    {
+        assertType(StatefulGuard::class, Auth::guard('enum'));
+    }
+
     public function testGuardUser(): void
     {
         assertType('App\User|null', Auth::guard('web')->user());

--- a/tests/application/app/ProviderEnum.php
+++ b/tests/application/app/ProviderEnum.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App;
+
+enum ProviderEnum: string
+{
+    case Users = 'users';
+}

--- a/tests/application/config/auth.php
+++ b/tests/application/config/auth.php
@@ -23,6 +23,11 @@ return [
             'provider' => 'users',
             'hash' => false,
         ],
+
+        'enum' => [
+            'driver' => 'session',
+            'provider' => App\ProviderEnum::Users,
+        ],
     ],
 
     'providers' => [


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

If you are using a BackedEnum for the auth provider, this resolves issues with that.

**Breaking changes**

There are no BC
