### PR TITLE
[3.x] fix: collection template types being overwritten

### DIFF
--- a/src/ReturnTypes/EloquentBuilderExtension.php
+++ b/src/ReturnTypes/EloquentBuilderExtension.php
@@ -14,11 +14,11 @@ use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\DynamicMethodReturnTypeExtension;
-use PHPStan\Type\Generic\GenericObjectType;
-use PHPStan\Type\IntegerType;
-use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
 
+use function collect;
+use function count;
 use function in_array;
 
 final class EloquentBuilderExtension implements DynamicMethodReturnTypeExtension
@@ -79,29 +79,15 @@ final class EloquentBuilderExtension implements DynamicMethodReturnTypeExtension
 
         $classNames = $modelType->getObjectClassNames();
 
-        if ($classNames !== [] && $modelType->isObject()->yes() && in_array(Collection::class, $returnType->getReferencedClasses(), true)) {
-            $collectionClassName = $this->collectionHelper->determineCollectionClassName($classNames[0]);
-
-            $collectionReflection = $this->reflectionProvider->getClass($collectionClassName);
-
-            if (! $collectionReflection->isGeneric()) {
-                // Not generic. So return the type as is
-                return new ObjectType($collectionClassName);
-            }
-
-            $typeMap = $collectionReflection->getActiveTemplateTypeMap();
-
-            // Specifies key and value
-            if ($typeMap->count() === 2) {
-                return new GenericObjectType($collectionClassName, [new IntegerType(), $modelType]);
-            }
-
-            // Specifies only value
-            if (($typeMap->count() === 1) && $typeMap->hasType('TModel')) {
-                return new GenericObjectType($collectionClassName, [$modelType]);
-            }
+        if (count($classNames) === 0 || ! in_array(Collection::class, $returnType->getReferencedClasses(), true)) {
+            return null;
         }
 
-        return null;
+        return TypeCombinator::union(
+            ...collect($classNames)
+                ->map(fn ($className) => $this->collectionHelper->determineCollectionClass($className, $modelType))
+                ->filter()
+                ->all(),
+        );
     }
 }

--- a/src/Support/CollectionHelper.php
+++ b/src/Support/CollectionHelper.php
@@ -99,8 +99,10 @@ final class CollectionHelper
         }
     }
 
-    public function determineCollectionClass(string $modelClassName): Type
+    public function determineCollectionClass(string $modelClassName, Type|null $modelType = null): Type
     {
+        $modelType ??= new ObjectType($modelClassName);
+
         $collectionClassName  = $this->determineCollectionClassName($modelClassName);
         $collectionReflection = $this->reflectionProvider->getClass($collectionClassName);
 
@@ -109,12 +111,12 @@ final class CollectionHelper
 
             // Specifies key and value
             if ($typeMap->count() === 2) {
-                return new GenericObjectType($collectionClassName, [new IntegerType(), new ObjectType($modelClassName)]);
+                return new GenericObjectType($collectionClassName, [new IntegerType(), $modelType]);
             }
 
             // Specifies only value
             if (($typeMap->count() === 1) && $typeMap->hasType('TModel')) {
-                return new GenericObjectType($collectionClassName, [new ObjectType($modelClassName)]);
+                return new GenericObjectType($collectionClassName, [$modelType]);
             }
         }
 
@@ -137,13 +139,14 @@ final class CollectionHelper
                 return $traverse($type);
             }
 
-            $models = $type->getTemplateType(EloquentCollection::class, 'TModel')->getObjectClassNames();
+            $templateType = $type->getTemplateType(EloquentCollection::class, 'TModel');
+            $models       = $templateType->getObjectClassNames();
 
-            if (count($models) === 0) {
-                return $type;
-            }
-
-            return TypeCombinator::union(...array_map([$this, 'determineCollectionClass'], $models));
+            return match (count($models)) {
+                0 => $type,
+                1 => $this->determineCollectionClass($models[0], $templateType),
+                default => TypeCombinator::union(...array_map(fn ($m) => $this->determineCollectionClass($m), $models)),
+            };
         });
     }
 

--- a/tests/Type/GeneralTypeTest.php
+++ b/tests/Type/GeneralTypeTest.php
@@ -26,6 +26,7 @@ class GeneralTypeTest extends TypeInferenceTestCase
         yield from self::gatherAssertTypes(__DIR__ . '/data/bug-1760.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/bug-1830.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/bug-1985.php');
+        yield from self::gatherAssertTypes(__DIR__ . '/data/bug-2044.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/bug-2073.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/bug-2111.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/conditionable.php');

--- a/tests/Type/data/bug-2044.php
+++ b/tests/Type/data/bug-2044.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Bug2044;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
+
+use function PHPStan\Testing\assertType;
+
+/** @template TModel of \Illuminate\Database\Eloquent\Model */
+class Repository
+{
+    /** @var Builder<TModel> */
+    private Builder $query;
+
+    /** @return Collection<int, TModel> */
+    public function all(): Collection
+    {
+        $models = $this->query->get();
+        assertType('Illuminate\Database\Eloquent\Collection<int, TModel of Illuminate\Database\Eloquent\Model (class Bug2044\Repository, argument)>', $models);
+
+        return $models;
+    }
+}

--- a/tests/Type/data/collection-generic-static-methods.php
+++ b/tests/Type/data/collection-generic-static-methods.php
@@ -110,8 +110,8 @@ function test(
     assertType('App\UserCollection', $secondCustomEloquentCollection->pop(2));
     assertType('Illuminate\Support\Collection<int, int>', $items->pop(3));
 
-    assertType('App\Role', User::firstOrFail(1)->roles->random());
-    assertType('App\RoleCollection<int, App\Role>', User::firstOrFail(1)->roles->random(1));
+    assertType('App\Role&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}', User::firstOrFail(1)->roles->random());
+    assertType('App\RoleCollection<int, App\Role&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}>', User::firstOrFail(1)->roles->random(1));
     assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', $collection->random(1));
     assertType('App\TransactionCollection<int, App\Transaction>', $customEloquentCollection->random(2));
     assertType('App\UserCollection', $secondCustomEloquentCollection->random(2));

--- a/tests/Type/data/custom-eloquent-collection.php
+++ b/tests/Type/data/custom-eloquent-collection.php
@@ -101,26 +101,26 @@ function test(): void
     assertType('App\NonGenericCollection', (new User)->modelsWithNonGenericCollection);
     assertType('App\OnlyValueGenericCollection<App\ModelWithOnlyValueGenericCollection>', (new User)->modelsWithOnlyValueGenericCollection);
 
-    assertType('App\RoleCollection<int, App\Role>', (new User)->roles()->find([1, 2]));
-    assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', (new Role)->users()->find([1, 2]));
+    assertType('App\RoleCollection<int, App\Role&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}>', (new User)->roles()->find([1, 2]));
+    assertType('Illuminate\Database\Eloquent\Collection<int, App\User&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}>', (new Role)->users()->find([1, 2]));
 
     assertType('(App\Role&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot})|null', (new User)->roles()->find(1));
-    assertType('App\RoleCollection<int, App\Role>', (new User)->roles()->findOrFail([1, 2]));
+    assertType('App\RoleCollection<int, App\Role&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}>', (new User)->roles()->findOrFail([1, 2]));
 
-    assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', (new Role)->users()->findOrFail([1, 2]));
+    assertType('Illuminate\Database\Eloquent\Collection<int, App\User&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}>', (new Role)->users()->findOrFail([1, 2]));
     assertType('App\Role&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}', (new User)->roles()->findOrFail(1));
 
-    assertType('App\RoleCollection<int, App\Role>', (new User)->roles()->findMany([1, 2]));
-    assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', (new Role)->users()->findMany([1, 2]));
+    assertType('App\RoleCollection<int, App\Role&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}>', (new User)->roles()->findMany([1, 2]));
+    assertType('Illuminate\Database\Eloquent\Collection<int, App\User&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}>', (new Role)->users()->findMany([1, 2]));
 
     assertType('App\TransactionCollection<int, App\Transaction>', (new User)->transactions()->find([1, 2]));
-    assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', (new Role)->users()->find([1, 2]));
+    assertType('Illuminate\Database\Eloquent\Collection<int, App\User&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}>', (new Role)->users()->find([1, 2]));
     assertType('App\Transaction|null', (new User)->transactions()->find(1));
     assertType('App\TransactionCollection<int, App\Transaction>', (new User)->transactions()->findOrFail([1, 2]));
-    assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', (new Role)->users()->findOrFail([1, 2]));
+    assertType('Illuminate\Database\Eloquent\Collection<int, App\User&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}>', (new Role)->users()->findOrFail([1, 2]));
     assertType('App\Transaction', (new User)->transactions()->findOrFail(1));
     assertType('App\TransactionCollection<int, App\Transaction>', (new User)->transactions()->findMany([1, 2]));
-    assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', (new Role)->users()->findMany([1, 2]));
+    assertType('Illuminate\Database\Eloquent\Collection<int, App\User&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}>', (new Role)->users()->findMany([1, 2]));
     assertType('App\AccountCollection<int, App\Account>', (new Group)->accounts()->find([1, 2]));
     assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', (new User)->children()->find([1, 2]));
     assertType('App\Account|null', (new Group)->accounts()->find(1));

--- a/tests/Type/data/model-relations.php
+++ b/tests/Type/data/model-relations.php
@@ -53,12 +53,12 @@ function test(
 
     assertType('App\AccountCollection<int, App\Account>', $group->accounts()->where('active', 1)->get());
     assertType('App\Account', $appUser->accounts()->make());
-    assertType('App\RoleCollection<int, App\Role>', $appUser->roles()->find([1]));
-    assertType('App\RoleCollection<int, App\Role>', $appUser->roles()->findMany([1, 2, 3]));
-    assertType('App\RoleCollection<int, App\Role>', $appUser->roles()->findOrNew([1]));
-    assertType('App\RoleCollection<int, App\Role>', $appUser->roles()->findOrFail([1]));
-    assertType('42|App\RoleCollection<int, App\Role>', $appUser->roles()->findOr([1], fn () => 42));
-    assertType('42|App\RoleCollection<int, App\Role>', $appUser->roles()->findOr([1], callback: fn () => 42));
+    assertType('App\RoleCollection<int, App\Role&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}>', $appUser->roles()->find([1]));
+    assertType('App\RoleCollection<int, App\Role&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}>', $appUser->roles()->findMany([1, 2, 3]));
+    assertType('App\RoleCollection<int, App\Role&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}>', $appUser->roles()->findOrNew([1]));
+    assertType('App\RoleCollection<int, App\Role&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}>', $appUser->roles()->findOrFail([1]));
+    assertType('42|App\RoleCollection<int, App\Role&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}>', $appUser->roles()->findOr([1], fn () => 42));
+    assertType('42|App\RoleCollection<int, App\Role&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}>', $appUser->roles()->findOr([1], callback: fn () => 42));
     assertType('App\Role&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}', $appUser->roles()->findOrNew(1));
     assertType('App\Role&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}', $appUser->roles()->findOrFail(1));
     assertType('(App\Role&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot})|null', $appUser->roles()->find(1));
@@ -147,14 +147,14 @@ function test(
     assertType('App\Account|false', $user->accountsCamel()->saveQuietly(new Account()));
 
     assertType('Illuminate\Database\Eloquent\Relations\BelongsToMany<App\Role, App\User, Illuminate\Database\Eloquent\Relations\Pivot, \'pivot\'>', $user->roles());
-    assertType('App\RoleCollection<int, App\Role>', $user->roles()->getResults());
-    assertType('App\RoleCollection<int, App\Role>', $user->roles);
-    assertType('App\RoleCollection<int, App\Role>', $user->roles()->find([1]));
-    assertType('App\RoleCollection<int, App\Role>', $user->roles()->findMany([1, 2, 3]));
-    assertType('App\RoleCollection<int, App\Role>', $user->roles()->findOrNew([1]));
-    assertType('App\RoleCollection<int, App\Role>', $user->roles()->findOrFail([1]));
-    assertType('42|App\RoleCollection<int, App\Role>', $user->roles()->findOr([1], fn () => 42));
-    assertType('42|App\RoleCollection<int, App\Role>', $user->roles()->findOr([1], callback: fn () => 42));
+    assertType('App\RoleCollection<int, App\Role&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}>', $user->roles()->getResults());
+    assertType('App\RoleCollection<int, App\Role&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}>', $user->roles);
+    assertType('App\RoleCollection<int, App\Role&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}>', $user->roles()->find([1]));
+    assertType('App\RoleCollection<int, App\Role&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}>', $user->roles()->findMany([1, 2, 3]));
+    assertType('App\RoleCollection<int, App\Role&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}>', $user->roles()->findOrNew([1]));
+    assertType('App\RoleCollection<int, App\Role&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}>', $user->roles()->findOrFail([1]));
+    assertType('42|App\RoleCollection<int, App\Role&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}>', $user->roles()->findOr([1], fn () => 42));
+    assertType('42|App\RoleCollection<int, App\Role&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}>', $user->roles()->findOr([1], callback: fn () => 42));
     assertType('App\Role&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}', $user->roles()->findOrNew(1));
     assertType('App\Role&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}', $user->roles()->findOrFail(1));
     assertType('(App\Role&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot})|null', $user->roles()->find(1));
@@ -173,10 +173,10 @@ function test(
     assertType('App\Role&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}', $user->roles()->save(new Role()));
     assertType('App\Role&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}', $user->roles()->saveQuietly(new Role()));
     $roles = $user->roles()->getResults();
-    assertType('App\RoleCollection<int, App\Role>', $user->roles()->saveMany($roles));
-    assertType('array<int, App\Role>', $user->roles()->saveMany($roles->all()));
-    assertType('App\RoleCollection<int, App\Role>', $user->roles()->saveManyQuietly($roles));
-    assertType('array<int, App\Role>', $user->roles()->saveManyQuietly($roles->all()));
+    assertType('Illuminate\Support\Collection<int, App\Role>', $user->roles()->saveMany(collect([new Role()])));
+    assertType('array<int, App\Role&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}>', $user->roles()->saveMany($roles->all()));
+    assertType('Illuminate\Support\Collection<int, App\Role>', $user->roles()->saveManyQuietly(collect([new Role()])));
+    assertType('array<int, App\Role&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}>', $user->roles()->saveManyQuietly($roles->all()));
     assertType('array<int, App\Role&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}>', $user->roles()->createMany($roles));
     assertType('array{attached: array, detached: array, updated: array}', $user->roles()->sync($roles));
     assertType('array{attached: array, detached: array, updated: array}', $user->roles()->syncWithoutDetaching($roles));
@@ -236,8 +236,8 @@ function test(
     assertType('App\Comment', $comment->commentable()->dissociate());
 
     assertType('Illuminate\Database\Eloquent\Relations\MorphToMany<App\Tag, App\Post, Illuminate\Database\Eloquent\Relations\MorphPivot, \'pivot\'>', $post->tags());
-    assertType('Illuminate\Database\Eloquent\Collection<int, App\Tag>', $post->tags()->getResults());
-    assertType('Illuminate\Database\Eloquent\Collection<int, App\Tag>', $post->tags);
+    assertType('Illuminate\Database\Eloquent\Collection<int, App\Tag&object{pivot: Illuminate\Database\Eloquent\Relations\MorphPivot}>', $post->tags()->getResults());
+    assertType('Illuminate\Database\Eloquent\Collection<int, App\Tag&object{pivot: Illuminate\Database\Eloquent\Relations\MorphPivot}>', $post->tags);
 
     $user->roles()->where(function (Builder $query) {
         assertType('Illuminate\Database\Eloquent\Builder<App\Role>', $query);


### PR DESCRIPTION
Hello!

This was merged in #2193 and then reverted so reopening.

This closes #2044 by preventing the collection template types from being overwritten.

This has been released on my [fork](https://github.com/calebdw/larastan) if anyone would like to take advantage of this immediately.

Thanks!