### PR TITLE
Add types for first methods in HasManyThrough

### DIFF
--- a/stubs/10.0.0/HasManyThrough.stub
+++ b/stubs/10.0.0/HasManyThrough.stub
@@ -49,6 +49,34 @@ class HasManyThrough extends Relation
     public function cursorPaginate($perPage = null, $columns = ['*'], $cursorName = 'cursor', $cursor = null);
 
     /**
+     * Execute the query and get the first related model.
+     *
+     * @param  array<int, string>  $columns
+     * @return TRelatedModel|null
+     */
+    public function first($columns = ['*']);
+
+    /**
+     * Execute the query and get the first result or throw an exception.
+     *
+     * @param  array<int, string>  $columns
+     * @return TRelatedModel
+     *
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException<TRelatedModel>
+     */
+    public function firstOrFail($columns = ['*']);
+
+    /**
+     * Execute the query and get the first result or call a callback.
+     *
+     * @template TReturnClosure
+     * @param  (\Closure(): TReturnClosure)|array<int, string>  $columns
+     * @param  (\Closure(): TReturnClosure)|null  $callback
+     * @return TRelatedModel|TReturnClosure
+     */
+    public function firstOr($columns = ['*'], ?\Closure $callback = null);
+
+    /**
      * Find a related model by its primary key.
      *
      * @param  mixed  $id
@@ -72,4 +100,5 @@ class HasManyThrough extends Relation
      * @return HasOneThrough<TRelatedModel>
      */
     public function one();
+
 }

--- a/stubs/common/HasManyThrough.stub
+++ b/stubs/common/HasManyThrough.stub
@@ -49,6 +49,35 @@ class HasManyThrough extends Relation
     public function cursorPaginate($perPage = null, $columns = ['*'], $cursorName = 'cursor', $cursor = null);
 
     /**
+     * Execute the query and get the first related model.
+     *
+     * @param  array<int, string>  $columns
+     * @return TRelatedModel|null
+     */
+    public function first($columns = ['*']);
+
+    /**
+     * Execute the query and get the first result or throw an exception.
+     *
+     * @param  array<int, string>  $columns
+     * @return TRelatedModel
+     *
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException<TRelatedModel>
+     */
+    public function firstOrFail($columns = ['*']);
+
+    /**
+     * Execute the query and get the first result or call a callback.
+     *
+     * @template TReturnClosure
+     * @param  (\Closure(): TReturnClosure)|array<int, string>  $columns
+     * @param  (\Closure(): TReturnClosure)|null  $callback
+     * @return TRelatedModel|TReturnClosure
+     */
+    public function firstOr($columns = ['*'], ?\Closure $callback = null);
+
+
+    /**
      * Find a related model by its primary key.
      *
      * @param  mixed  $id

--- a/tests/Type/data/custom-eloquent-collection.php
+++ b/tests/Type/data/custom-eloquent-collection.php
@@ -116,6 +116,9 @@ function test(): void
     assertType('App\TransactionCollection<int, App\Transaction>', (new User)->transactions()->find([1, 2]));
     assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', (new Role)->users()->find([1, 2]));
     assertType('App\Transaction|null', (new User)->transactions()->find(1));
+    assertType('App\Transaction|null', (new User)->transactions()->first());
+    assertType('App\Transaction', (new User)->transactions()->firstOrFail());
+    assertType('App\Transaction|string', (new User)->transactions()->firstOr(callback: fn () => ''));
     assertType('App\TransactionCollection<int, App\Transaction>', (new User)->transactions()->findOrFail([1, 2]));
     assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', (new Role)->users()->findOrFail([1, 2]));
     assertType('App\Transaction', (new User)->transactions()->findOrFail(1));

--- a/tests/Type/data/model-relations.php
+++ b/tests/Type/data/model-relations.php
@@ -5,6 +5,7 @@ namespace ModelRelations;
 use App\Account;
 use App\Group;
 use App\Post;
+use App\Transaction;
 use App\User;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -44,6 +45,10 @@ function test(User $user, \App\Address $address, Account $account, ExtendsModelW
     assertType('App\Account', $user->accounts()->create());
     assertType('App\Account|null', (new User())->accounts()->where('name', 'bar')->first());
     assertType('App\User', User::with('accounts')->whereHas('accounts')->firstOrFail());
+    assertType('Illuminate\Database\Eloquent\Relations\HasManyThrough<App\Transaction>', (new User())->transactions()->whereIn('id', [1, 2, 3]));
+    assertType('App\Transaction|null', (new User())->transactions()->first());
+    assertType('App\Transaction', (new User())->transactions()->firstOrFail());
+    assertType('App\Transaction|int', (new User())->transactions()->firstOr(fn () => -1));
     assertType('Illuminate\Database\Eloquent\Relations\BelongsTo<App\User, App\Account>', $account->ownerRelation());
     assertType('Illuminate\Database\Eloquent\Relations\BelongsTo<App\Account, App\Account>', $account->parent());
     assertType('Illuminate\Database\Eloquent\Relations\HasMany<App\User>', $user->children());


### PR DESCRIPTION
- [X] Added or updated tests
- [X] Documented user facing changes

I did not yet create an issue for this PR. If this is required, please notify me.

**Changes**

Added types for the `first`, `firstOrFail` and `firstOr` methods in the `HasManyThrough` relation. I added tests to show what my changes are fixing. The tests failed before I added the method stubs.

**Breaking changes**

No breaking changes
