### PR TITLE
Only set macro methods as static in facades

### DIFF
--- a/src/Methods/MacroMethodsClassReflectionExtension.php
+++ b/src/Methods/MacroMethodsClassReflectionExtension.php
@@ -62,6 +62,7 @@ class MacroMethodsClassReflectionExtension implements MethodsClassReflectionExte
         $classNames         = [];
         $found              = false;
         $macroTraitProperty = null;
+        $isFacade           = false;
 
         if ($classReflection->isInterface() && Str::startsWith($classReflection->getName(), 'Illuminate\Contracts')) {
             /** @var object|null $concrete */
@@ -109,6 +110,7 @@ class MacroMethodsClassReflectionExtension implements MethodsClassReflectionExte
                     if ($facadeClassName) {
                         $classNames         = [$facadeClassName];
                         $macroTraitProperty = 'macros';
+                        $isFacade           = true;
                     }
                 }
             }
@@ -169,7 +171,7 @@ class MacroMethodsClassReflectionExtension implements MethodsClassReflectionExte
                         $this->closureTypeFactory->fromClosureObject($macroDefinition),
                     );
 
-                    $methodReflection->setIsStatic(true);
+                    $methodReflection->setIsStatic($isFacade);
                 }
 
                 $this->methods[$classReflection->getName() . '-' . $methodName] = $methodReflection;


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Documented user facing changes

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

With phpstan-strict-rules installed, errors are generated when calling a static method on an instance or when calling an instance method statically.

Larastan is currently adding all macro methods that are defined using a closure as static methods to the base class. In most cases, this is incorrect as macro methods are instance methods. The only case where they should be static methods is when being added to a class behind a facade.

Unable to add a test as this requires strict rules to be installed.