### PR TITLE
route-name-type and stubs for Illuminate\Routing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "illuminate/database": "^9.52.16 || ^10.28.0 || ^11.0",
         "illuminate/http": "^9.52.16 || ^10.28.0 || ^11.0",
         "illuminate/pipeline": "^9.52.16 || ^10.28.0 || ^11.0",
+        "illuminate/routing": "^9.52.16 || ^10.28.0 || ^11.0.0",
         "illuminate/support": "^9.52.16 || ^10.28.0 || ^11.0",
         "phpmyadmin/sql-parser": "^5.9.0",
         "phpstan/phpstan": "^1.11.2"

--- a/extension.neon
+++ b/extension.neon
@@ -382,6 +382,11 @@ services:
             - phpstan.phpDoc.typeNodeResolverExtension
 
     -
+        class: Larastan\Larastan\Types\RouteNameStringTypeNodeResolverExtension
+        tags:
+            - phpstan.phpDoc.typeNodeResolverExtension
+
+    -
         class: Larastan\Larastan\Rules\OctaneCompatibilityRule
 
     -

--- a/src/Types/RouteNameStringType.php
+++ b/src/Types/RouteNameStringType.php
@@ -1,0 +1,192 @@
+<?php
+
+namespace Larastan\Larastan\Types;
+
+use PHPStan\TrinaryLogic;
+use PHPStan\Type\AcceptsResult;
+use PHPStan\Type\CompoundType;
+use PHPStan\Type\StringType;
+use PHPStan\Type\Type;
+use PHPStan\Type\VerbosityLevel;
+
+use function app;
+use function array_map;
+use function array_slice;
+use function count;
+use function implode;
+use function in_array;
+use function levenshtein;
+use function usort;
+
+class RouteNameStringType extends StringType
+{
+    public function describe(VerbosityLevel $level): string
+    {
+        return 'route-name-string';
+    }
+
+    public function accepts(Type $type, bool $strictTypes): TrinaryLogic
+    {
+        return $this->acceptsWithReason($type, $strictTypes)->result;
+    }
+
+    public function acceptsWithReason(
+        Type $type,
+        bool $strictTypes
+    ): AcceptsResult {
+        if ($type instanceof self) {
+            return AcceptsResult::createYes();
+        }
+
+        if ($type instanceof CompoundType) {
+            return $type->acceptsWithReason($type, $strictTypes);
+        }
+
+        $constantStrings = $type->getConstantStrings();
+        if (count($constantStrings) === 1) {
+            $existingRouteNames = $this->resolveExistingRouteNames();
+            $routeName = $constantStrings[0]->getValue();
+
+            if (in_array($routeName, $existingRouteNames)) {
+                return AcceptsResult::createYes();
+            }
+
+            // @phpstan-ignore-next-line Phpstan tells me, that this function is not covered by their BC promise, even though the class clearly has the @api tag in its doc-comment.
+            return new AcceptsResult(
+                TrinaryLogic::createNo(),
+                [$this->describeWhyNotAccepted($routeName, $existingRouteNames)],
+            );
+        }
+
+        if ($type->isString()->yes()) {
+            return AcceptsResult::createMaybe();
+        }
+
+        return AcceptsResult::createNo();
+    }
+
+    public function isSuperTypeOf(Type $type): TrinaryLogic
+    {
+        $constantStrings = $type->getConstantStrings();
+        if (count($constantStrings) === 1) {
+            $routeName = $constantStrings[0]->getValue();
+            $existingRouteNames = $this->resolveExistingRouteNames();
+
+            return TrinaryLogic::createFromBoolean(
+                in_array($routeName, $existingRouteNames),
+            );
+        }
+
+        if ($type instanceof self) {
+            return TrinaryLogic::createYes();
+        }
+
+        if ($type->isString()->yes()) {
+            return TrinaryLogic::createMaybe();
+        }
+
+        if ($type instanceof CompoundType) {
+            return $type->isSubTypeOf($this);
+        }
+
+        return TrinaryLogic::createNo();
+    }
+
+    /**
+     * @param  mixed[]  $properties
+     * @return Type
+     */
+    public static function __set_state(array $properties): Type
+    {
+        return new self();
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function resolveExistingRouteNames(): array
+    {
+        $names = [];
+
+        foreach (app('router')->getRoutes()->getRoutes() as $route) {
+            $name = $route->getName();
+            if ($name !== null) {
+                $names[] = $name;
+            }
+        }
+
+        return $names;
+    }
+
+    /**
+     * @param list<string> $existingRouteNames
+     */
+    private function describeWhyNotAccepted(
+        string $routeName,
+        array $existingRouteNames,
+    ): string
+    {
+        $message = "Route '$routeName' does not exist.";
+
+        $alternatives = $this->closestRouteNamesTo($routeName, $existingRouteNames);
+        if (count($alternatives) > 0) {
+            $quoted = array_map(fn (string $name) => "'$name'", $alternatives);
+
+            if (count($alternatives) === 1) {
+                $message .= ' Did you mean '.$quoted[0].'?';
+            } else {
+                $list = implode(', ', array_slice($quoted, 0, -1));
+                $last = $quoted[count($quoted) - 1];
+                $message .= " Did you mean $list or $last?";
+            }
+        }
+
+        return $message;
+    }
+
+    /**
+     * Tries to find similarly named routes to the given one using
+     * the {@link levenshtein()}-distance.
+     *
+     * @param  string  $query  A route name that probably does not exist, but we search a similarly named route for
+     * @param  list<string>  $existingRouteNames  All known route names
+     * @param  int  $threshold  Max. acceptable edit distance. Inversely proportional to the number of returned results.
+     * @param  int  $maxResults  Max. number of returned results
+     * @return list<string>
+     */
+    private function closestRouteNamesTo(
+        string $query,
+        array $existingRouteNames,
+        int $threshold = 3,
+        int $maxResults = 3,
+    ): array {
+        $withDistance = array_map(function (string $existingRoute) use ($query) {
+            return [$existingRoute, levenshtein($query, $existingRoute)];
+        }, $existingRouteNames);
+
+        // This sorts the name-distance pairs in ascending order. Therefore, the
+        // most similar names are at the top
+        usort(
+            $withDistance,
+            /**
+             * @param  array{0: string, 1: int}  $a
+             * @param  array{0: string, 1: int}  $b
+             */
+            fn (array $a, array $b): int => $a[1] - $b[1]
+        );
+
+        $results = [];
+        foreach ($withDistance as [$route, $distance]) {
+            if (count($results) === $maxResults) {
+                break;
+            }
+            if ($distance > $threshold) {
+                break;
+            }
+
+            $results[] = $route;
+        }
+
+        return $results;
+    }
+}

--- a/src/Types/RouteNameStringTypeNodeResolverExtension.php
+++ b/src/Types/RouteNameStringTypeNodeResolverExtension.php
@@ -15,7 +15,7 @@ use PHPStan\Type\Type;
  */
 class RouteNameStringTypeNodeResolverExtension implements TypeNodeResolverExtension
 {
-    public function resolve(TypeNode $typeNode, NameScope $nameScope): ?Type
+    public function resolve(TypeNode $typeNode, NameScope $nameScope): Type|null
     {
         if ($typeNode instanceof IdentifierTypeNode && $typeNode->__toString() === 'route-name-string') {
             return new RouteNameStringType();

--- a/src/Types/RouteNameStringTypeNodeResolverExtension.php
+++ b/src/Types/RouteNameStringTypeNodeResolverExtension.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Larastan\Larastan\Types;
+
+use PHPStan\Analyser\NameScope;
+use PHPStan\PhpDoc\TypeNodeResolverExtension;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\TypeNode;
+use PHPStan\Type\Type;
+
+/**
+ * Ensures a 'route-name-string' type in PHPDoc is recognised to be of type RouteNameStringType.
+ */
+class RouteNameStringTypeNodeResolverExtension implements TypeNodeResolverExtension
+{
+    public function resolve(TypeNode $typeNode, NameScope $nameScope): ?Type
+    {
+        if ($typeNode instanceof IdentifierTypeNode && $typeNode->__toString() === 'route-name-string') {
+            return new RouteNameStringType();
+        }
+
+        return null;
+    }
+}

--- a/stubs/common/Facades.stub
+++ b/stubs/common/Facades.stub
@@ -33,3 +33,8 @@ class Log extends Facade {}
  * @mixin \Illuminate\Http\Request
  */
 class Request extends Facade {}
+
+/**
+ * @mixin \Illuminate\Routing\UrlGenerator
+ */
+class URL extends Facade {}

--- a/stubs/common/Helpers.stub
+++ b/stubs/common/Helpers.stub
@@ -200,3 +200,26 @@ function blank($value) {}
  * @return bool|string|TDefault
  */
 function env($key, $default = null) {}
+
+/**
+ * Generate the URL to a named route.
+ *
+ * @param  route-name-string  $name
+ * @param  mixed  $parameters
+ * @param  bool  $absolute
+ * @return string
+ */
+function route($name, $parameters = [], $absolute = true) {}
+
+/**
+ * Create a new redirect response to a named route.
+ *
+ * @param  route-name-string  $route
+ * @param  mixed  $parameters
+ * @param  int  $status
+ * @param  array<string, mixed>  $headers
+ * @return \Illuminate\Http\RedirectResponse
+ */
+function to_route($route, $parameters = [], $status = 302, $headers = [])
+{
+}

--- a/tests/Type/RouteNameStringTypeTest.php
+++ b/tests/Type/RouteNameStringTypeTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Type;
+
+use Illuminate\Foundation\Application;
+use Illuminate\Routing\Router;
+use PHPStan\Rules\Functions\CallToFunctionParametersRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * Tests the 'route-string-name' actually works as expected.
+ *
+ * This is done by example using the commonly used {@link route()} helper.
+ * It is realized as a {@link RuleTestCase} for the
+ * {@link CallToFunctionParametersRule}, since it validates types, and we can
+ * properly set up our named routes as desired.
+ */
+class RouteNameStringTypeTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(CallToFunctionParametersRule::class);
+    }
+
+    public function testWithFile(): void
+    {
+        /** @var Router $router */
+        $router = Application::getInstance()->get('router');
+        $router->get('existing')->name('existing');
+        $router->get('also-existing')->name('also-existing');
+        $router->get('also-another-existing')->name('also-another-existing');
+
+        $router->getRoutes()->refreshNameLookups();
+
+        $this->analyse([
+            __DIR__.'/data/route-access.php',
+        ], [
+            ['Parameter #1 $name of function route expects route-name-string, string given.', 4, "Route 'existingg' does not exist. Did you mean 'existing'?"],
+            ['Parameter #1 $name of function route expects route-name-string, string given.', 5, "Route 'abcdefghjkl' does not exist."],
+        ]);
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__.'/../phpstan-tests.neon'];
+    }
+}

--- a/tests/Type/RouteNameStringTypeTest.php
+++ b/tests/Type/RouteNameStringTypeTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Type;
 
 use Illuminate\Foundation\Application;
@@ -34,15 +36,16 @@ class RouteNameStringTypeTest extends RuleTestCase
         $router->getRoutes()->refreshNameLookups();
 
         $this->analyse([
-            __DIR__.'/data/route-access.php',
+            __DIR__ . '/data/route-access.php',
         ], [
             ['Parameter #1 $name of function route expects route-name-string, string given.', 4, "Route 'existingg' does not exist. Did you mean 'existing'?"],
             ['Parameter #1 $name of function route expects route-name-string, string given.', 5, "Route 'abcdefghjkl' does not exist."],
         ]);
     }
 
+    /** @return string[] */
     public static function getAdditionalConfigFiles(): array
     {
-        return [__DIR__.'/../phpstan-tests.neon'];
+        return [__DIR__ . '/../phpstan-tests.neon'];
     }
 }

--- a/tests/Type/data/route-access.php
+++ b/tests/Type/data/route-access.php
@@ -1,0 +1,5 @@
+<?php
+
+route('existing'); // Exists, no error here
+route('existingg'); // Typo -> should be caught as not existing and be suggested as a fix
+route('abcdefghjkl'); // Simply does not exist. No alternative should be suggested

--- a/tests/laravel-test.sh
+++ b/tests/laravel-test.sh
@@ -24,7 +24,7 @@ parameters:
         - app/
     ignoreErrors:
         -
-            message: "#^Parameter \\#1 \\$name of function route expects route-name-string, string given\\.\\$#"
+            message: '#^Parameter \#1 \$name of function route expects route-name-string, string given\.$#'
             count: 1
             path: app/Http/Middleware/Authenticate.php
 EOF

--- a/tests/laravel-test.sh
+++ b/tests/laravel-test.sh
@@ -22,6 +22,11 @@ parameters:
     level: 5
     paths:
         - app/
+    ignoreErrors:
+        -
+            message: "#^Parameter \\#1 \\$name of function route expects route-name-string, string given\\.\\$#"
+            count: 1
+            path: app/Http/Middleware/Authenticate.php
 EOF
 
 echo "Test Laravel"


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes

Resurrect #1734 by @NiclasvanEyk

**Changes**

Similar to how view names are checked when using view, the functions that generate URLs (route, to_route, Url::signedRoute, etc.) are now checked too. This way a developer gets an error when referring to a route that does not exist.
