### PR TITLE
New rule: Ensure access to defined filesystems

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -32,6 +32,33 @@ parameters:
 
 to your `phpstan.neon` file.
 
+## NoUndefinedFilesystems
+
+Ensures access to a defined filesystem or 'disk' configured in `config/filesystems.php` when using Laravel Storage abstraction API.
+
+#### Examples
+
+```php
+Storage::disk('this-is-not-defined');
+```
+
+Will result in the following error:
+
+```
+Called 'Storage::disk()' with an undefined filesystem disk.
+```
+
+#### Configuration
+
+This rule is enabled by default. To disable it completely, add:
+
+```neon
+parameters:
+    noUndefinedFilesystems: false
+```
+
+to your `phpstan.neon` file.
+
 ## NoUnnecessaryCollectionCall
 
 Checks for method calls on instances of `Illuminate\Support\Collection` and their 

--- a/extension.neon
+++ b/extension.neon
@@ -14,6 +14,7 @@ parameters:
     checkOctaneCompatibility: false
     noEnvCallsOutsideOfConfig: false
     noModelMake: true
+    noUndefinedFilesystems: true
     noUnnecessaryCollectionCall: true
     noUnnecessaryCollectionCallOnly: []
     noUnnecessaryCollectionCallExcept: []
@@ -31,6 +32,7 @@ parametersSchema:
     checkOctaneCompatibility: bool()
     noEnvCallsOutsideOfConfig: bool()
     noModelMake: bool()
+    noUndefinedFilesystems: bool()
     noUnnecessaryCollectionCall: bool()
     noUnnecessaryCollectionCallOnly: listOf(string())
     noUnnecessaryCollectionCallExcept: listOf(string())
@@ -48,6 +50,8 @@ conditionalTags:
         phpstan.rules.rule: %noEnvCallsOutsideOfConfig%
     Larastan\Larastan\Rules\NoModelMakeRule:
         phpstan.rules.rule: %noModelMake%
+    Larastan\Larastan\Rules\NoUndefinedFilesystemsRule:
+        phpstan.rules.rule: %noUndefinedFilesystems%
     Larastan\Larastan\Rules\NoUnnecessaryCollectionCallRule:
         phpstan.rules.rule: %noUnnecessaryCollectionCall%
     Larastan\Larastan\Rules\OctaneCompatibilityRule:
@@ -389,6 +393,9 @@ services:
 
     -
         class: Larastan\Larastan\Rules\NoModelMakeRule
+
+    -
+        class: Larastan\Larastan\Rules\NoUndefinedFilesystemsRule
 
     -
         class: Larastan\Larastan\Rules\NoUnnecessaryCollectionCallRule

--- a/src/Rules/NoUndefinedFilesystemsRule.php
+++ b/src/Rules/NoUndefinedFilesystemsRule.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Larastan\Larastan\Rules;
+
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Storage;
+use PhpParser\Node;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name\FullyQualified;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\ObjectType;
+
+/**
+ * Catches the use of undefined filesystem in laravel storage abstraction.
+ *
+ * For example:
+ * Storage::disk('this-is-not-defined')
+ *
+ * @implements Rule<StaticCall>
+ */
+class NoUndefinedFilesystemsRule implements Rule
+{
+    public function __construct(protected ReflectionProvider $reflectionProvider)
+    {
+    }
+
+    public function getNodeType(): string
+    {
+        return StaticCall::class;
+    }
+
+    /** @return array<int, RuleError> */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $name = $node->name;
+
+        if (! $name instanceof Identifier) {
+            return [];
+        }
+
+        if ($name->name !== 'disk') {
+            return [];
+        }
+
+        if (! $this->isCalledOnStorage($node, $scope)) {
+            return [];
+        }
+
+        // Check if the disk is declared
+        $declaredDisks = Config::get('filesystems.disks', []);
+        $selectedDisk  = $this->getSelectedDiskFromArgs($node);
+
+        if (isset($declaredDisks[$selectedDisk])) {
+            return [];
+        }
+
+        return [
+            RuleErrorBuilder::message("Called 'Storage::disk()' with an undefined filesystem disk.")
+                ->identifier('larastan.noUndefinedFilesystems')
+                ->line($node->getLine())
+                ->file($scope->getFile())
+                ->build(),
+        ];
+    }
+
+    /**
+     * Was the expression called on a Storage instance?
+     */
+    protected function isCalledOnStorage(StaticCall $call, Scope $scope): bool
+    {
+        $class = $call->class;
+        if ($class instanceof FullyQualified) {
+            $type = new ObjectType($class->toString());
+        } elseif ($class instanceof Expr) {
+            $type = $scope->getType($class);
+
+            if ($type->isClassStringType()->yes() && $type->getConstantStrings() !== []) {
+                $type = new ObjectType($type->getConstantStrings()[0]->getValue());
+            }
+        } else {
+            // TODO can we handle relative names, do they even occur here?
+            return false;
+        }
+
+        return (new ObjectType(Storage::class))
+            ->isSuperTypeOf($type)
+            ->yes();
+    }
+
+    protected function getSelectedDiskFromArgs(StaticCall $node): string
+    {
+        $args = $node->getRawArgs();
+
+        if (! isset($args[0])) {
+            return '';
+        }
+
+        if (! isset($args[0]->value)) {
+            return '';
+        }
+
+        return $args[0]->value->value;
+    }
+}

--- a/tests/Rules/NoUndefinedFilesystemsRuleTest.php
+++ b/tests/Rules/NoUndefinedFilesystemsRuleTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Rules;
+
+use Larastan\Larastan\Rules\NoUndefinedFilesystemsRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/** @extends RuleTestCase<NoUndefinedFilesystemsRule> */
+class NoUndefinedFilesystemsRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new NoUndefinedFilesystemsRule($this->createReflectionProvider());
+    }
+
+    public function testNoFalsePositives(): void
+    {
+        $this->analyse([__DIR__ . '/data/CorrectFilesystem.php'], []);
+    }
+
+    public function testStorageDisk(): void
+    {
+        $this->analyse([__DIR__ . '/data/UndefinedFilesystem.php'], [
+            ["Called 'Storage::disk()' with an undefined filesystem disk.", 13],
+        ]);
+    }
+}

--- a/tests/Rules/data/CorrectFilesystem.php
+++ b/tests/Rules/data/CorrectFilesystem.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Rules\Data;
+
+use Illuminate\Support\Facades\Storage;
+
+class CorrectFilesystem
+{
+    public function getStorage(): Storage
+    {
+        return Storage::disk('local');
+    }
+}

--- a/tests/Rules/data/UndefinedFilesystem.php
+++ b/tests/Rules/data/UndefinedFilesystem.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Rules\Data;
+
+use Illuminate\Support\Facades\Storage;
+
+class UndefinedFilesystem
+{
+    public function getStorage(): Storage
+    {
+        return Storage::disk('this-is-not-defined');
+    }
+}


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

Added a rule that ensures access to a defined filesystem or 'disk' configured in `config/filesystems.php` when using Laravel Storage abstraction API.

**Breaking changes**

No breaking changes.
