### PR TITLE
fix: factory {has,for}* methods should return static

### DIFF
--- a/src/Methods/ModelFactoryMethodsClassReflectionExtension.php
+++ b/src/Methods/ModelFactoryMethodsClassReflectionExtension.php
@@ -18,7 +18,7 @@ use PHPStan\Reflection\ParametersAcceptor;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\Generic\TemplateTypeMap;
-use PHPStan\Type\ObjectType;
+use PHPStan\Type\StaticType;
 use PHPStan\Type\Type;
 
 use function array_key_exists;
@@ -116,7 +116,7 @@ class ModelFactoryMethodsClassReflectionExtension implements MethodsClassReflect
             /** @return ParametersAcceptor[] */
             public function getVariants(): array
             {
-                $returnType     = new ObjectType($this->classReflection->getName());
+                $returnType     = new StaticType($this->classReflection);
                 $stateParameter = $this->classReflection->getMethod('state', new OutOfClassScope())->getVariants()[0]->getParameters()[0];
                 $countParameter = $this->classReflection->getMethod('count', new OutOfClassScope())->getVariants()[0]->getParameters()[0];
 

--- a/tests/Type/data/model-factories.php
+++ b/tests/Type/data/model-factories.php
@@ -4,11 +4,11 @@ namespace ModelFactories;
 
 use App\Post;
 use App\User;
-
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\Factories\Sequence;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
 use function PHPStan\Testing\assertType;
 
 function test(?int $foo): void {
@@ -94,6 +94,12 @@ class Comment extends Model
 {
     use HasFactory;
 
+    /** @return BelongsTo<User> */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
     /** @return CommentFactory */
     protected static function newFactory(): Factory
     {
@@ -112,5 +118,26 @@ class CommentFactory extends Factory
     public function definition(): array
     {
         return [];
+    }
+
+    public function foo(): static
+    {
+        return $this->state(['foo' => 'bar']);
+    }
+
+    private function test(User $user): void
+    {
+        $type = 'static(ModelFactories\CommentFactory)';
+        assertType($type, $this->state([]));
+        assertType($type, $this->afterMaking(fn ($c) => $c));
+        assertType($type, $this->afterCreating(fn ($c) => $c));
+        assertType($type, $this->foo());
+        assertType($type, $this->recycle($user));
+        assertType($type, $this->has(User::factory()));
+        assertType($type, $this->hasAttached(User::factory()));
+        assertType($type, $this->for(User::factory()));
+        assertType($type, $this->for($user));
+        assertType($type, $this->forUser());
+        assertType($type, $this->hasUser());
     }
 }


### PR DESCRIPTION
Hello!

The dynamic factory methods `{has,for}*` (e.g., `->hasUser()`) should return static. This especially matters when you are inside the factory itself and are trying to call the methods inside a state:

```php
class CommentFactory extends Factory
{
    public function foo(): static
    {
        return $this
             // this caused the whole chain to return CommentFactory instead of static(CommentFactory)!
            ->forUser()
            ->state(['foo' => 'bar']);
    }
}
```

This has been released on my [fork](https://github.com/calebdw/larastan) if anyone would like to take advantage of this immediately.

Thanks!