### PR TITLE
[3.x] fix: builder stubs and builder/model forwarding

### DIFF
--- a/src/Methods/EloquentBuilderForwardsCallsExtension.php
+++ b/src/Methods/EloquentBuilderForwardsCallsExtension.php
@@ -14,21 +14,22 @@ use PHPStan\Reflection\MethodsClassReflectionExtension;
 use PHPStan\Reflection\MissingMethodFromReflectionException;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\ShouldNotHappenException;
-use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\Generic\TemplateObjectType;
 use PHPStan\Type\IntegerType;
-use PHPStan\Type\ObjectType;
+use PHPStan\Type\ThisType;
 
 use function array_key_exists;
 use function array_map;
 use function array_merge;
-use function array_values;
 use function in_array;
 
 final class EloquentBuilderForwardsCallsExtension implements MethodsClassReflectionExtension
 {
     /** @var array<string, MethodReflection> */
     private array $cache = [];
+
+    /** @var list<string> */
+    private array $softDeletesMethods = ['withTrashed', 'onlyTrashed', 'withoutTrashed', 'restore', 'createOrRestore', 'restoreOrCreate'];
 
     public function __construct(private BuilderHelper $builderHelper, private ReflectionProvider $reflectionProvider)
     {
@@ -95,41 +96,29 @@ final class EloquentBuilderForwardsCallsExtension implements MethodsClassReflect
         if ($ref === null) {
             // Special case for `SoftDeletes` trait
             if (
-                in_array($methodName, ['withTrashed', 'onlyTrashed', 'withoutTrashed', 'restore', 'createOrRestore', 'restoreOrCreate'], true) &&
-                array_key_exists(SoftDeletes::class, array_merge(...array_map(static fn ($r) => $r->getTraits(true), $modelType->getObjectClassReflections())))
+                ! in_array($methodName, $this->softDeletesMethods, true) ||
+                ! array_key_exists(SoftDeletes::class, array_merge(...array_map(static fn ($r) => $r->getTraits(true), $modelType->getObjectClassReflections())))
             ) {
-                $ref = $this->reflectionProvider->getClass(SoftDeletes::class)->getMethod($methodName, new OutOfClassScope());
-
-                if ($methodName === 'restore') {
-                    return new EloquentBuilderMethodReflection(
-                        $methodName,
-                        $classReflection,
-                        $ref->getVariants()[0]->getParameters(),
-                        new IntegerType(),
-                        $ref->getVariants()[0]->isVariadic(),
-                    );
-                }
-
-                if ($methodName === 'restoreOrCreate' || $methodName === 'createOrRestore') {
-                    return new EloquentBuilderMethodReflection(
-                        $methodName,
-                        $classReflection,
-                        $ref->getVariants()[0]->getParameters(),
-                        $modelType,
-                        $ref->getVariants()[0]->isVariadic(),
-                    );
-                }
-
-                return new EloquentBuilderMethodReflection(
-                    $methodName,
-                    $classReflection,
-                    $ref->getVariants()[0]->getParameters(),
-                    new GenericObjectType($classReflection->getName(), [$modelType]),
-                    $ref->getVariants()[0]->isVariadic(),
-                );
+                return null;
             }
 
-            return null;
+            $ref = $this->reflectionProvider->getClass(SoftDeletes::class)->getMethod($methodName, new OutOfClassScope());
+
+            if ($methodName === 'restore') {
+                $returnType = new IntegerType();
+            } elseif ($methodName === 'restoreOrCreate' || $methodName === 'createOrRestore') {
+                $returnType = $modelType;
+            } else {
+                $returnType = new ThisType($classReflection);
+            }
+
+            return new EloquentBuilderMethodReflection(
+                $methodName,
+                $classReflection,
+                $ref->getVariants()[0]->getParameters(),
+                $returnType,
+                $ref->getVariants()[0]->isVariadic(),
+            );
         }
 
         // Macros have their own reflection. And return type, parameters, etc. are already set with the closure.
@@ -138,17 +127,12 @@ final class EloquentBuilderForwardsCallsExtension implements MethodsClassReflect
         }
 
         $parametersAcceptor = $ref->getVariants()[0];
+        $returnType         = $parametersAcceptor->getReturnType();
 
-        if (in_array($methodName, $this->builderHelper->passthru, true)) {
-            $returnType = $parametersAcceptor->getReturnType();
-        } elseif ($classReflection->isGeneric()) {
-            $returnType = new GenericObjectType($classReflection->getName(), array_values($classReflection->getTemplateTypeMap()->getTypes()));
-        } else {
-            $returnType = new ObjectType($classReflection->getName());
+        if (! in_array($methodName, $this->builderHelper->passthru, true)) {
+            $returnType = new ThisType($classReflection);
         }
 
-        // Returning custom reflection
-        // to ensure return type is always `EloquentBuilder<Model>`
         return new EloquentBuilderMethodReflection(
             $methodName,
             $classReflection,

--- a/src/Methods/ModelForwardsCallsExtension.php
+++ b/src/Methods/ModelForwardsCallsExtension.php
@@ -22,6 +22,7 @@ use PHPStan\TrinaryLogic;
 use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\StaticType;
+use PHPStan\Type\ThisType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeTraverser;
 use PHPStan\Type\TypeWithClassName;
@@ -75,110 +76,24 @@ final class ModelForwardsCallsExtension implements MethodsClassReflectionExtensi
             return null;
         }
 
-        $builderName = $this->builderHelper->determineBuilderName($classReflection->getName());
-
         if (in_array($methodName, ['increment', 'decrement'], true)) {
-            $methodReflection = $classReflection->getNativeMethod($methodName);
-
-            return new class ($classReflection, $methodName, $methodReflection) implements MethodReflection
-            {
-                private ClassReflection $classReflection;
-
-                private string $methodName;
-
-                private MethodReflection $methodReflection;
-
-                public function __construct(ClassReflection $classReflection, string $methodName, MethodReflection $methodReflection)
-                {
-                    $this->classReflection  = $classReflection;
-                    $this->methodName       = $methodName;
-                    $this->methodReflection = $methodReflection;
-                }
-
-                public function getDeclaringClass(): ClassReflection
-                {
-                    return $this->classReflection;
-                }
-
-                public function isStatic(): bool
-                {
-                    return false;
-                }
-
-                public function isPrivate(): bool
-                {
-                    return false;
-                }
-
-                public function isPublic(): bool
-                {
-                    return true;
-                }
-
-                public function getDocComment(): string|null
-                {
-                    return null;
-                }
-
-                public function getName(): string
-                {
-                    return $this->methodName;
-                }
-
-                public function getPrototype(): ClassMemberReflection
-                {
-                    return $this;
-                }
-
-                /** @return ParametersAcceptor[] */
-                public function getVariants(): array
-                {
-                    return $this->methodReflection->getVariants();
-                }
-
-                public function isDeprecated(): TrinaryLogic
-                {
-                    return TrinaryLogic::createNo();
-                }
-
-                public function getDeprecatedDescription(): string|null
-                {
-                    return null;
-                }
-
-                public function isFinal(): TrinaryLogic
-                {
-                    return TrinaryLogic::createNo();
-                }
-
-                public function isInternal(): TrinaryLogic
-                {
-                    return TrinaryLogic::createNo();
-                }
-
-                public function getThrowType(): Type|null
-                {
-                    return null;
-                }
-
-                public function hasSideEffects(): TrinaryLogic
-                {
-                    return TrinaryLogic::createYes();
-                }
-            };
+            return $this->counterMethodReflection($classReflection, $methodName);
         }
 
-        $builderReflection          = $this->reflectionProvider->getClass($builderName)->withTypes([new ObjectType($classReflection->getName())]);
-        $genericBuilderAndModelType = new GenericObjectType($builderName, [new ObjectType($classReflection->getName())]);
+        $builderName       = $this->builderHelper->determineBuilderName($classReflection->getName());
+        $builderReflection = $this->reflectionProvider->getClass($builderName)->withTypes([new ObjectType($classReflection->getName())]);
+        $builderType       = $builderReflection->isGeneric()
+            ? new GenericObjectType($builderName, [new ObjectType($classReflection->getName())])
+            : new ObjectType($builderName);
 
         if ($builderReflection->hasNativeMethod($methodName)) {
             $reflection = $builderReflection->getNativeMethod($methodName);
 
-            $parametersAcceptor = $this->transformStaticParameters($reflection, $genericBuilderAndModelType);
+            $parametersAcceptor = $this->transformStaticParameters($reflection, $builderType);
 
-            $returnType = TypeTraverser::map($parametersAcceptor->getReturnType(), static function (Type $type, callable $traverse) use ($genericBuilderAndModelType) {
+            $returnType = TypeTraverser::map($parametersAcceptor->getReturnType(), static function (Type $type, callable $traverse) use ($builderType) {
                 if ($type instanceof TypeWithClassName && $type->getClassName() === Builder::class) {
-                    return $genericBuilderAndModelType;
+                    return $builderType;
                 }
 
                 return $traverse($type);
@@ -193,14 +108,32 @@ final class ModelForwardsCallsExtension implements MethodsClassReflectionExtensi
             );
         }
 
-        if ($this->eloquentBuilderForwardsCallsExtension->hasMethod($builderReflection, $methodName)) {
-            return $this->eloquentBuilderForwardsCallsExtension->getMethod($builderReflection, $methodName);
+        if (! $this->eloquentBuilderForwardsCallsExtension->hasMethod($builderReflection, $methodName)) {
+            return null;
         }
 
-        return null;
+        $reflection = $this->eloquentBuilderForwardsCallsExtension->getMethod($builderReflection, $methodName);
+
+        if (! $reflection instanceof EloquentBuilderMethodReflection) {
+            return $reflection;
+        }
+
+        $returnType = $reflection->getVariants()[0]->getReturnType();
+
+        if (! $returnType instanceof ThisType) {
+            return $reflection;
+        }
+
+        return new EloquentBuilderMethodReflection(
+            $reflection->getName(),
+            $reflection->getDeclaringClass(),
+            $reflection->getVariants()[0]->getParameters(),
+            $returnType->getStaticObjectType(),
+            $reflection->getVariants()[0]->isVariadic(),
+        );
     }
 
-    private function transformStaticParameters(MethodReflection $method, GenericObjectType $builder): ParametersAcceptor
+    private function transformStaticParameters(MethodReflection $method, ObjectType $builder): ParametersAcceptor
     {
         $acceptor = $method->getVariants()[0];
 
@@ -218,7 +151,7 @@ final class ModelForwardsCallsExtension implements MethodsClassReflectionExtensi
         }, $acceptor->getParameters()), $acceptor->isVariadic(), $this->transformStaticType($acceptor->getReturnType(), $builder));
     }
 
-    private function transformStaticType(Type $type, GenericObjectType $builder): Type
+    private function transformStaticType(Type $type, ObjectType $builder): Type
     {
         return TypeTraverser::map($type, static function (Type $type, callable $traverse) use ($builder): Type {
             if ($type instanceof StaticType) {
@@ -227,5 +160,87 @@ final class ModelForwardsCallsExtension implements MethodsClassReflectionExtensi
 
             return $traverse($type);
         });
+    }
+
+    private function counterMethodReflection(ClassReflection $classReflection, string $methodName): MethodReflection
+    {
+        $methodReflection = $classReflection->getNativeMethod($methodName);
+
+        return new class ($classReflection, $methodName, $methodReflection) implements MethodReflection {
+            public function __construct(private ClassReflection $classReflection, private string $methodName, private MethodReflection $methodReflection)
+            {
+            }
+
+            public function getDeclaringClass(): ClassReflection
+            {
+                return $this->classReflection;
+            }
+
+            public function isStatic(): bool
+            {
+                return false;
+            }
+
+            public function isPrivate(): bool
+            {
+                return false;
+            }
+
+            public function isPublic(): bool
+            {
+                return true;
+            }
+
+            public function getDocComment(): string|null
+            {
+                return null;
+            }
+
+            public function getName(): string
+            {
+                return $this->methodName;
+            }
+
+            public function getPrototype(): ClassMemberReflection
+            {
+                return $this;
+            }
+
+            /** @return ParametersAcceptor[] */
+            public function getVariants(): array
+            {
+                return $this->methodReflection->getVariants();
+            }
+
+            public function isDeprecated(): TrinaryLogic
+            {
+                return TrinaryLogic::createNo();
+            }
+
+            public function getDeprecatedDescription(): string|null
+            {
+                return null;
+            }
+
+            public function isFinal(): TrinaryLogic
+            {
+                return TrinaryLogic::createNo();
+            }
+
+            public function isInternal(): TrinaryLogic
+            {
+                return TrinaryLogic::createNo();
+            }
+
+            public function getThrowType(): Type|null
+            {
+                return null;
+            }
+
+            public function hasSideEffects(): TrinaryLogic
+            {
+                return TrinaryLogic::createYes();
+            }
+        };
     }
 }

--- a/src/Methods/ModelForwardsCallsExtension.php
+++ b/src/Methods/ModelForwardsCallsExtension.php
@@ -80,10 +80,11 @@ final class ModelForwardsCallsExtension implements MethodsClassReflectionExtensi
             return $this->counterMethodReflection($classReflection, $methodName);
         }
 
+        $modelType         = new StaticType($classReflection);
         $builderName       = $this->builderHelper->determineBuilderName($classReflection->getName());
-        $builderReflection = $this->reflectionProvider->getClass($builderName)->withTypes([new ObjectType($classReflection->getName())]);
+        $builderReflection = $this->reflectionProvider->getClass($builderName)->withTypes([$modelType]);
         $builderType       = $builderReflection->isGeneric()
-            ? new GenericObjectType($builderName, [new ObjectType($classReflection->getName())])
+            ? new GenericObjectType($builderName, [$modelType])
             : new ObjectType($builderName);
 
         if ($builderReflection->hasNativeMethod($methodName)) {
@@ -154,7 +155,7 @@ final class ModelForwardsCallsExtension implements MethodsClassReflectionExtensi
     private function transformStaticType(Type $type, ObjectType $builder): Type
     {
         return TypeTraverser::map($type, static function (Type $type, callable $traverse) use ($builder): Type {
-            if ($type instanceof StaticType) {
+            if ($type instanceof StaticType && (new ObjectType(Builder::class))->isSuperTypeOf($type)->yes()) {
                 return $builder;
             }
 

--- a/stubs/common/EloquentBuilder.stub
+++ b/stubs/common/EloquentBuilder.stub
@@ -23,7 +23,7 @@ class Builder
      *
      * @param  string  $identifier
      * @param  \Illuminate\Database\Eloquent\Scope|\Closure  $scope
-     * @return static
+     * @return $this
      */
     public function withGlobalScope($identifier, $scope);
 
@@ -31,7 +31,7 @@ class Builder
      * Remove a registered global scope.
      *
      * @param  \Illuminate\Database\Eloquent\Scope|string  $scope
-     * @return static
+     * @return $this
      */
     public function withoutGlobalScope($scope);
 
@@ -194,7 +194,7 @@ class Builder
      * @param  mixed  $operator
      * @param  mixed  $value
      * @param  string  $boolean
-     * @return static
+     * @return $this
      */
     public function where($column, $operator = null, $value = null, $boolean = 'and');
 
@@ -384,7 +384,7 @@ class Builder
      * @param  \Closure|string|array<mixed>|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  mixed  $operator
      * @param  mixed  $value
-     * @return static
+     * @return $this
      */
     public function whereRelation($relation, $column, $operator = null, $value = null);
 

--- a/tests/Integration/IntegrationTest.php
+++ b/tests/Integration/IntegrationTest.php
@@ -23,6 +23,7 @@ class IntegrationTest extends PHPStanTestCase
         self::getContainer();
 
         yield [__DIR__ . '/data/bug-2074.php'];
+        yield [__DIR__ . '/data/bug-2263.php'];
         yield [__DIR__ . '/data/test-case-extension.php', [34 => ['Call to function method_exists() with $this(TestTestCase) and \'partialMock\' will always evaluate to true.']]];
         yield [__DIR__ . '/data/model-builder.php'];
         yield [__DIR__ . '/data/model-properties.php'];
@@ -37,7 +38,7 @@ class IntegrationTest extends PHPStanTestCase
                 16 => ['Parameter #1 $column of method Illuminate\Database\Eloquent\Builder<App\User>::firstWhere() expects array<int|model property of App\User, mixed>|(Closure(Illuminate\Database\Eloquent\Builder<App\User>): Illuminate\Database\Eloquent\Builder<App\User>)|(Closure(Illuminate\Database\Eloquent\Builder<App\User>): void)|Illuminate\Contracts\Database\Query\Expression|model property of App\User, \'id\'|\'unionNotExisting\' given.'],
                 17 => ['Parameter #1 $column of method Illuminate\Database\Eloquent\Builder<App\User>::where() expects array<int|model property of App\User, mixed>|(Closure(Illuminate\Database\Eloquent\Builder<App\User>): Illuminate\Database\Eloquent\Builder<App\User>)|(Closure(Illuminate\Database\Eloquent\Builder<App\User>): void)|Illuminate\Contracts\Database\Query\Expression|model property of App\User, \'foo\' given.'],
                 19 => ['Parameter #1 $column of method Illuminate\Database\Eloquent\Builder<App\User>::where() expects array<int|model property of App\User, mixed>|(Closure(Illuminate\Database\Eloquent\Builder<App\User>): Illuminate\Database\Eloquent\Builder<App\User>)|(Closure(Illuminate\Database\Eloquent\Builder<App\User>): void)|Illuminate\Contracts\Database\Query\Expression|model property of App\User, \'foo\' given.'],
-                20 => ['Parameter #1 $column of method Illuminate\Database\Eloquent\Builder<App\User>::where() expects array<int|model property of App\User, mixed>|(Closure(Illuminate\Database\Eloquent\Builder<App\User>): Illuminate\Database\Eloquent\Builder<App\User>)|(Closure(Illuminate\Database\Eloquent\Builder<App\User>): void)|Illuminate\Contracts\Database\Query\Expression|model property of App\User, \'foo\' given.'],
+                20 => ['Parameter #1 $column of method Illuminate\Database\Eloquent\Builder<static(App\User)>::where() expects array<int|model property of App\User, mixed>|(Closure(Illuminate\Database\Eloquent\Builder<App\User>): Illuminate\Database\Eloquent\Builder<App\User>)|(Closure(Illuminate\Database\Eloquent\Builder<App\User>): void)|Illuminate\Contracts\Database\Query\Expression|model property of App\User, \'foo\' given.'],
                 24 => ['Parameter #1 $column of method Illuminate\Database\Eloquent\Builder<App\User>::where() expects array<int|model property of App\User, mixed>|(Closure(Illuminate\Database\Eloquent\Builder<App\User>): Illuminate\Database\Eloquent\Builder<App\User>)|(Closure(Illuminate\Database\Eloquent\Builder<App\User>): void)|Illuminate\Contracts\Database\Query\Expression|model property of App\User, string given.'],
                 25 => ['Parameter #1 $column of method Illuminate\Database\Eloquent\Builder<App\User>::orWhere() expects array<int|model property of App\User, mixed>|(Closure(Illuminate\Database\Eloquent\Builder<App\User>): Illuminate\Database\Eloquent\Builder<App\User>)|(Closure(Illuminate\Database\Eloquent\Builder<App\User>): void)|Illuminate\Contracts\Database\Query\Expression|model property of App\User, \'foo\' given.'],
                 26 => ['Parameter #1 $column of method Illuminate\Database\Eloquent\Builder<App\User>::orWhere() expects array<int|model property of App\User, mixed>|(Closure(Illuminate\Database\Eloquent\Builder<App\User>): Illuminate\Database\Eloquent\Builder<App\User>)|(Closure(Illuminate\Database\Eloquent\Builder<App\User>): void)|Illuminate\Contracts\Database\Query\Expression|model property of App\User, \'foo\' given.'],
@@ -85,10 +86,10 @@ class IntegrationTest extends PHPStanTestCase
         yield [
             __DIR__ . '/data/model-property-static-call.php',
             [
-                10 => ['Parameter #1 $attributes of static method Illuminate\Database\Eloquent\Builder<App\User>::create() expects array<model property of App\User, mixed>, array<string, string> given.'],
-                14 => ['Parameter #1 $attributes of static method Illuminate\Database\Eloquent\Builder<App\User>::create() expects array<model property of App\User, mixed>, array<string, string> given.'],
-                26 => ['Parameter #1 $attributes of static method Illuminate\Database\Eloquent\Builder<ModelPropertyStaticCall\ModelPropertyStaticCallsInClass>::create() expects array<model property of ModelPropertyStaticCall\ModelPropertyStaticCallsInClass, mixed>, array<string, string> given.'],
-                34 => ['Parameter #1 $attributes of static method Illuminate\Database\Eloquent\Builder<ModelPropertyStaticCall\ModelPropertyStaticCallsInClass>::create() expects array<model property of ModelPropertyStaticCall\ModelPropertyStaticCallsInClass, mixed>, array<string, string> given.'],
+                10 => ['Parameter #1 $attributes of static method Illuminate\Database\Eloquent\Builder<static(App\User)>::create() expects array<model property of App\User, mixed>, array<string, string> given.'],
+                14 => ['Parameter #1 $attributes of static method Illuminate\Database\Eloquent\Builder<static(App\User)>::create() expects array<model property of App\User, mixed>, array<string, string> given.'],
+                26 => ['Parameter #1 $attributes of static method Illuminate\Database\Eloquent\Builder<static(ModelPropertyStaticCall\ModelPropertyStaticCallsInClass)>::create() expects array<model property of static(ModelPropertyStaticCall\ModelPropertyStaticCallsInClass), mixed>, array<string, string> given.'],
+                34 => ['Parameter #1 $attributes of static method Illuminate\Database\Eloquent\Builder<static(ModelPropertyStaticCall\ModelPropertyStaticCallsInClass)>::create() expects array<model property of static(ModelPropertyStaticCall\ModelPropertyStaticCallsInClass), mixed>, array<string, string> given.'],
             ],
         ];
 

--- a/tests/Integration/data/bug-2263.php
+++ b/tests/Integration/data/bug-2263.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Bug2263;
+
+/**
+ * @template T of \Illuminate\Database\Eloquent\Model
+ *
+ * @param  class-string<T>  $class
+ * @return T
+ */
+function test(string $class): mixed
+{
+    return $class::findOrFail(1);
+}

--- a/tests/Type/data/custom-eloquent-builder.php
+++ b/tests/Type/data/custom-eloquent-builder.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
+use Illuminate\Database\Eloquent\SoftDeletes;
 use function PHPStan\Testing\assertType;
 
 function test(FooModel $foo, NonGenericBuilder $nonGenericBuilder): void
@@ -62,6 +63,8 @@ function test(FooModel $foo, NonGenericBuilder $nonGenericBuilder): void
  */
 class ModelWithCustomBuilder extends Model
 {
+    use SoftDeletes;
+
     // Dummy relation
     /** @return HasMany<User> */
     public function users(): HasMany
@@ -70,16 +73,15 @@ class ModelWithCustomBuilder extends Model
     }
 
     /**
-     * @param  CustomEloquentBuilder<ModelWithCustomBuilder>  $query
-     *
-     * @phpstan-return CustomEloquentBuilder<ModelWithCustomBuilder>
+     * @param  CustomEloquentBuilder<static>  $query
+     * @return CustomEloquentBuilder<static>
      */
     public function scopeFoo(CustomEloquentBuilder $query, string $foo): CustomEloquentBuilder
     {
         return $query->where(['email' => $foo]);
     }
 
-    /** @phpstan-return CustomEloquentBuilder<ModelWithCustomBuilder> */
+    /** @phpstan-return CustomEloquentBuilder<static> */
     public function testCustomBuilderReturnType(): CustomEloquentBuilder
     {
         return $this->where('email', 'bar');
@@ -87,7 +89,7 @@ class ModelWithCustomBuilder extends Model
 
     /**
      * @param  \Illuminate\Database\Query\Builder  $query
-     * @return CustomEloquentBuilder<ModelWithCustomBuilder>
+     * @return CustomEloquentBuilder<static>
      */
     public function newEloquentBuilder($query): CustomEloquentBuilder
     {
@@ -98,36 +100,57 @@ class ModelWithCustomBuilder extends Model
 /**
  * @template TModel of ModelWithCustomBuilder
  *
- * @extends Builder<ModelWithCustomBuilder>
+ * @extends Builder<TModel>
  */
 class CustomEloquentBuilder extends Builder
 {
-    /** @phpstan-return CustomEloquentBuilder<ModelWithCustomBuilder> */
-    public function category(string $category): CustomEloquentBuilder
+    /** @return $this */
+    public function category(string $category): static
     {
-        assertType('static(CustomEloquentBuilder\CustomEloquentBuilder<TModel of CustomEloquentBuilder\ModelWithCustomBuilder (class CustomEloquentBuilder\CustomEloquentBuilder, argument)>)', $this->where('category', $category));
+        $query = $this->where('category', $category);
+        assertType('$this(CustomEloquentBuilder\CustomEloquentBuilder<TModel of CustomEloquentBuilder\ModelWithCustomBuilder (class CustomEloquentBuilder\CustomEloquentBuilder, argument)>)', $query);
 
-        return $this->where('category', $category);
+        return $query;
     }
 
-    /** @phpstan-return CustomEloquentBuilder<ModelWithCustomBuilder> */
-    public function type(string $type): CustomEloquentBuilder
+    /** @return $this */
+    public function type(string $type): static
     {
-        assertType('static(CustomEloquentBuilder\CustomEloquentBuilder<TModel of CustomEloquentBuilder\ModelWithCustomBuilder (class CustomEloquentBuilder\CustomEloquentBuilder, argument)>)', $this->where(['type' => $type]));
+        $query = $this->where(['type' => $type]);
+        assertType('$this(CustomEloquentBuilder\CustomEloquentBuilder<TModel of CustomEloquentBuilder\ModelWithCustomBuilder (class CustomEloquentBuilder\CustomEloquentBuilder, argument)>)', $query);
 
-        return $this->where(['type' => $type]);
+        return $query;
     }
 
     /**
      * @param  string[]  $categories
-     *
-     * @phpstan-return CustomEloquentBuilder<ModelWithCustomBuilder>
+     * @return $this
      */
-    public function categories(array $categories): CustomEloquentBuilder
+    public function categories(array $categories): static
     {
-        assertType('CustomEloquentBuilder\CustomEloquentBuilder<TModel of CustomEloquentBuilder\ModelWithCustomBuilder (class CustomEloquentBuilder\CustomEloquentBuilder, argument)>', $this->whereIn('category', $categories));
+        $query = $this->whereIn('category', $categories);
+        assertType('$this(CustomEloquentBuilder\CustomEloquentBuilder<TModel of CustomEloquentBuilder\ModelWithCustomBuilder (class CustomEloquentBuilder\CustomEloquentBuilder, argument)>)', $query);
 
-        return $this->whereIn('category', $categories);
+        return $query;
+    }
+
+    protected function test(): void
+    {
+        $type = '$this(CustomEloquentBuilder\CustomEloquentBuilder<TModel of CustomEloquentBuilder\ModelWithCustomBuilder (class CustomEloquentBuilder\CustomEloquentBuilder, argument)>)';
+        assertType($type, $this->where('email', 'bar'));
+        assertType($type, $this->where(['email' => 'bar']));
+        assertType($type, $this->whereNull('finished_at'));
+        assertType($type, $this->whereNotNull('finished_at'));
+        assertType($type, $this->orderBy('name'));
+        assertType($type, $this->orderByDesc('name'));
+        assertType($type, $this->whereRaw('lower(email) = foo'));
+        assertType($type, $this->whereRelation('user', 'id', 1));
+        assertType($type, $this->join('user', 'user.id', '=', 'id'));
+        assertType($type, $this->leftJoin('user', 'user.id', '=', 'id'));
+        assertType($type, $this->rightJoin('user', 'user.id', '=', 'id'));
+        assertType($type, $this->select('*'));
+        assertType($type, $this->selectRaw('count(*) as count'));
+        assertType($type, $this->withTrashed());
     }
 }
 
@@ -166,7 +189,7 @@ class CustomBuilder2 extends Builder
 {
 }
 
-class ModelWithNonGenericBuilder extends Model
+class ModelWithNonGenericBuilder extends ModelWithCustomBuilder
 {
     /**
      * @param  \Illuminate\Database\Query\Builder  $query
@@ -183,6 +206,22 @@ class ModelWithNonGenericBuilder extends Model
  */
 class NonGenericBuilder extends Builder
 {
+    protected function test(): void
+    {
+        $type = '$this(CustomEloquentBuilder\NonGenericBuilder)';
+        assertType($type, $this->whereNull('finished_at'));
+        assertType($type, $this->whereNotNull('finished_at'));
+        assertType($type, $this->orderBy('name'));
+        assertType($type, $this->orderByDesc('name'));
+        assertType($type, $this->whereRaw('lower(email) = foo'));
+        assertType($type, $this->whereRelation('user', 'id', 1));
+        assertType($type, $this->join('user', 'user.id', '=', 'id'));
+        assertType($type, $this->leftJoin('user', 'user.id', '=', 'id'));
+        assertType($type, $this->rightJoin('user', 'user.id', '=', 'id'));
+        assertType($type, $this->select('*'));
+        assertType($type, $this->selectRaw('count(*) as count'));
+        assertType($type, $this->withTrashed());
+    }
 }
 
 class ChildNonGenericBuilder extends NonGenericBuilder

--- a/tests/Type/data/eloquent-builder-l11-42.php
+++ b/tests/Type/data/eloquent-builder-l11-42.php
@@ -365,9 +365,9 @@ class TestModel extends Model
 {
     public function test(): void
     {
-        assertType('Illuminate\Database\Eloquent\Collection<int, EloquentBuilder\TestModel>', $this->where('email', 1)->get());
+        assertType('Illuminate\Database\Eloquent\Collection<int, static(EloquentBuilder\TestModel)>', $this->where('email', 1)->get());
         assertType('Illuminate\Database\Eloquent\Builder<static(EloquentBuilder\TestModel)>', static::query()->where('email', 'bar'));
-        assertType('Illuminate\Database\Eloquent\Builder<EloquentBuilder\TestModel>', $this->where('email', 'bar'));
+        assertType('Illuminate\Database\Eloquent\Builder<static(EloquentBuilder\TestModel)>', $this->where('email', 'bar'));
     }
 }
 

--- a/tests/Type/data/eloquent-builder.php
+++ b/tests/Type/data/eloquent-builder.php
@@ -365,9 +365,9 @@ class TestModel extends Model
 {
     public function test(): void
     {
-        assertType('Illuminate\Database\Eloquent\Collection<int, EloquentBuilder\TestModel>', $this->where('email', 1)->get());
+        assertType('Illuminate\Database\Eloquent\Collection<int, static(EloquentBuilder\TestModel)>', $this->where('email', 1)->get());
         assertType('Illuminate\Database\Eloquent\Builder<static(EloquentBuilder\TestModel)>', static::query()->where('email', 'bar'));
-        assertType('Illuminate\Database\Eloquent\Builder<EloquentBuilder\TestModel>', $this->where('email', 'bar'));
+        assertType('Illuminate\Database\Eloquent\Builder<static(EloquentBuilder\TestModel)>', $this->where('email', 'bar'));
     }
 }
 

--- a/tests/Type/data/model-scopes.php
+++ b/tests/Type/data/model-scopes.php
@@ -28,15 +28,14 @@ class Scopes extends Model
     /** @param Builder<Scopes> $query */
     public function test(User $user, Builder $query): void
     {
-        // TODO: fix these
-//        assertType('Illuminate\Database\Eloquent\Relations\HasOne<App\User, ModelScope\Scopes>', $this->hasOne(User::class)->active());
-//        assertType('Illuminate\Database\Eloquent\Relations\HasMany<App\User, ModelScope\Scopes>', $this->hasMany(User::class)->active());
+        assertType('Illuminate\Database\Eloquent\Relations\HasOne<App\User, $this(ModelScope\Scopes)>', $this->hasOne(User::class)->active());
+        assertType('Illuminate\Database\Eloquent\Relations\HasMany<App\User, $this(ModelScope\Scopes)>', $this->hasMany(User::class)->active());
         assertType('Illuminate\Database\Eloquent\Builder<App\User>', User::where('name', 'bar')->where('name', 'bar')->where('name', 'bar')->where('name', 'bar')->where('name', 'bar')->where('name', 'bar')->where('name', 'bar')->where('name', 'bar')->where('name', 'bar')->active());
 
         assertType('Illuminate\Database\Eloquent\Builder<App\User>', $this->user->where('name', 'bar')->where('name', 'bar')->where('name', 'bar')->where('name', 'bar')->where('name', 'bar')->where('name', 'bar')->where('name', 'bar')->where('name', 'bar')->where('name', 'bar')->active());
         assertType('App\User|null', $this->user->where('name', 'bar')->active()->first());
-        assertType('Illuminate\Database\Eloquent\Builder<ModelScope\Scopes>', $this->withVoidReturn());
-        assertType('ModelScope\Scopes|null', $this->withVoidReturn()->first());
+        assertType('Illuminate\Database\Eloquent\Builder<static(ModelScope\Scopes)>', $this->withVoidReturn());
+        assertType('static(ModelScope\Scopes)|null', $this->withVoidReturn()->first());
         assertType('Illuminate\Database\Eloquent\Builder<App\User>', User::query()->whereActive());
 
         assertType('Illuminate\Database\Eloquent\Builder<App\User>', $user->someScope());


### PR DESCRIPTION
Hello!

Closes #2263 
Fixes https://github.com/larastan/larastan/discussions/2281#discussioncomment-13629745

These were fixed in #1990, but I guess they didn't make it into the release. This fixes the builder / model forwarding so the correct types are returned for methods that are forwarded to the underlying QueryBuilder

https://github.com/laravel/framework/blob/53091c205f110fb57ffdc1584e10bdaaf10d0d88/src/Illuminate/Database/Eloquent/Builder.php#L2098-L2104

This has been released on my [fork](https://github.com/calebdw/larastan) if anyone would like to take advantage of this immediately.

Thanks!
