### PR TITLE
[3.x] fix: handle collection intersection types

### DIFF
--- a/e2e/filamentphp-filament.baseline.neon
+++ b/e2e/filamentphp-filament.baseline.neon
@@ -111,6 +111,16 @@ parameters:
 			path: ../../e2e/packages/panels/src/Commands/MakeResourceCommand.php
 
 		-
+			message: "#^Unable to resolve the template type TGroupKey in call to method Illuminate\\\\Support\\\\Collection\\<\\(int\\|string\\),Filament\\\\Navigation\\\\NavigationItem\\>\\:\\:groupBy\\(\\)$#"
+			count: 1
+			path: ../../e2e/packages/panels/src/Navigation/NavigationManager.php
+
+		-
+			message: "#^Unable to resolve the template type TGroupKey in call to method Illuminate\\\\Support\\\\Collection\\<int,Filament\\\\Navigation\\\\NavigationItem\\>\\:\\:groupBy\\(\\)$#"
+			count: 1
+			path: ../../e2e/packages/panels/src/Navigation/NavigationManager.php
+
+		-
 			message: "#^Unable to resolve the template type TMapValue in call to method Illuminate\\\\Support\\\\Collection\\<\\(int\\|string\\),string\\>\\:\\:map\\(\\)$#"
 			count: 1
 			path: ../../e2e/packages/spatie-laravel-tags-plugin/src/Forms/Components/SpatieTagsInput.php

--- a/src/ReturnTypes/BuilderModelFindExtension.php
+++ b/src/ReturnTypes/BuilderModelFindExtension.php
@@ -21,6 +21,7 @@ use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 
+use function array_filter;
 use function count;
 use function in_array;
 
@@ -99,6 +100,8 @@ final class BuilderModelFindExtension implements DynamicMethodReturnTypeExtensio
                 );
             }
         }
+
+        $models = array_filter($models);
 
         return count($models) > 0 ? TypeCombinator::union(...$models) : null;
     }

--- a/src/ReturnTypes/BuilderModelFindExtension.php
+++ b/src/ReturnTypes/BuilderModelFindExtension.php
@@ -84,7 +84,7 @@ final class BuilderModelFindExtension implements DynamicMethodReturnTypeExtensio
 
             if ($argType->isIterable()->yes()) {
                 if (in_array(Collection::class, $returnType->getReferencedClasses(), true)) {
-                    $models[] = $this->collectionHelper->determineCollectionClass($modelName);
+                    $models[] = $this->collectionHelper->determineCollectionType($modelName);
                     continue;
                 }
 

--- a/src/ReturnTypes/EloquentBuilderExtension.php
+++ b/src/ReturnTypes/EloquentBuilderExtension.php
@@ -14,11 +14,11 @@ use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\DynamicMethodReturnTypeExtension;
-use PHPStan\Type\Generic\GenericObjectType;
-use PHPStan\Type\IntegerType;
-use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
 
+use function collect;
+use function count;
 use function in_array;
 
 final class EloquentBuilderExtension implements DynamicMethodReturnTypeExtension
@@ -79,29 +79,19 @@ final class EloquentBuilderExtension implements DynamicMethodReturnTypeExtension
 
         $classNames = $modelType->getObjectClassNames();
 
-        if ($classNames !== [] && $modelType->isObject()->yes() && in_array(Collection::class, $returnType->getReferencedClasses(), true)) {
-            $collectionClassName = $this->collectionHelper->determineCollectionClassName($classNames[0]);
-
-            $collectionReflection = $this->reflectionProvider->getClass($collectionClassName);
-
-            if (! $collectionReflection->isGeneric()) {
-                // Not generic. So return the type as is
-                return new ObjectType($collectionClassName);
-            }
-
-            $typeMap = $collectionReflection->getActiveTemplateTypeMap();
-
-            // Specifies key and value
-            if ($typeMap->count() === 2) {
-                return new GenericObjectType($collectionClassName, [new IntegerType(), $modelType]);
-            }
-
-            // Specifies only value
-            if (($typeMap->count() === 1) && $typeMap->hasType('TModel')) {
-                return new GenericObjectType($collectionClassName, [$modelType]);
-            }
+        if (count($classNames) === 0) {
+            return null;
         }
 
-        return null;
+        if (! in_array(Collection::class, $returnType->getReferencedClasses(), true)) {
+            return null;
+        }
+
+        return TypeCombinator::union(
+            ...collect($classNames)
+                ->map(fn ($className) => $this->collectionHelper->determineCollectionType($className))
+                ->filter()
+                ->all(),
+        );
     }
 }

--- a/src/ReturnTypes/ModelDynamicStaticMethodReturnTypeExtension.php
+++ b/src/ReturnTypes/ModelDynamicStaticMethodReturnTypeExtension.php
@@ -24,6 +24,7 @@ use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 
+use function array_filter;
 use function array_intersect;
 use function count;
 use function in_array;
@@ -126,6 +127,8 @@ final class ModelDynamicStaticMethodReturnTypeExtension implements DynamicStatic
             foreach ($modelNames as $modelName) {
                 $types[] = $this->collectionHelper->determineCollectionType($modelName);
             }
+
+            $types = array_filter($types);
 
             if ($types !== []) {
                 return TypeCombinator::union(...$types);

--- a/src/ReturnTypes/ModelDynamicStaticMethodReturnTypeExtension.php
+++ b/src/ReturnTypes/ModelDynamicStaticMethodReturnTypeExtension.php
@@ -124,7 +124,7 @@ final class ModelDynamicStaticMethodReturnTypeExtension implements DynamicStatic
             $types = [];
 
             foreach ($modelNames as $modelName) {
-                $types[] = $this->collectionHelper->determineCollectionClass($modelName);
+                $types[] = $this->collectionHelper->determineCollectionType($modelName);
             }
 
             if ($types !== []) {

--- a/src/ReturnTypes/ModelFindExtension.php
+++ b/src/ReturnTypes/ModelFindExtension.php
@@ -86,7 +86,7 @@ final class ModelFindExtension implements DynamicStaticMethodReturnTypeExtension
 
             if ($argType->isIterable()->yes()) {
                 if (in_array(Collection::class, $returnType->getReferencedClasses(), true)) {
-                    $types[] = $this->collectionHelper->determineCollectionClass($modelName);
+                    $types[] = $this->collectionHelper->determineCollectionType($modelName);
                     continue;
                 }
 

--- a/src/ReturnTypes/ModelFindExtension.php
+++ b/src/ReturnTypes/ModelFindExtension.php
@@ -23,6 +23,7 @@ use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 
+use function array_filter;
 use function count;
 use function in_array;
 
@@ -106,6 +107,8 @@ final class ModelFindExtension implements DynamicStaticMethodReturnTypeExtension
                 );
             }
         }
+
+        $types = array_filter($types);
 
         return TypeCombinator::union(...$types);
     }

--- a/src/Support/CollectionHelper.php
+++ b/src/Support/CollectionHelper.php
@@ -99,7 +99,7 @@ final class CollectionHelper
         }
     }
 
-    public function determineCollectionClass(string $modelClassName): Type
+    public function determineCollectionType(string $modelClassName, Type|null $modelType = null): Type
     {
         $collectionClassName  = $this->determineCollectionClassName($modelClassName);
         $collectionReflection = $this->reflectionProvider->getClass($collectionClassName);
@@ -143,7 +143,7 @@ final class CollectionHelper
                 return $type;
             }
 
-            return TypeCombinator::union(...array_map([$this, 'determineCollectionClass'], $models));
+            return TypeCombinator::union(...array_map([$this, 'determineCollectionType'], $models));
         });
     }
 

--- a/tests/Type/GeneralTypeTest.php
+++ b/tests/Type/GeneralTypeTest.php
@@ -24,8 +24,11 @@ class GeneralTypeTest extends TypeInferenceTestCase
         yield from self::gatherAssertTypes(__DIR__ . '/data/bug-1565.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/bug-1718.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/bug-1760.php');
+        yield from self::gatherAssertTypes(__DIR__ . '/data/bug-1819.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/bug-1830.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/bug-1985.php');
+        yield from self::gatherAssertTypes(__DIR__ . '/data/bug-1997.php');
+        yield from self::gatherAssertTypes(__DIR__ . '/data/bug-2057.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/bug-2073.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/bug-2111.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/conditionable.php');
@@ -68,8 +71,6 @@ class GeneralTypeTest extends TypeInferenceTestCase
         yield from self::gatherAssertTypes(__DIR__ . '/data/view-exists.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/view.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/where-relation.php');
-        yield from self::gatherAssertTypes(__DIR__ . '/data/bug-1997.php');
-        yield from self::gatherAssertTypes(__DIR__ . '/data/bug-1819.php');
 
         if (laravel_version_compare('11.28.0', '>=')) {
             yield from self::gatherAssertTypes(__DIR__ . '/data/model-collections-l11-28.php');

--- a/tests/Type/data/bug-2057.php
+++ b/tests/Type/data/bug-2057.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Bug2057;
+
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
+
+use function PHPStan\Testing\assertType;
+
+/** @template T of \Illuminate\Database\Eloquent\Model */
+interface TreeLikeCollection
+{
+    /** @return $this */
+    public function getTree(): static;
+}
+
+/**
+ * @template TKey of array-key
+ * @template TModel of \Illuminate\Database\Eloquent\Model
+ *
+ * @extends Collection<TKey, TModel>
+ * @implements TreeLikeCollection<TModel>
+ */
+class TreeCollection extends Collection implements TreeLikeCollection
+{
+    /** @return $this */
+    public function getTree(): static
+    {
+        return $this;
+    }
+}
+
+class User extends Model
+{
+    /**
+     * @param  array<array-key, static>  $models
+     * @return Collection<int, static>&TreeLikeCollection<static>
+     */
+    public function newCollection(array $models = []): Collection&TreeLikeCollection
+    {
+        /** @phpstan-ignore return.type (generics) */
+        return new TreeCollection($models);
+    }
+}
+
+class Post extends Model
+{
+    /**
+     * @param  array<array-key, static>  $models
+     * @return TreeCollection<int, static>
+     */
+    public function newCollection(array $models = []): Collection&TreeLikeCollection
+    {
+        /** @phpstan-ignore return.type (generics) */
+        return new TreeCollection($models);
+    }
+}
+
+function test(): void
+{
+    assertType('Bug2057\TreeLikeCollection<static(Bug2057\User)>&Illuminate\Database\Eloquent\Collection<int, Bug2057\User>', User::all());
+    assertType('Bug2057\TreeLikeCollection<static(Bug2057\User)>&Illuminate\Database\Eloquent\Collection<int, Bug2057\User>', User::all()->getTree());
+    assertType('Bug2057\TreeCollection<int, Bug2057\Post>', Post::all());
+    assertType('Bug2057\TreeCollection<int, Bug2057\Post>', Post::all()->getTree());
+}

--- a/tests/Type/data/collection-generic-static-methods.php
+++ b/tests/Type/data/collection-generic-static-methods.php
@@ -110,8 +110,8 @@ function test(
     assertType('App\UserCollection', $secondCustomEloquentCollection->pop(2));
     assertType('Illuminate\Support\Collection<int, int>', $items->pop(3));
 
-    assertType('App\Role', User::firstOrFail(1)->roles->random());
-    assertType('App\RoleCollection<int, App\Role>', User::firstOrFail(1)->roles->random(1));
+    assertType('App\Role&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}', User::firstOrFail(1)->roles->random());
+    assertType('App\RoleCollection<int, App\Role&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}>', User::firstOrFail(1)->roles->random(1));
     assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', $collection->random(1));
     assertType('App\TransactionCollection<int, App\Transaction>', $customEloquentCollection->random(2));
     assertType('App\UserCollection', $secondCustomEloquentCollection->random(2));

--- a/tests/Type/data/custom-eloquent-collection.php
+++ b/tests/Type/data/custom-eloquent-collection.php
@@ -101,26 +101,26 @@ function test(): void
     assertType('App\NonGenericCollection', (new User)->modelsWithNonGenericCollection);
     assertType('App\OnlyValueGenericCollection<App\ModelWithOnlyValueGenericCollection>', (new User)->modelsWithOnlyValueGenericCollection);
 
-    assertType('App\RoleCollection<int, App\Role>', (new User)->roles()->find([1, 2]));
-    assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', (new Role)->users()->find([1, 2]));
+    assertType('App\RoleCollection<int, App\Role&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}>', (new User)->roles()->find([1, 2]));
+    assertType('Illuminate\Database\Eloquent\Collection<int, App\User&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}>', (new Role)->users()->find([1, 2]));
 
     assertType('(App\Role&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot})|null', (new User)->roles()->find(1));
-    assertType('App\RoleCollection<int, App\Role>', (new User)->roles()->findOrFail([1, 2]));
+    assertType('App\RoleCollection<int, App\Role&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}>', (new User)->roles()->findOrFail([1, 2]));
 
-    assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', (new Role)->users()->findOrFail([1, 2]));
+    assertType('Illuminate\Database\Eloquent\Collection<int, App\User&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}>', (new Role)->users()->findOrFail([1, 2]));
     assertType('App\Role&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}', (new User)->roles()->findOrFail(1));
 
-    assertType('App\RoleCollection<int, App\Role>', (new User)->roles()->findMany([1, 2]));
-    assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', (new Role)->users()->findMany([1, 2]));
+    assertType('App\RoleCollection<int, App\Role&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}>', (new User)->roles()->findMany([1, 2]));
+    assertType('Illuminate\Database\Eloquent\Collection<int, App\User&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}>', (new Role)->users()->findMany([1, 2]));
 
     assertType('App\TransactionCollection<int, App\Transaction>', (new User)->transactions()->find([1, 2]));
-    assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', (new Role)->users()->find([1, 2]));
+    assertType('Illuminate\Database\Eloquent\Collection<int, App\User&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}>', (new Role)->users()->find([1, 2]));
     assertType('App\Transaction|null', (new User)->transactions()->find(1));
     assertType('App\TransactionCollection<int, App\Transaction>', (new User)->transactions()->findOrFail([1, 2]));
-    assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', (new Role)->users()->findOrFail([1, 2]));
+    assertType('Illuminate\Database\Eloquent\Collection<int, App\User&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}>', (new Role)->users()->findOrFail([1, 2]));
     assertType('App\Transaction', (new User)->transactions()->findOrFail(1));
     assertType('App\TransactionCollection<int, App\Transaction>', (new User)->transactions()->findMany([1, 2]));
-    assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', (new Role)->users()->findMany([1, 2]));
+    assertType('Illuminate\Database\Eloquent\Collection<int, App\User&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}>', (new Role)->users()->findMany([1, 2]));
     assertType('App\AccountCollection<int, App\Account>', (new Group)->accounts()->find([1, 2]));
     assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', (new User)->children()->find([1, 2]));
     assertType('App\Account|null', (new Group)->accounts()->find(1));

--- a/tests/Type/data/model-relations.php
+++ b/tests/Type/data/model-relations.php
@@ -53,12 +53,12 @@ function test(
 
     assertType('App\AccountCollection<int, App\Account>', $group->accounts()->where('active', 1)->get());
     assertType('App\Account', $appUser->accounts()->make());
-    assertType('App\RoleCollection<int, App\Role>', $appUser->roles()->find([1]));
-    assertType('App\RoleCollection<int, App\Role>', $appUser->roles()->findMany([1, 2, 3]));
-    assertType('App\RoleCollection<int, App\Role>', $appUser->roles()->findOrNew([1]));
-    assertType('App\RoleCollection<int, App\Role>', $appUser->roles()->findOrFail([1]));
-    assertType('42|App\RoleCollection<int, App\Role>', $appUser->roles()->findOr([1], fn () => 42));
-    assertType('42|App\RoleCollection<int, App\Role>', $appUser->roles()->findOr([1], callback: fn () => 42));
+    assertType('App\RoleCollection<int, App\Role&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}>', $appUser->roles()->find([1]));
+    assertType('App\RoleCollection<int, App\Role&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}>', $appUser->roles()->findMany([1, 2, 3]));
+    assertType('App\RoleCollection<int, App\Role&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}>', $appUser->roles()->findOrNew([1]));
+    assertType('App\RoleCollection<int, App\Role&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}>', $appUser->roles()->findOrFail([1]));
+    assertType('42|App\RoleCollection<int, App\Role&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}>', $appUser->roles()->findOr([1], fn () => 42));
+    assertType('42|App\RoleCollection<int, App\Role&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}>', $appUser->roles()->findOr([1], callback: fn () => 42));
     assertType('App\Role&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}', $appUser->roles()->findOrNew(1));
     assertType('App\Role&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}', $appUser->roles()->findOrFail(1));
     assertType('(App\Role&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot})|null', $appUser->roles()->find(1));
@@ -147,14 +147,14 @@ function test(
     assertType('App\Account|false', $user->accountsCamel()->saveQuietly(new Account()));
 
     assertType('Illuminate\Database\Eloquent\Relations\BelongsToMany<App\Role, App\User, Illuminate\Database\Eloquent\Relations\Pivot, \'pivot\'>', $user->roles());
-    assertType('App\RoleCollection<int, App\Role>', $user->roles()->getResults());
-    assertType('App\RoleCollection<int, App\Role>', $user->roles);
-    assertType('App\RoleCollection<int, App\Role>', $user->roles()->find([1]));
-    assertType('App\RoleCollection<int, App\Role>', $user->roles()->findMany([1, 2, 3]));
-    assertType('App\RoleCollection<int, App\Role>', $user->roles()->findOrNew([1]));
-    assertType('App\RoleCollection<int, App\Role>', $user->roles()->findOrFail([1]));
-    assertType('42|App\RoleCollection<int, App\Role>', $user->roles()->findOr([1], fn () => 42));
-    assertType('42|App\RoleCollection<int, App\Role>', $user->roles()->findOr([1], callback: fn () => 42));
+    assertType('App\RoleCollection<int, App\Role&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}>', $user->roles()->getResults());
+    assertType('App\RoleCollection<int, App\Role&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}>', $user->roles);
+    assertType('App\RoleCollection<int, App\Role&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}>', $user->roles()->find([1]));
+    assertType('App\RoleCollection<int, App\Role&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}>', $user->roles()->findMany([1, 2, 3]));
+    assertType('App\RoleCollection<int, App\Role&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}>', $user->roles()->findOrNew([1]));
+    assertType('App\RoleCollection<int, App\Role&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}>', $user->roles()->findOrFail([1]));
+    assertType('42|App\RoleCollection<int, App\Role&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}>', $user->roles()->findOr([1], fn () => 42));
+    assertType('42|App\RoleCollection<int, App\Role&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}>', $user->roles()->findOr([1], callback: fn () => 42));
     assertType('App\Role&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}', $user->roles()->findOrNew(1));
     assertType('App\Role&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}', $user->roles()->findOrFail(1));
     assertType('(App\Role&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot})|null', $user->roles()->find(1));
@@ -173,10 +173,10 @@ function test(
     assertType('App\Role&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}', $user->roles()->save(new Role()));
     assertType('App\Role&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}', $user->roles()->saveQuietly(new Role()));
     $roles = $user->roles()->getResults();
-    assertType('App\RoleCollection<int, App\Role>', $user->roles()->saveMany($roles));
-    assertType('array<int, App\Role>', $user->roles()->saveMany($roles->all()));
-    assertType('App\RoleCollection<int, App\Role>', $user->roles()->saveManyQuietly($roles));
-    assertType('array<int, App\Role>', $user->roles()->saveManyQuietly($roles->all()));
+    assertType('Illuminate\Support\Collection<int, App\Role>', $user->roles()->saveMany(collect([new Role()])));
+    assertType('array<int, App\Role&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}>', $user->roles()->saveMany($roles->all()));
+    assertType('Illuminate\Support\Collection<int, App\Role>', $user->roles()->saveManyQuietly(collect([new Role()])));
+    assertType('array<int, App\Role&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}>', $user->roles()->saveManyQuietly($roles->all()));
     assertType('array<int, App\Role&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}>', $user->roles()->createMany($roles));
     assertType('array{attached: array, detached: array, updated: array}', $user->roles()->sync($roles));
     assertType('array{attached: array, detached: array, updated: array}', $user->roles()->syncWithoutDetaching($roles));
@@ -236,8 +236,8 @@ function test(
     assertType('App\Comment', $comment->commentable()->dissociate());
 
     assertType('Illuminate\Database\Eloquent\Relations\MorphToMany<App\Tag, App\Post, Illuminate\Database\Eloquent\Relations\MorphPivot, \'pivot\'>', $post->tags());
-    assertType('Illuminate\Database\Eloquent\Collection<int, App\Tag>', $post->tags()->getResults());
-    assertType('Illuminate\Database\Eloquent\Collection<int, App\Tag>', $post->tags);
+    assertType('Illuminate\Database\Eloquent\Collection<int, App\Tag&object{pivot: Illuminate\Database\Eloquent\Relations\MorphPivot}>', $post->tags()->getResults());
+    assertType('Illuminate\Database\Eloquent\Collection<int, App\Tag&object{pivot: Illuminate\Database\Eloquent\Relations\MorphPivot}>', $post->tags);
 
     $user->roles()->where(function (Builder $query) {
         assertType('Illuminate\Database\Eloquent\Builder<App\Role>', $query);


### PR DESCRIPTION
Hello!

This closes #2057 by properly handling intersection types / multiple classes in the `newCollection` method.

This has been released on my [fork](https://github.com/calebdw/larastan) if anyone would like to take advantage of this immediately.

Thanks!
