### PR TITLE
Add arrow function and first class callable support for value helper

### DIFF
--- a/src/ReturnTypes/Helpers/ValueExtension.php
+++ b/src/ReturnTypes/Helpers/ValueExtension.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Larastan\Larastan\ReturnTypes\Helpers;
 
 use PhpParser\Node\Expr\ArrowFunction;
+use PhpParser\Node\Expr\CallLike;
 use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
@@ -34,7 +35,7 @@ final class ValueExtension implements DynamicFunctionReturnTypeExtension
         }
 
         $arg = $functionCall->getArgs()[0]->value;
-        if ($arg instanceof Closure || $arg instanceof ArrowFunction) {
+        if ($arg instanceof Closure || $arg instanceof ArrowFunction || $arg instanceof CallLike) {
             $callbackType = $scope->getType($arg);
 
             return ParametersAcceptorSelector::selectFromArgs(

--- a/src/ReturnTypes/Helpers/ValueExtension.php
+++ b/src/ReturnTypes/Helpers/ValueExtension.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Larastan\Larastan\ReturnTypes\Helpers;
 
+use PhpParser\Node\Expr\ArrowFunction;
 use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
@@ -33,7 +34,7 @@ final class ValueExtension implements DynamicFunctionReturnTypeExtension
         }
 
         $arg = $functionCall->getArgs()[0]->value;
-        if ($arg instanceof Closure) {
+        if ($arg instanceof Closure || $arg instanceof ArrowFunction) {
             $callbackType = $scope->getType($arg);
 
             return ParametersAcceptorSelector::selectFromArgs(

--- a/tests/Type/data/helpers.php
+++ b/tests/Type/data/helpers.php
@@ -137,6 +137,10 @@ function test(?int $value = 0): void
     }));
 
     assertType('5', value(5));
+    assertType('6', value(fn () => 6));
+    assertType('7', value(function () {
+        return 7;
+    }));
 
     assertType('array|null', transform(User::first(), fn (User $user) => $user->toArray()));
     assertType('array', transform(User::sole(), fn (User $user) => $user->toArray()));

--- a/tests/Type/data/helpers.php
+++ b/tests/Type/data/helpers.php
@@ -141,6 +141,8 @@ function test(?int $value = 0): void
     assertType('7', value(function () {
         return 7;
     }));
+    assertType('int', value(intval(...), 8));
+    assertType('int', value(\Closure::fromCallable('intval'), 9));
 
     assertType('array|null', transform(User::first(), fn (User $user) => $user->toArray()));
     assertType('array', transform(User::sole(), fn (User $user) => $user->toArray()));


### PR DESCRIPTION
- [x] Added or updated tests

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**
This PR allows return type resolution for arrow functions and first class callables.

```php
// This PR adds support for:
value(fn () => 5);
value(intval(...), 5);
value(\Closure::fromCallable('intval'), 5);
value(SomeRandomClass::doMagic(...));

// to the already handled formats:
value(5);
value(function () {
    return 5;
});
```

Test are also added for the new formats as well as the missing closure format.

<!-- Detail the changes in behaviour this PR introduces. -->

**Breaking changes**
None
<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
