### PR TITLE
Prevent error Argument #2 ($array) must be of type array

### DIFF
--- a/src/Methods/MacroMethodsClassReflectionExtension.php
+++ b/src/Methods/MacroMethodsClassReflectionExtension.php
@@ -128,7 +128,7 @@ class MacroMethodsClassReflectionExtension implements MethodsClassReflectionExte
                 $refProperty = $macroClassReflection->getNativeReflection()->getProperty($macroTraitProperty);
                 $refProperty->setAccessible(true);
 
-                $found = array_key_exists($methodName, $refProperty->getValue());
+                $found = array_key_exists($methodName, (array) $refProperty->getValue());
 
                 if (! $found) {
                     continue;


### PR DESCRIPTION
This PR will fix the following error when checking model macros:

```
Uncaught TypeError: array_key_exists(): Argument #2 ($array) must be of type array,
 null given in vendor/larastan/larastan/src/Methods/MacroMethodsClassReflectionExtension.php:135
```

This PR won't have any breaking changes.

The return value of `$refProperty->getValue()` can be null.

<img width="936" alt="image" src="https://github.com/user-attachments/assets/11e0f368-4e8b-4a02-b400-dbf26558d3e0">

So with this change, it will be ignored if `$refProperty->getValue()` is null.
