### PR TITLE
Add stub for Http facade

### DIFF
--- a/stubs/common/Facades.stub
+++ b/stubs/common/Facades.stub
@@ -54,3 +54,8 @@ class Cookie extends Facade {
      */
     public static function get($key = null, $default = null);
 }
+
+/**
+ * @mixin \Illuminate\Http\Client\Factory
+ */
+class Http extends Facade {}

--- a/stubs/common/Http/Client.stub
+++ b/stubs/common/Http/Client.stub
@@ -1,0 +1,10 @@
+<?php
+
+namespace Illuminate\Http\Client;
+
+class PendingRequest {}
+
+/**
+ * @mixin \Illuminate\Http\Client\PendingRequest
+ */
+class Factory {}

--- a/tests/Integration/IntegrationTest.php
+++ b/tests/Integration/IntegrationTest.php
@@ -28,6 +28,7 @@ class IntegrationTest extends PHPStanTestCase
         yield [__DIR__ . '/data/model-factories.php'];
         yield [__DIR__ . '/data/blade-view.php'];
         yield [__DIR__ . '/data/helpers.php'];
+        yield [__DIR__ . '/data/facades.php'];
 
         yield [
             __DIR__ . '/data/model-property-builder.php',

--- a/tests/Integration/data/facades.php
+++ b/tests/Integration/data/facades.php
@@ -1,0 +1,10 @@
+<?php
+
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Support\Facades\Http;
+
+try {
+    Http::get('http://localhost:3000/health');
+} catch (ConnectionException) {
+    return false;
+}


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes

Given the following code:

```php
try {
    $response = Http::get('http://localhost:3000/health');
} catch (ConnectionException) {
    return Result::make()->failed('Unreachable');
}
```

PHPStan currently emits a false positive because it doesn't know about the `@throws` tag defined [here](https://github.com/laravel/framework/blob/25873116d90107414a21ab22a3b20e5a802f9a26/src/Illuminate/Http/Client/PendingRequest.php#L768). The only way PHPStan currently knows about the `get` method is via the `@method` tag on the Http facade [here](https://github.com/laravel/framework/blob/25873116d90107414a21ab22a3b20e5a802f9a26/src/Illuminate/Support/Facades/Http.php#L68), which does not and cannot include a `@throws` tag.

```
 ------ -------------------------------------------------------------------------------------------
  Line   app/Health/GotenbergCheck.php
 ------ -------------------------------------------------------------------------------------------
  16     Dead catch - Illuminate\Http\Client\ConnectionException is never thrown in the try block.
         🪪  catch.neverThrown
 ------ -------------------------------------------------------------------------------------------
```

**Changes**

Defines [Illuminate\Http\Client\Factory](https://github.com/laravel/framework/blob/11.x/src/Illuminate/Http/Client/Factory.php) as a mixin on the Http facade. This class has a mixin tag for [Illuminate\Http\Client\PendingRequest](https://github.com/laravel/framework/blob/11.x/src/Illuminate/Http/Client/PendingRequest.php) which includes the actual get method (and other request methods).

**Breaking changes**

When your code contains calls like `Http:get()` without a catch statement or `@throws` tag, PHPStan will start emitting errors like these:

```
 ------ --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Line   modules/Language/Database/Seeders/ImportIso639Part3Table.php
 ------ --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  34     Method Modules\Language\Database\Seeders\ImportIso639Part3Table::synchronizeLanguages() throws checked exception Illuminate\Http\Client\ConnectionException but it's missing
         from the PHPDoc @throws tag.
         🪪  missingType.checkedException
  69     Method Modules\Language\Database\Seeders\ImportIso639Part3Table::synchronizeMacrolanguageDefinitions() throws checked exception Illuminate\Http\Client\ConnectionException but
         it's missing from the PHPDoc @throws tag.
         🪪  missingType.checkedException
 ------ --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

However, you will already get this when calling any method on the Http facade that returns a PendingRequest before finally calling the `->get()` method, so I do not consider this to be a breaking change, but rather just a fix.