### PR TITLE
[3.x] feat: add NoConstructorDependencyInjectionRule for console commands

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -559,3 +559,59 @@ parameters:
     checkConfigTypes: true
 ```
 
+## NoConstructorDependencyInjectionRule
+
+This rule ensures that console commands follow Laravel's best practice of using method injection in the `handle()` method rather than constructor injection.
+
+### Examples
+
+Constructor dependency injection:
+```php
+class MyCommand extends Command
+{
+    public function __construct(
+        private UserService $userService
+    ) {
+        parent::__construct();
+    }
+    
+    public function handle(): int
+    {
+        // ...
+    }
+}
+```
+
+This will result in the following error:
+```
+Console command "MyCommand" should not have constructor arguments. Use dependency injection in the handle() method instead.
+```
+
+To fix the error, use method injection in the handle method:
+```php
+class MyCommand extends Command
+{
+    public function handle(UserService $userService): int
+    {
+        // ...
+    }
+}
+```
+
+### Why This Rule Exists
+
+Laravel's documentation and community best practices recommend avoiding constructor dependency injection in console commands. This pattern:
+- Improves testability
+- Follows Laravel conventions
+- Avoids potential issues with command initialization
+- Makes commands more consistent with the framework
+
+### Configuration
+
+This rule is disabled by default. To enable, add the following to your `phpstan.neon` file:
+
+```neon
+parameters:
+    noConsoleCommandConstructorInjection: true
+```
+

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -561,7 +561,7 @@ parameters:
 
 ## NoConstructorDependencyInjectionRule
 
-This rule ensures that console commands follow Laravel's best practice of using method injection in the `handle()` method rather than constructor injection.
+This rule ensures that console commands follow Laravel's best practice of using method injection in the `handle()` or `__invoke()` method rather than constructor injection.
 
 ### Examples
 
@@ -584,14 +584,25 @@ class MyCommand extends Command
 
 This will result in the following error:
 ```
-Console command "MyCommand" should not have constructor arguments. Use dependency injection in the handle() method instead.
+Console command "MyCommand" should not have constructor arguments. Use dependency injection in the handle() or __invoke() method instead.
 ```
 
-To fix the error, use method injection in the handle method:
+To fix the error, use method injection in the handle or __invoke method:
 ```php
 class MyCommand extends Command
 {
     public function handle(UserService $userService): int
+    {
+        // ...
+    }
+}
+```
+
+Or with an invokable command:
+```php
+class MyInvokableCommand extends Command
+{
+    public function __invoke(UserService $userService): int
     {
         // ...
     }

--- a/extension.neon
+++ b/extension.neon
@@ -28,6 +28,7 @@ parameters:
     generalizeEnvReturnType: false
     checkConfigTypes: false
     checkAuthCallsWhenInRequestScope: false
+    noConsoleCommandConstructorInjection: false
 
 parametersSchema:
     checkOctaneCompatibility: bool()
@@ -49,6 +50,7 @@ parametersSchema:
     generalizeEnvReturnType: bool()
     checkConfigTypes: bool()
     checkAuthCallsWhenInRequestScope: bool()
+    noConsoleCommandConstructorInjection: bool()
 
 conditionalTags:
     Larastan\Larastan\Rules\NoEnvCallsOutsideOfConfigRule:
@@ -79,6 +81,8 @@ conditionalTags:
         phpstan.broker.dynamicStaticMethodReturnTypeExtension: %checkConfigTypes%
     Larastan\Larastan\Rules\ConfigCollectionRule:
         phpstan.rules.rule: %checkConfigTypes%
+    Larastan\Larastan\Rules\ConsoleCommand\NoConstructorDependencyInjectionRule:
+        phpstan.rules.rule: %noConsoleCommandConstructorInjection%
 
 services:
     -
@@ -625,6 +629,9 @@ services:
 
     -
         class: Larastan\Larastan\Rules\ConfigCollectionRule
+
+    -
+        class: Larastan\Larastan\Rules\ConsoleCommand\NoConstructorDependencyInjectionRule
 
 rules:
     - Larastan\Larastan\Rules\UselessConstructs\NoUselessWithFunctionCallsRule

--- a/src/Rules/ConsoleCommand/NoConstructorDependencyInjectionRule.php
+++ b/src/Rules/ConsoleCommand/NoConstructorDependencyInjectionRule.php
@@ -57,7 +57,7 @@ final class NoConstructorDependencyInjectionRule implements Rule
                     ),
                 )->line($methodNode->getLine())
                     ->tip('Move all dependencies to the handle() or __invoke() methods.')
-                    ->identifier('larastan.console.constructorInjection')
+                    ->identifier('larastan.consoleConstructorInjection')
                     ->build(),
             ];
         }

--- a/src/Rules/ConsoleCommand/NoConstructorDependencyInjectionRule.php
+++ b/src/Rules/ConsoleCommand/NoConstructorDependencyInjectionRule.php
@@ -38,7 +38,7 @@ final class NoConstructorDependencyInjectionRule implements Rule
 
         $classReflection = $node->getClassReflection();
 
-        if (! $classReflection->isSubclassOf(Command::class)) {
+        if (! $classReflection->is(Command::class)) {
             return [];
         }
 
@@ -52,11 +52,11 @@ final class NoConstructorDependencyInjectionRule implements Rule
             return [
                 RuleErrorBuilder::message(
                     sprintf(
-                        'Console command "%s" should not have constructor arguments. Use dependency injection in the handle() or __invoke() method instead.',
+                        'Console command "%s" should not have constructor arguments.',
                         $classReflection->getName(),
                     ),
                 )->line($methodNode->getLine())
-                    ->tip('Move all dependencies to the handle() or __invoke() method parameters for better testability and Laravel best practices.')
+                    ->tip('Move all dependencies to the handle() or __invoke() methods.')
                     ->identifier('larastan.console.constructorInjection')
                     ->build(),
             ];

--- a/src/Rules/ConsoleCommand/NoConstructorDependencyInjectionRule.php
+++ b/src/Rules/ConsoleCommand/NoConstructorDependencyInjectionRule.php
@@ -6,9 +6,8 @@ namespace Larastan\Larastan\Rules\ConsoleCommand;
 
 use Illuminate\Console\Command;
 use PhpParser\Node;
-use PhpParser\Node\Stmt\Class_;
 use PHPStan\Analyser\Scope;
-use PHPStan\Node\InClassNode;
+use PHPStan\Node\InClassMethodNode;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleError;
 use PHPStan\Rules\RuleErrorBuilder;
@@ -16,21 +15,27 @@ use PHPStan\Rules\RuleErrorBuilder;
 use function count;
 use function sprintf;
 
-/** @implements Rule<InClassNode> */
+/** @implements Rule<InClassMethodNode> */
 final class NoConstructorDependencyInjectionRule implements Rule
 {
     public function getNodeType(): string
     {
-        return InClassNode::class;
+        return InClassMethodNode::class;
     }
 
     /**
-     * @param InClassNode $node
+     * @param InClassMethodNode $node
      *
-     * @return list<RuleError>
+     * @return RuleError[] errors
      */
     public function processNode(Node $node, Scope $scope): array
     {
+        $method = $node->getMethodReflection();
+
+        if (! $method->isConstructor()) {
+            return [];
+        }
+
         $classReflection = $node->getClassReflection();
 
         if (! $classReflection->isSubclassOf(Command::class)) {
@@ -41,34 +46,17 @@ final class NoConstructorDependencyInjectionRule implements Rule
             return [];
         }
 
-        $originalNode = $node->getOriginalNode();
-        if (! $originalNode instanceof Class_) {
-            return [];
-        }
+        $methodNode = $node->getOriginalNode();
 
-        $constructor = null;
-        foreach ($originalNode->stmts as $stmt) {
-            if ($stmt instanceof Node\Stmt\ClassMethod && $stmt->name->toString() === '__construct') {
-                $constructor = $stmt;
-                break;
-            }
-        }
-
-        if ($constructor === null) {
-            return [];
-        }
-
-        $params = $constructor->params;
-
-        if (count($params) > 0) {
+        if (count($methodNode->params) > 0) {
             return [
                 RuleErrorBuilder::message(
                     sprintf(
-                        'Console command "%s" should not have constructor arguments. Use dependency injection in the handle() method instead.',
+                        'Console command "%s" should not have constructor arguments. Use dependency injection in the handle() or __invoke() method instead.',
                         $classReflection->getName(),
                     ),
-                )->line($constructor->getLine())
-                    ->tip('Move all dependencies to the handle() method parameters for better testability and Laravel best practices.')
+                )->line($methodNode->getLine())
+                    ->tip('Move all dependencies to the handle() or __invoke() method parameters for better testability and Laravel best practices.')
                     ->identifier('larastan.console.constructorInjection')
                     ->build(),
             ];

--- a/src/Rules/ConsoleCommand/NoConstructorDependencyInjectionRule.php
+++ b/src/Rules/ConsoleCommand/NoConstructorDependencyInjectionRule.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Larastan\Larastan\Rules\ConsoleCommand;
+
+use Illuminate\Console\Command;
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Class_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\InClassNode;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+
+use function count;
+use function sprintf;
+
+/** @implements Rule<InClassNode> */
+final class NoConstructorDependencyInjectionRule implements Rule
+{
+    public function getNodeType(): string
+    {
+        return InClassNode::class;
+    }
+
+    /**
+     * @param InClassNode $node
+     *
+     * @return list<RuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $classReflection = $node->getClassReflection();
+
+        if (! $classReflection->isSubclassOf(Command::class)) {
+            return [];
+        }
+
+        if ($classReflection->isAbstract()) {
+            return [];
+        }
+
+        $originalNode = $node->getOriginalNode();
+        if (! $originalNode instanceof Class_) {
+            return [];
+        }
+
+        $constructor = null;
+        foreach ($originalNode->stmts as $stmt) {
+            if ($stmt instanceof Node\Stmt\ClassMethod && $stmt->name->toString() === '__construct') {
+                $constructor = $stmt;
+                break;
+            }
+        }
+
+        if ($constructor === null) {
+            return [];
+        }
+
+        $params = $constructor->params;
+
+        if (count($params) > 0) {
+            return [
+                RuleErrorBuilder::message(
+                    sprintf(
+                        'Console command "%s" should not have constructor arguments. Use dependency injection in the handle() method instead.',
+                        $classReflection->getName(),
+                    ),
+                )->line($constructor->getLine())
+                    ->tip('Move all dependencies to the handle() method parameters for better testability and Laravel best practices.')
+                    ->identifier('larastan.console.constructorInjection')
+                    ->build(),
+            ];
+        }
+
+        return [];
+    }
+}

--- a/tests/Rules/ConsoleCommand/NoConstructorDependencyInjectionRuleTest.php
+++ b/tests/Rules/ConsoleCommand/NoConstructorDependencyInjectionRuleTest.php
@@ -22,19 +22,19 @@ class NoConstructorDependencyInjectionRuleTest extends RuleTestCase
     {
         $this->analyse([__DIR__ . '/data/console-command-constructor-injection.php'], [
             [
-                'Console command "Tests\Rules\ConsoleCommand\Data\CommandWithConstructorDI" should not have constructor arguments. Use dependency injection in the handle() or __invoke() method instead.',
+                'Console command "Tests\Rules\ConsoleCommand\Data\CommandWithConstructorDI" should not have constructor arguments.',
                 9,
-                'Move all dependencies to the handle() or __invoke() method parameters for better testability and Laravel best practices.',
+                'Move all dependencies to the handle() or __invoke() methods.',
             ],
             [
-                'Console command "Tests\Rules\ConsoleCommand\Data\CommandWithMultipleConstructorArgs" should not have constructor arguments. Use dependency injection in the handle() or __invoke() method instead.',
+                'Console command "Tests\Rules\ConsoleCommand\Data\CommandWithMultipleConstructorArgs" should not have constructor arguments.',
                 43,
-                'Move all dependencies to the handle() or __invoke() method parameters for better testability and Laravel best practices.',
+                'Move all dependencies to the handle() or __invoke() methods.',
             ],
             [
-                'Console command "Tests\Rules\ConsoleCommand\Data\InvokableCommandWithConstructorDI" should not have constructor arguments. Use dependency injection in the handle() or __invoke() method instead.',
+                'Console command "Tests\Rules\ConsoleCommand\Data\InvokableCommandWithConstructorDI" should not have constructor arguments.',
                 82,
-                'Move all dependencies to the handle() or __invoke() method parameters for better testability and Laravel best practices.',
+                'Move all dependencies to the handle() or __invoke() methods.',
             ],
         ]);
     }

--- a/tests/Rules/ConsoleCommand/NoConstructorDependencyInjectionRuleTest.php
+++ b/tests/Rules/ConsoleCommand/NoConstructorDependencyInjectionRuleTest.php
@@ -2,11 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Larastan\Larastan\Tests\Rules\ConsoleCommand;
+namespace Tests\Rules\ConsoleCommand;
 
 use Larastan\Larastan\Rules\ConsoleCommand\NoConstructorDependencyInjectionRule;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 /** @extends RuleTestCase<NoConstructorDependencyInjectionRule> */
 class NoConstructorDependencyInjectionRuleTest extends RuleTestCase
@@ -16,18 +17,24 @@ class NoConstructorDependencyInjectionRuleTest extends RuleTestCase
         return new NoConstructorDependencyInjectionRule();
     }
 
+    #[Test]
     public function testRule(): void
     {
         $this->analyse([__DIR__ . '/data/console-command-constructor-injection.php'], [
             [
-                'Console command "Larastan\Larastan\Tests\Rules\ConsoleCommand\data\CommandWithConstructorDI" should not have constructor arguments. Use dependency injection in the handle() method instead.',
+                'Console command "Tests\Rules\ConsoleCommand\Data\CommandWithConstructorDI" should not have constructor arguments. Use dependency injection in the handle() or __invoke() method instead.',
                 9,
-                'Move all dependencies to the handle() method parameters for better testability and Laravel best practices.',
+                'Move all dependencies to the handle() or __invoke() method parameters for better testability and Laravel best practices.',
             ],
             [
-                'Console command "Larastan\Larastan\Tests\Rules\ConsoleCommand\data\CommandWithMultipleConstructorArgs" should not have constructor arguments. Use dependency injection in the handle() method instead.',
+                'Console command "Tests\Rules\ConsoleCommand\Data\CommandWithMultipleConstructorArgs" should not have constructor arguments. Use dependency injection in the handle() or __invoke() method instead.',
                 43,
-                'Move all dependencies to the handle() method parameters for better testability and Laravel best practices.',
+                'Move all dependencies to the handle() or __invoke() method parameters for better testability and Laravel best practices.',
+            ],
+            [
+                'Console command "Tests\Rules\ConsoleCommand\Data\InvokableCommandWithConstructorDI" should not have constructor arguments. Use dependency injection in the handle() or __invoke() method instead.',
+                82,
+                'Move all dependencies to the handle() or __invoke() method parameters for better testability and Laravel best practices.',
             ],
         ]);
     }

--- a/tests/Rules/ConsoleCommand/NoConstructorDependencyInjectionRuleTest.php
+++ b/tests/Rules/ConsoleCommand/NoConstructorDependencyInjectionRuleTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Larastan\Larastan\Tests\Rules\ConsoleCommand;
+
+use Larastan\Larastan\Rules\ConsoleCommand\NoConstructorDependencyInjectionRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/** @extends RuleTestCase<NoConstructorDependencyInjectionRule> */
+class NoConstructorDependencyInjectionRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new NoConstructorDependencyInjectionRule();
+    }
+
+    public function testRule(): void
+    {
+        $this->analyse([__DIR__ . '/data/console-command-constructor-injection.php'], [
+            [
+                'Console command "Larastan\Larastan\Tests\Rules\ConsoleCommand\data\CommandWithConstructorDI" should not have constructor arguments. Use dependency injection in the handle() method instead.',
+                9,
+                'Move all dependencies to the handle() method parameters for better testability and Laravel best practices.',
+            ],
+            [
+                'Console command "Larastan\Larastan\Tests\Rules\ConsoleCommand\data\CommandWithMultipleConstructorArgs" should not have constructor arguments. Use dependency injection in the handle() method instead.',
+                43,
+                'Move all dependencies to the handle() method parameters for better testability and Laravel best practices.',
+            ],
+        ]);
+    }
+}

--- a/tests/Rules/ConsoleCommand/data/console-command-constructor-injection.php
+++ b/tests/Rules/ConsoleCommand/data/console-command-constructor-injection.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Larastan\Larastan\Tests\Rules\ConsoleCommand\data;
+
+use Illuminate\Console\Command;
+
+class CommandWithConstructorDI extends Command
+{
+    public function __construct(private SomeService $service)
+    {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        return 0;
+    }
+}
+
+class CommandWithoutConstructor extends Command
+{
+    public function handle(): int
+    {
+        return 0;
+    }
+}
+
+class CommandWithEmptyConstructor extends Command
+{
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        return 0;
+    }
+}
+
+class CommandWithMultipleConstructorArgs extends Command
+{
+    public function __construct(
+        private SomeService $service,
+        private AnotherService $anotherService
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        return 0;
+    }
+}
+
+abstract class AbstractCommand extends Command
+{
+    public function __construct(private SomeService $service)
+    {
+        parent::__construct();
+    }
+}
+
+class CommandWithMethodInjection extends Command
+{
+    public function handle(SomeService $service, AnotherService $anotherService): int
+    {
+        return 0;
+    }
+}
+
+class SomeService
+{
+}
+
+class AnotherService
+{
+}

--- a/tests/Rules/ConsoleCommand/data/console-command-constructor-injection.php
+++ b/tests/Rules/ConsoleCommand/data/console-command-constructor-injection.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Larastan\Larastan\Tests\Rules\ConsoleCommand\data;
+namespace Tests\Rules\ConsoleCommand\Data;
 
 use Illuminate\Console\Command;
 
@@ -75,4 +75,33 @@ class SomeService
 
 class AnotherService
 {
+}
+
+class InvokableCommandWithConstructorDI extends Command
+{
+    public function __construct(private SomeService $service)
+    {
+        parent::__construct();
+    }
+
+    public function __invoke(): int
+    {
+        return 0;
+    }
+}
+
+class InvokableCommandWithoutConstructor extends Command
+{
+    public function __invoke(): int
+    {
+        return 0;
+    }
+}
+
+class InvokableCommandWithMethodInjection extends Command
+{
+    public function __invoke(SomeService $service, AnotherService $anotherService): int
+    {
+        return 0;
+    }
 }


### PR DESCRIPTION
  ## Description

  This PR adds a new rule that enforces Laravel's best practice of using method injection in the `handle()` method rather than constructor injection for console commands.

  ### Background

  Laravel's documentation and community best practices recommend avoiding constructor dependency injection in console commands. Instead, dependencies should be injected into the `handle()`
  method. This pattern:
  - Improves testability
  - Follows Laravel conventions
  - Avoids potential issues with command initialization
  - Makes commands more consistent with the framework

  ### What this rule does

  - Detects console commands extending `Illuminate\Console\Command`
  - Checks if the constructor has any parameters
  - Reports violations with helpful error messages and tips
  - Is disabled by default for backward compatibility

  ### Example

  ```php
  // This will trigger an error:
  class MyCommand extends Command
  {
      public function __construct(private UserService $userService)
      {
          parent::__construct();
      }
  }

  // Error: Console command "MyCommand" should not have constructor arguments. Use dependency injection in the handle() method instead.
```

 ### Configuration

To enable the rule, add to your phpstan.neon:
  parameters:
      noConsoleCommandConstructorInjection: true

- Added or updated tests
- Documented user facing changes

###  Changes

- Added new rule NoConstructorDependencyInjectionRule in src/Rules/ConsoleCommand/
- Added comprehensive test coverage with various scenarios (commands with/without constructors, abstract commands, etc.)
- Added documentation in docs/rules.md explaining the rule, its purpose, and configuration
- Updated extension.neon to register the rule with opt-in configuration parameter

###  Breaking changes

None. The rule is disabled by default to maintain backward compatibility. Users must explicitly enable it in their configuration.