### PR TITLE
[3.x] refactor: create FileHelper to clean up repeated logic

### DIFF
--- a/docs/custom-config-parameters.md
+++ b/docs/custom-config-parameters.md
@@ -12,6 +12,8 @@ By default, the default Laravel database migration path (`database/migrations`) 
 
 You can give absolute paths, or paths relative to the PHPStan config file.
 
+Paths with wildcards are also supported (passed to `glob` function).
+
 ### Example
 ```neon
 parameters:
@@ -37,6 +39,8 @@ parameters:
 ## `squashedMigrationsPath`
 
 By default, Larastan will check `database/schema` directory to find schema dumps. If you have them in other locations or if you have multiple folders, you can use this config option to add them.
+
+Paths with wildcards are also supported (passed to `glob` function).
 
 ### Example
 ```neon

--- a/extension.neon
+++ b/extension.neon
@@ -589,6 +589,9 @@ services:
         class: Larastan\Larastan\Internal\ConsoleApplicationHelper
 
     -
+        class: Larastan\Larastan\Internal\FileHelper
+
+    -
         class: Larastan\Larastan\Support\HigherOrderCollectionProxyHelper
 
     -

--- a/how t
+++ b/how t
@@ -1,0 +1,57 @@
+[1m[38;5;2m@[0m  [1m[38;5;13mmr[38;5;8mmmxsll[39m [38;5;3mcdwhite3@pm.me[39m [38;5;14m2025-07-15 08:51:38[39m [38;5;12m908[38;5;8m825ce[39m[0m
+│  [1m[38;5;3m(no description set)[39m[0m
+[1m[38;5;1m×[0m  [1m[38;5;5mq[0m[38;5;8mroqstvp[39m [38;5;3mcdwhite3@pm.me[39m [38;5;6m2025-07-14 22:31:26[39m [38;5;5mwildcards*[39m [38;5;2mgit_head()[39m [1m[38;5;4ma[0m[38;5;8md14a00c[39m [38;5;1mconflict[39m
+│  perf: don't reglob dirs in NoEnvCallsOutsideOfConfigRule
+[1m[38;5;1m×[0m  [1m[38;5;5mt[0m[38;5;8mktxtsvm[39m [38;5;3mcdwhite3@pm.me[39m [38;5;6m2025-07-14 22:31:26[39m [1m[38;5;4m03[0m[38;5;8m06bb41[39m [38;5;1mconflict[39m
+│  refactor: create FileHelper to clean up repeated logic
+│ ○  [1m[38;5;5mrkt[0m[38;5;8mlxlqr[39m [38;5;3mcdwhite3@pm.me[39m [38;5;6m2025-07-15 08:50:28[39m [1m[38;5;4m3[0m[38;5;8m6d7fec9[39m
+├─╯  fix: update NoUnnecessaryEnumerableToArrayCallsRule to handle nullable collections
+│ ○  [1m[38;5;5mrw[0m[38;5;8muqtkqz[39m [38;5;3mcdwhite3@pm.me[39m [38;5;6m2025-07-14 22:31:26[39m [38;5;5mcollection_intersection*[39m [1m[38;5;4m8[0m[38;5;8me9679a0[39m
+│ │  tests: update filamentphp baseline
+│ ○  [1m[38;5;5mwy[0m[38;5;8mwuytvz[39m [38;5;3mcdwhite3@pm.me[39m [38;5;6m2025-07-14 22:31:26[39m [1m[38;5;4m16[0m[38;5;8ma66c3e[39m
+│ │  fix: existing tests
+│ ○  [1m[38;5;5myn[0m[38;5;8mkwpqwl[39m [38;5;3mcdwhite3@pm.me[39m [38;5;6m2025-07-14 22:31:26[39m [1m[38;5;4m20[0m[38;5;8m4c66c6[39m
+│ │  fix: handle collection intersection types
+│ ○  [1m[38;5;5mmn[0m[38;5;8mkqqrzx[39m [38;5;3mcdwhite3@pm.me[39m [38;5;6m2025-07-14 22:31:26[39m [1m[38;5;4m5[0m[38;5;8mb485f00[39m
+├─╯  refactor: rename helper method to mention Type instead of Class
+│ ○  [1m[38;5;5ms[0m[38;5;8mtrpomto[39m [38;5;3mcdwhite3@pm.me[39m [38;5;6m2025-07-14 22:31:26[39m [38;5;5mdefault_date_casts*[39m [1m[38;5;4m95[0m[38;5;8m26492e[39m
+├─╯  fix: default date casting
+│ ○  [1m[38;5;5ml[0m[38;5;8mwltmrsp[39m [38;5;3mcdwhite3@pm.me[39m [38;5;6m2025-07-14 22:31:26[39m [38;5;5mfix/ulid-or-uuid-primary-key*[39m [1m[38;5;4m40[0m[38;5;8m7faa8b[39m
+├─╯  fix: property type for uuid and ulid primary keys
+│ ○  [1m[38;5;5mo[0m[38;5;8mtstlrup[39m [38;5;3mcdwhite3@pm.me[39m [38;5;6m2025-07-14 22:31:26[39m [38;5;5mfix_builder_stubs*[39m [1m[38;5;4m995[0m[38;5;8mf3f44[39m
+│ │  fix: model static forwarding
+│ ○  [1m[38;5;5mpp[0m[38;5;8mrlzytn[39m [38;5;3mcdwhite3@pm.me[39m [38;5;6m2025-07-14 22:31:26[39m [1m[38;5;4mf[0m[38;5;8m7bd9628[39m
+├─╯  fix: builder stubs and builder/model forwarding
+│ ○  [1m[38;5;5myk[0m[38;5;8msomkyt[39m [38;5;3mcdwhite3@pm.me[39m [38;5;6m2025-07-14 22:31:26[39m [38;5;5mstatic_factory*[39m [1m[38;5;4m99a[0m[38;5;8m34b0a[39m
+├─╯  fix: factory {has,for}* methods should return static
+│ ○  [1m[38;5;5mut[0m[38;5;8mpmtuxp[39m [38;5;3mcdwhite3@pm.me[39m [38;5;6m2025-07-14 22:31:26[39m [38;5;5mfix_collection_templates*[39m [1m[38;5;4m4a[0m[38;5;8m6a3fb9[39m
+│ │  fix: existing tests
+│ ○  [1m[38;5;5mvqz[0m[38;5;8mlnnkp[39m [38;5;3mcdwhite3@pm.me[39m [38;5;6m2025-07-14 22:31:26[39m [1m[38;5;4m2e[0m[38;5;8m76d9c0[39m
+│ │  chore: cleanup EloquentBuilderExtension to reduce duplication
+│ ○  [1m[38;5;5mrkl[0m[38;5;8mqvtzp[39m [38;5;3mcdwhite3@pm.me[39m [38;5;6m2025-07-14 22:31:26[39m [1m[38;5;4m1f[0m[38;5;8m9740b4[39m
+├─╯  fix: collection template types being overwritten
+│ [1m[38;5;1m×[0m  [1m[38;5;5mvql[0m[38;5;8muxmuz[39m [38;5;3mcdwhite3@pm.me[39m [38;5;6m2025-07-14 22:31:26[39m [38;5;5mconfig*[39m [1m[38;5;4mc2[0m[38;5;8med3489[39m [38;5;1mconflict[39m
+├─╯  feat: add support for config array shapes
+│ [1m[38;5;1m×[0m  [1m[38;5;5mwp[0m[38;5;8mqspyku[39m [38;5;3mcdwhite3@pm.me[39m [38;5;6m2025-07-14 22:31:26[39m [38;5;5mmultiple_connections*[39m [1m[38;5;4m23[0m[38;5;8mc0726b[39m [38;5;1mconflict[39m
+│ │  fix: typo
+│ [1m[38;5;1m×[0m  [1m[38;5;5mnn[0m[38;5;8myststn[39m [38;5;3mcdwhite3@pm.me[39m [38;5;6m2025-07-14 22:31:26[39m [1m[38;5;4mde[0m[38;5;8m81a82b[39m [38;5;1mconflict[39m
+│ │  fix: update generic model property type to use ModelDatabaseHelper
+│ [1m[38;5;1m×[0m  [1m[38;5;5mk[0m[38;5;8mywztrzw[39m [38;5;3mcdwhite3@pm.me[39m [38;5;6m2025-07-14 22:31:26[39m [1m[38;5;4m0e[0m[38;5;8me2f768[39m [38;5;1mconflict[39m
+│ │  fix: recursive loop
+│ [1m[38;5;1m×[0m  [1m[38;5;5mxw[0m[38;5;8mqwpkyq[39m [38;5;3mcdwhite3@pm.me[39m [38;5;6m2025-07-14 22:31:26[39m [1m[38;5;4mc0[0m[38;5;8m533ce7[39m [38;5;1mconflict[39m
+│ │  chore: minor cleanup
+│ [1m[38;5;1m×[0m  [1m[38;5;5mzx[0m[38;5;8mosxvsy[39m [38;5;3mcdwhite3@pm.me[39m [38;5;6m2025-07-14 22:31:26[39m [1m[38;5;4mdc[0m[38;5;8mf84de9[39m [38;5;1mconflict[39m
+│ │  tests: add models on foo connection
+│ [1m[38;5;1m×[0m  [1m[38;5;5mzw[0m[38;5;8mxvtkrr[39m [38;5;3mcdwhite3@pm.me[39m [38;5;6m2025-07-14 22:31:26[39m [1m[38;5;4mc5[0m[38;5;8m44d15b[39m [38;5;1mconflict[39m
+│ │  feat: update migration and schema parsing tests
+│ [1m[38;5;1m×[0m  [1m[38;5;5mxr[0m[38;5;8mvwlwtk[39m [38;5;3mcdwhite3@pm.me[39m [38;5;6m2025-07-14 22:31:26[39m [1m[38;5;4m42[0m[38;5;8m9eca64[39m [38;5;1mconflict[39m
+├─╯  feat: support multiple connections
+[1m[38;5;14m◆[0m  [1m[38;5;5mux[0m[38;5;8mtpynlr[39m [38;5;3mcan9119@gmail.com[39m [38;5;6m2025-07-11 01:52:52[39m [38;5;5m3.x@upstream[39m [1m[38;5;4m6[0m[38;5;8m431d010[39m
+│  fix PHPUnit deprecations
+~
+
+○  [1m[38;5;5mno[0m[38;5;8mvposrn[39m [38;5;3mcdwhite3@pm.me[39m [38;5;6m2025-07-15 00:11:31[39m [1m[38;5;4me[0m[38;5;8m9a61915[39m
+│  feat: add support for pluck
+[1m[38;5;14m◆[0m  [1m[38;5;5mpm[0m[38;5;8mvwknry[39m [38;5;3mandreglaser@fastmail.com[39m [38;5;6m2025-07-14 16:23:08[39m [38;5;5m3.x[39m [38;5;5mv3.6.0[39m [1m[38;5;4m904[0m[38;5;8me7c12[39m
+│  feat: introduce noModelForwardingToBuilder and noModelStaticForwardingToBuilder rules
+~

--- a/src/Internal/FileHelper.php
+++ b/src/Internal/FileHelper.php
@@ -39,7 +39,8 @@ final class FileHelper
         return array_values(array_reduce(
             $directories,
             function (array $carry, string $path): array {
-                $absolutePath = $this->fileHelper->absolutizePath($path);
+                $normalPath   = $this->fileHelper->normalizePath($path);
+                $absolutePath = $this->fileHelper->absolutizePath($normalPath);
 
                 if ($this->isGlobPattern($absolutePath)) {
                     $glob = glob($absolutePath, GLOB_ONLYDIR);

--- a/src/Internal/FileHelper.php
+++ b/src/Internal/FileHelper.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Larastan\Larastan\Internal;
+
+use PHPStan\File\FileHelper as PHPStanFileHelper;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use RegexIterator;
+use SplFileInfo;
+
+use function array_push;
+use function array_reduce;
+use function array_values;
+use function glob;
+use function is_dir;
+use function is_string;
+use function iterator_to_array;
+use function preg_match;
+
+use const GLOB_ONLYDIR;
+
+/** @internal */
+final class FileHelper
+{
+    public function __construct(
+        private PHPStanFileHelper $fileHelper,
+    ) {
+    }
+
+    /**
+     * @param  array<array-key, string> $directories
+     *
+     * @return list<non-empty-string>
+     */
+    public function getDirectories(array $directories): array
+    {
+        return array_values(array_reduce(
+            $directories,
+            function (array $carry, string $path): array {
+                $absolutePath = $this->fileHelper->absolutizePath($path);
+
+                if ($this->isGlobPattern($absolutePath)) {
+                    $glob = glob($absolutePath, GLOB_ONLYDIR);
+
+                    if ($glob === false) {
+                        return $carry;
+                    }
+
+                    array_push($carry, ...$glob);
+                } else {
+                    if (! is_dir($absolutePath)) {
+                        return $carry;
+                    }
+
+                    $carry[] = $absolutePath;
+                }
+
+                return $carry;
+            },
+            [],
+        ));
+    }
+
+    /**
+     * @param  array<array-key, string> $directories
+     *
+     * @return array<non-empty-string, SplFileInfo>
+     */
+    public function getFiles(array $directories, string|null $filter = null): array
+    {
+        return array_reduce(
+            $this->getDirectories($directories),
+            static function (array $carry, string $directory) use ($filter): array {
+                $iterator = new RecursiveIteratorIterator(
+                    new RecursiveDirectoryIterator($directory),
+                );
+
+                if (is_string($filter)) {
+                    $iterator = new RegexIterator($iterator, $filter);
+                }
+
+                $carry += iterator_to_array($iterator);
+
+                return $carry;
+            },
+            [],
+        );
+    }
+
+    private function isGlobPattern(string $path): bool
+    {
+        return preg_match('~[*?[\]]~', $path) > 0;
+    }
+}

--- a/src/Properties/MigrationHelper.php
+++ b/src/Properties/MigrationHelper.php
@@ -4,20 +4,14 @@ declare(strict_types=1);
 
 namespace Larastan\Larastan\Properties;
 
-use PHPStan\File\FileHelper;
+use Larastan\Larastan\Internal\FileHelper;
 use PHPStan\Parser\Parser;
 use PHPStan\Parser\ParserErrorsException;
 use PHPStan\Reflection\ReflectionProvider;
-use RecursiveDirectoryIterator;
-use RecursiveIteratorIterator;
-use RegexIterator;
 use SplFileInfo;
 
 use function count;
 use function database_path;
-use function glob;
-use function is_dir;
-use function iterator_to_array;
 use function uasort;
 
 class MigrationHelper
@@ -48,7 +42,7 @@ class MigrationHelper
         }
 
         $schemaAggregator = new SchemaAggregator($this->reflectionProvider, $tables);
-        $filesArray       = $this->getMigrationFiles();
+        $filesArray       = $this->fileHelper->getFiles($this->databaseMigrationPath, '/\.php$/i');
 
         if (empty($filesArray)) {
             return $tables;
@@ -67,31 +61,5 @@ class MigrationHelper
         }
 
         return $schemaAggregator->tables;
-    }
-
-    /** @return SplFileInfo[] */
-    private function getMigrationFiles(): array
-    {
-        /** @var SplFileInfo[] $migrationFiles */
-        $migrationFiles = [];
-
-        foreach ($this->databaseMigrationPath as $additionalPathGlob) {
-            foreach ((glob($additionalPathGlob) ?: []) as $additionalPath) {
-                $absolutePath = $this->fileHelper->absolutizePath($additionalPath);
-
-                if (! is_dir($absolutePath)) {
-                    continue;
-                }
-
-                $migrationFiles += iterator_to_array(
-                    new RegexIterator(
-                        new RecursiveIteratorIterator(new RecursiveDirectoryIterator($absolutePath)),
-                        '/\.php$/i',
-                    ),
-                );
-            }
-        }
-
-        return $migrationFiles;
     }
 }

--- a/src/Properties/SquashedMigrationHelper.php
+++ b/src/Properties/SquashedMigrationHelper.php
@@ -6,21 +6,14 @@ namespace Larastan\Larastan\Properties;
 
 use iamcal\SQLParser;
 use iamcal\SQLParserSyntaxException;
+use Larastan\Larastan\Internal\FileHelper;
 use Larastan\Larastan\Properties\Schema\MySqlDataTypeToPhpTypeConverter;
-use PHPStan\File\FileHelper;
-use RecursiveDirectoryIterator;
-use RecursiveIteratorIterator;
-use RegexIterator;
-use SplFileInfo;
 
 use function array_key_exists;
 use function database_path;
 use function file_get_contents;
-use function glob;
 use function is_array;
 use function is_bool;
-use function is_dir;
-use function iterator_to_array;
 use function ksort;
 
 final class SquashedMigrationHelper
@@ -45,7 +38,7 @@ final class SquashedMigrationHelper
             $this->schemaPaths = [database_path('schema')];
         }
 
-        $filesArray = $this->getSchemaFiles();
+        $filesArray = $this->fileHelper->getFiles($this->schemaPaths, '/\.dump|\.sql/i');
 
         if (empty($filesArray)) {
             return [];
@@ -99,32 +92,6 @@ final class SquashedMigrationHelper
         }
 
         return $tables;
-    }
-
-    /** @return SplFileInfo[] */
-    private function getSchemaFiles(): array
-    {
-        /** @var SplFileInfo[] $schemaFiles */
-        $schemaFiles = [];
-
-        foreach ($this->schemaPaths as $additionalPathGlob) {
-            foreach ((glob($additionalPathGlob) ?: []) as $additionalPath) {
-                $absolutePath = $this->fileHelper->absolutizePath($additionalPath);
-
-                if (! is_dir($absolutePath)) {
-                    continue;
-                }
-
-                $schemaFiles += iterator_to_array(
-                    new RegexIterator(
-                        new RecursiveIteratorIterator(new RecursiveDirectoryIterator($absolutePath)),
-                        '/\.dump|\.sql/i',
-                    ),
-                );
-            }
-        }
-
-        return $schemaFiles;
     }
 
     /** @param  array<string, string|bool|null> $definition */

--- a/src/Rules/NoEnvCallsOutsideOfConfigRule.php
+++ b/src/Rules/NoEnvCallsOutsideOfConfigRule.php
@@ -5,19 +5,17 @@ declare(strict_types=1);
 namespace Larastan\Larastan\Rules;
 
 use Larastan\Larastan\Concerns\HasContainer;
+use Larastan\Larastan\Internal\FileHelper;
 use PhpParser\Node;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Name;
 use PHPStan\Analyser\Scope;
-use PHPStan\File\FileHelper;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleError;
 use PHPStan\Rules\RuleErrorBuilder;
 
 use function config_path;
 use function count;
-use function glob;
-use function is_dir;
 use function str_starts_with;
 
 /**
@@ -79,17 +77,12 @@ class NoEnvCallsOutsideOfConfigRule implements Rule
 
     protected function isCalledOutsideOfConfig(FuncCall $call, Scope $scope): bool
     {
-        foreach ($this->configDirectories as $configDirectoryGlob) {
-            foreach ((glob($configDirectoryGlob) ?: []) as $configDirectory) {
-                $absolutePath = $this->fileHelper->absolutizePath($configDirectory);
+        $directories = $this->fileHelper->getDirectories($this->configDirectories);
+        $file        = $scope->getFile();
 
-                if (! is_dir($absolutePath)) {
-                    continue;
-                }
-
-                if (str_starts_with($scope->getFile(), $absolutePath)) {
-                    return false;
-                }
+        foreach ($directories as $directory) {
+            if (str_starts_with($file, $directory)) {
+                return false;
             }
         }
 

--- a/src/Rules/NoEnvCallsOutsideOfConfigRule.php
+++ b/src/Rules/NoEnvCallsOutsideOfConfigRule.php
@@ -15,7 +15,6 @@ use PHPStan\Rules\RuleError;
 use PHPStan\Rules\RuleErrorBuilder;
 
 use function config_path;
-use function count;
 use function str_starts_with;
 
 /**
@@ -27,21 +26,17 @@ class NoEnvCallsOutsideOfConfigRule implements Rule
 {
     use HasContainer;
 
-    /** @var list<string> */
-    private array $configDirectories = [];
+    /** @var  list<non-empty-string> */
+    private array $directories;
 
     /** @param  list<non-empty-string> $configDirectories */
     public function __construct(array $configDirectories, private FileHelper $fileHelper)
     {
-        if (count($configDirectories) !== 0) {
-            foreach ($configDirectories as $directory) {
-                $this->configDirectories[] = $this->fileHelper->normalizePath($directory);
-            }
-
-            return;
+        if ($configDirectories === []) {
+            $configDirectories = [config_path()]; // @phpstan-ignore-line
         }
 
-        $this->configDirectories = [config_path()]; // @phpstan-ignore-line
+        $this->directories = $this->fileHelper->getDirectories($configDirectories);
     }
 
     public function getNodeType(): string
@@ -77,10 +72,9 @@ class NoEnvCallsOutsideOfConfigRule implements Rule
 
     protected function isCalledOutsideOfConfig(FuncCall $call, Scope $scope): bool
     {
-        $directories = $this->fileHelper->getDirectories($this->configDirectories);
-        $file        = $scope->getFile();
+        $file = $scope->getFile();
 
-        foreach ($directories as $directory) {
+        foreach ($this->directories as $directory) {
             if (str_starts_with($file, $directory)) {
                 return false;
             }

--- a/tests/Rules/NoEnvCallsOutsideOfConfigRuleTest.php
+++ b/tests/Rules/NoEnvCallsOutsideOfConfigRuleTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Rules;
 
 use Illuminate\Foundation\Application;
+use Larastan\Larastan\Internal\FileHelper;
 use Larastan\Larastan\Rules\NoEnvCallsOutsideOfConfigRule;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
@@ -23,7 +24,7 @@ class NoEnvCallsOutsideOfConfigRuleTest extends RuleTestCase
         return new NoEnvCallsOutsideOfConfigRule([
             __DIR__ . '/data/config',
             __DIR__ . '/data/module/*/config',
-        ], $this->getFileHelper());
+        ], new FileHelper($this->getFileHelper()));
     }
 
     #[Test]

--- a/tests/Unit/MigrationHelperTest.php
+++ b/tests/Unit/MigrationHelperTest.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace Tests\Unit;
 
+use Larastan\Larastan\Internal\FileHelper;
 use Larastan\Larastan\Properties\MigrationHelper;
 use Larastan\Larastan\Properties\SchemaTable;
-use PHPStan\File\FileHelper;
 use PHPStan\Parser\Parser;
+use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Testing\PHPStanTestCase;
 use PHPUnit\Framework\Attributes\Test;
 
@@ -19,10 +20,12 @@ class MigrationHelperTest extends PHPStanTestCase
 
     private FileHelper $fileHelper;
 
+    private ReflectionProvider $reflectionProvider;
+
     public function setUp(): void
     {
         $this->parser             = self::getContainer()->getService('currentPhpVersionSimpleDirectParser');
-        $this->fileHelper         = self::getContainer()->getByType(FileHelper::class);
+        $this->fileHelper         = new FileHelper($this->getFileHelper());
         $this->reflectionProvider = $this->createReflectionProvider();
     }
 

--- a/tests/Unit/SquashedMigrationHelperTest.php
+++ b/tests/Unit/SquashedMigrationHelperTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Tests\Unit;
 
+use Larastan\Larastan\Internal\FileHelper;
 use Larastan\Larastan\Properties\Schema\MySqlDataTypeToPhpTypeConverter;
 use Larastan\Larastan\Properties\SquashedMigrationHelper;
-use PHPStan\File\FileHelper;
 use PHPStan\Testing\PHPStanTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
@@ -16,13 +16,23 @@ use function array_keys;
 #[CoversClass(SquashedMigrationHelper::class)]
 class SquashedMigrationHelperTest extends PHPStanTestCase
 {
+    private FileHelper $fileHelper;
+
+    private MySqlDataTypeToPhpTypeConverter $converter;
+
+    public function setUp(): void
+    {
+        $this->fileHelper = new FileHelper($this->getFileHelper());
+        $this->converter  = new MySqlDataTypeToPhpTypeConverter();
+    }
+
     #[Test]
     public function it_can_parse_schema_dump_for_a_basic_schema(): void
     {
         $schemaParser = new SquashedMigrationHelper(
             [__DIR__ . '/data/schema/basic_schema'],
-            self::getContainer()->getByType(FileHelper::class),
-            new MySqlDataTypeToPhpTypeConverter(),
+            $this->fileHelper,
+            $this->converter,
             false,
         );
 
@@ -45,8 +55,8 @@ class SquashedMigrationHelperTest extends PHPStanTestCase
     {
         $schemaParser = new SquashedMigrationHelper(
             [__DIR__ . '/data/schema/multiple_schemas_for_same_table'],
-            self::getContainer()->getByType(FileHelper::class),
-            new MySqlDataTypeToPhpTypeConverter(),
+            $this->fileHelper,
+            $this->converter,
             false,
         );
 
@@ -69,8 +79,8 @@ class SquashedMigrationHelperTest extends PHPStanTestCase
     {
         $schemaParser = new SquashedMigrationHelper(
             [__DIR__ . '/data/schema/basic_schema_with_sql_extension'],
-            self::getContainer()->getByType(FileHelper::class),
-            new MySqlDataTypeToPhpTypeConverter(),
+            $this->fileHelper,
+            $this->converter,
             false,
         );
 
@@ -93,8 +103,8 @@ class SquashedMigrationHelperTest extends PHPStanTestCase
     {
         $schemaParser = new SquashedMigrationHelper(
             [__DIR__ . '/data/schema/multiple_schemas_with_different_extensions'],
-            self::getContainer()->getByType(FileHelper::class),
-            new MySqlDataTypeToPhpTypeConverter(),
+            $this->fileHelper,
+            $this->converter,
             false,
         );
 
@@ -126,8 +136,8 @@ class SquashedMigrationHelperTest extends PHPStanTestCase
     {
         $schemaParser = new SquashedMigrationHelper(
             [__DIR__ . '/data/schema/multiple_schemas_with_different_extensions'],
-            self::getContainer()->getByType(FileHelper::class),
-            new MySqlDataTypeToPhpTypeConverter(),
+            $this->fileHelper,
+            $this->converter,
             true,
         );
 


### PR DESCRIPTION
**Changes**

Hello!

~This PR allows wildcards to be specified in the migration/schema paths which closes #1954.~

This PR creates an internal FileHelper class that cleans up all the repeated file globing logic.

It also has a small performance tweak in the NoEnvCallsOutsideOfConfigRule---there's no need to reglob the directories on every `env` check

Thanks!
