### PR TITLE
feat: add support for Collection, Builder, and Arr pluck

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "require-dev": {
         "doctrine/coding-standard": "^13",
-        "nikic/php-parser": "^5.4",
+        "nikic/php-parser": "^5.6",
         "laravel/framework": "^11.44.2 || ^12.7.2",
         "mockery/mockery": "^1.6.12",
         "orchestra/canvas": "^v9.2.2 || ^10.0.1",

--- a/extension.neon
+++ b/extension.neon
@@ -605,6 +605,21 @@ services:
             - phpstan.broker.dynamicMethodReturnTypeExtension
 
     -
+        class: Larastan\Larastan\ReturnTypes\ArrPluckExtension
+        tags:
+            - phpstan.broker.dynamicStaticMethodReturnTypeExtension
+
+    -
+        class: Larastan\Larastan\ReturnTypes\EloquentBuilderPluckExtension
+        tags:
+            - phpstan.broker.dynamicMethodReturnTypeExtension
+
+    -
+        class: Larastan\Larastan\ReturnTypes\EnumerablePluckExtension
+        tags:
+            - phpstan.broker.dynamicMethodReturnTypeExtension
+
+    -
         class: Larastan\Larastan\ReturnTypes\LangGetReturnTypeExtension
         tags:
             - phpstan.broker.dynamicStaticMethodReturnTypeExtension
@@ -651,6 +666,9 @@ services:
 
     -
         class: Larastan\Larastan\ReturnTypes\Helpers\EnvFunctionDynamicFunctionReturnTypeExtension
+
+    -
+        class: Larastan\Larastan\Support\PluckHelper
 
     -
         class: Larastan\Larastan\ReturnTypes\FormRequestSafeDynamicMethodReturnTypeExtension

--- a/src/ReturnTypes/ArrPluckExtension.php
+++ b/src/ReturnTypes/ArrPluckExtension.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Larastan\Larastan\ReturnTypes;
+
+use Illuminate\Support\Arr;
+use Larastan\Larastan\Support\PluckHelper;
+use PhpParser\Node\Expr\StaticCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\DynamicStaticMethodReturnTypeExtension;
+use PHPStan\Type\Type;
+
+final class ArrPluckExtension implements DynamicStaticMethodReturnTypeExtension
+{
+    public function __construct(private PluckHelper $pluckHelper)
+    {
+    }
+
+    public function getClass(): string
+    {
+        return Arr::class;
+    }
+
+    public function isStaticMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return $methodReflection->getName() === 'pluck';
+    }
+
+    public function getTypeFromStaticMethodCall(
+        MethodReflection $methodReflection,
+        StaticCall $methodCall,
+        Scope $scope,
+    ): Type|null {
+        $arrayArg = $methodCall->getArg('array', 0);
+        $valueArg = $methodCall->getArg('value', 1);
+        $keyArg   = $methodCall->getArg('key', 2);
+
+        if ($arrayArg === null || $valueArg === null) {
+            return null;
+        }
+
+        $from = $scope->getType($arrayArg->value)->getIterableValueType();
+
+        return $this->pluckHelper->getArrayType($from, $valueArg, $keyArg, $scope);
+    }
+}

--- a/src/ReturnTypes/EloquentBuilderPluckExtension.php
+++ b/src/ReturnTypes/EloquentBuilderPluckExtension.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Larastan\Larastan\ReturnTypes;
+
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use Larastan\Larastan\Support\PluckHelper;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\Type;
+
+final class EloquentBuilderPluckExtension implements DynamicMethodReturnTypeExtension
+{
+    public function __construct(private PluckHelper $pluckHelper)
+    {
+    }
+
+    public function getClass(): string
+    {
+        return EloquentBuilder::class;
+    }
+
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return $methodReflection->getName() === 'pluck';
+    }
+
+    public function getTypeFromMethodCall(
+        MethodReflection $methodReflection,
+        MethodCall $methodCall,
+        Scope $scope,
+    ): Type|null {
+        $valueArg = $methodCall->getArg('column', 0);
+        $keyArg   = $methodCall->getArg('key', 1);
+
+        if ($valueArg === null) {
+            return null;
+        }
+
+        $from = $scope->getType($methodCall->var)->getTemplateType(EloquentBuilder::class, 'TModel');
+
+        return $this->pluckHelper->getCollectionType($from, $valueArg, $keyArg, $scope);
+    }
+}

--- a/src/ReturnTypes/EnumerablePluckExtension.php
+++ b/src/ReturnTypes/EnumerablePluckExtension.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Larastan\Larastan\ReturnTypes;
+
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Support\Enumerable;
+use Larastan\Larastan\Support\PluckHelper;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+
+final class EnumerablePluckExtension implements DynamicMethodReturnTypeExtension
+{
+    public function __construct(private PluckHelper $pluckHelper)
+    {
+    }
+
+    public function getClass(): string
+    {
+        return Enumerable::class;
+    }
+
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return $methodReflection->getName() === 'pluck';
+    }
+
+    public function getTypeFromMethodCall(
+        MethodReflection $methodReflection,
+        MethodCall $methodCall,
+        Scope $scope,
+    ): Type|null {
+        $calledOnType    = $scope->getType($methodCall->var);
+        $collectionClass = null;
+        $valueArg        = $methodCall->getArg('value', 0);
+        $keyArg          = $methodCall->getArg('key', 1);
+
+        if ($valueArg === null) {
+            return null;
+        }
+
+        if ((new ObjectType(EloquentCollection::class))->isSuperTypeOf($calledOnType)->no()) {
+            $collectionClass = $calledOnType->getObjectClassNames()[0] ?? null;
+        }
+
+        $from = $calledOnType->getTemplateType(Enumerable::class, 'TValue');
+
+        return $this->pluckHelper->getCollectionType($from, $valueArg, $keyArg, $scope, $collectionClass);
+    }
+}

--- a/src/Support/PluckHelper.php
+++ b/src/Support/PluckHelper.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Larastan\Larastan\Support;
+
+use Illuminate\Support\Collection;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
+use PHPStan\Analyser\MutatingScope;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\Native\NativeParameterReflection;
+use PHPStan\Reflection\PassedByReference;
+use PHPStan\Reflection\Php\DummyParameter;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\BenevolentUnionType;
+use PHPStan\Type\CallableType;
+use PHPStan\Type\ClosureType;
+use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\Generic\GenericObjectType;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\StringType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+use Throwable;
+
+use function array_filter;
+use function array_map;
+use function collect;
+use function explode;
+
+/** @internal */
+final class PluckHelper
+{
+    public function getArrayType(
+        Type $from,
+        Arg $valueArg,
+        Arg|null $keyArg,
+        Scope $scope,
+    ): ArrayType {
+        $valueType = $this->getTypeFromArg($from, $valueArg, $scope);
+        $keyType   = $keyArg === null ? new IntegerType() : $this->getTypeFromArg($from, $keyArg, $scope);
+
+        $keyType   ??= new BenevolentUnionType([new IntegerType(), new StringType()]);
+        $valueType ??= new MixedType();
+
+        return new ArrayType($keyType, $valueType);
+    }
+
+    public function getCollectionType(
+        Type $from,
+        Arg $valueArg,
+        Arg|null $keyArg,
+        Scope $scope,
+        string|null $collectionClass = null,
+    ): GenericObjectType {
+        $type = $this->getArrayType($from, $valueArg, $keyArg, $scope);
+
+        return new GenericObjectType(
+            $collectionClass ?? Collection::class,
+            [$type->getKeyType(), $type->getItemType()],
+        );
+    }
+
+    private function getTypeFromArg(Type $from, Arg $arg, Scope $scope): Type|null
+    {
+        $type = $scope->getType($arg->value);
+
+        if ($type->isCallable()->yes()) {
+            return $this->getTypeFromCallable($arg->value, $from, $scope);
+        }
+
+        $values = $this->getKeysFromType($type);
+
+        if ($values === []) {
+            return null;
+        }
+
+        $types = array_filter(array_map(
+            fn ($key) => $this->pluckFromType($from, $key, $scope),
+            $values,
+        ));
+
+        return TypeCombinator::union(...$types);
+    }
+
+    private function getTypeFromCallable(Expr $callable, Type $parameterType, Scope $scope): Type|null
+    {
+        /** @phpstan-ignore phpstanApi.class */
+        if (! $scope instanceof MutatingScope) {
+            return null;
+        }
+
+        /** @phpstan-ignore phpstanApi.method, phpstanApi.constructor */
+        $scopeWithContext = $scope->pushInFunctionCall(null, new DummyParameter(
+            'callback',
+            new CallableType([
+                /** @phpstan-ignore phpstanApi.constructor */
+                new NativeParameterReflection(
+                    'param',
+                    false,
+                    $parameterType,
+                    PassedByReference::createNo(),
+                    false,
+                    null,
+                ),
+            ], new MixedType()),
+            false,
+            PassedByReference::createNo(),
+            false,
+            null,
+        ));
+
+        $callableType = $scopeWithContext->getType($callable);
+
+        if ($callableType instanceof ClosureType) {
+            return $callableType->getReturnType();
+        }
+
+        return null;
+    }
+
+    /** @return array<int, array<int, string>> */
+    private function getKeysFromType(Type $type): array
+    {
+        if ($type->isConstantArray()->yes()) {
+            return collect($type->getConstantArrays())
+                ->map(
+                    static fn ($a) => collect($a->getValueTypes())
+                        ->map(static fn ($t) => $t->getConstantStrings()[0] ?? null)
+                        ->filter()
+                        ->map(static fn ($s) => $s->getValue())
+                        ->all() ?: null,
+                )
+                ->filter()
+                ->all();
+        }
+
+        return collect($type->getConstantStrings())
+            ->map(static fn ($s) => explode('.', $s->getValue()))
+            ->all();
+    }
+
+    /** @param array<int, string> $keys */
+    private function pluckFromType(Type $from, array $keys, Scope $scope): Type|null
+    {
+        if ($keys === []) {
+            return null;
+        }
+
+        foreach ($keys as $key) {
+            if (! $from->hasProperty($key)->no()) {
+                try {
+                    $from = $from->getProperty($key, $scope)->getReadableType();
+
+                    continue;
+                } catch (Throwable) {
+                }
+            }
+
+            $keyType = new ConstantStringType($key);
+
+            if (! $from->hasOffsetValueType($keyType)->no()) {
+                try {
+                    $from = $from->getOffsetValueType($keyType);
+
+                    continue;
+                } catch (Throwable) {
+                }
+            }
+
+            return null;
+        }
+
+        return $from;
+    }
+}

--- a/stubs/12.20.0/Arr.stub
+++ b/stubs/12.20.0/Arr.stub
@@ -1,0 +1,19 @@
+<?php
+
+namespace Illuminate\Support;
+
+class Arr
+{
+   /**
+    * Pluck an array of values from an array.
+    *
+    * @template TValue
+    * @template TPluckValueReturn = mixed
+    * @template TPluckKeyReturn of array-key = array-key
+    * @param  iterable<TValue>  $array
+    * @param  string|array<array-key, string>|(\Closure(TValue): TPluckValueReturn)|null  $value
+    * @param  string|array<array-key, string>|(\Closure(TValue): TPluckKeyReturn)|null  $key
+    * @return array<TPluckKeyReturn, TPluckValueReturn>
+    */
+   public function pluck($array, $value, $key = null);
+}

--- a/stubs/12.20.0/Enumerable.stub
+++ b/stubs/12.20.0/Enumerable.stub
@@ -49,13 +49,13 @@ interface Enumerable extends \Countable, \IteratorAggregate, \JsonSerializable, 
    public function chunkWhile(callable $callback);
 
    /**
-    * Get an array with the values of a given key.
+    * Get the values of a given key.
     *
-    * @template TPluckValueReturn
-    * @template TPluckKeyReturn of array-key
+    * @template TPluckValueReturn = mixed
+    * @template TPluckKeyReturn of array-key = array-key
     * @param  string|array<array-key, string>|(\Closure(TValue): TPluckValueReturn)|null  $value
-    * @param  string|(\Closure(TValue): TPluckKeyReturn)|null  $key
-    * @return ($value is \Closure ? ($key is \Closure ? \Illuminate\Support\Collection<TPluckKeyReturn, TPluckValueReturn> : \Illuminate\Support\Collection<array-key, TPluckValueReturn>) : ($key is \Closure ? \Illuminate\Support\Collection<TPluckKeyReturn, mixed> : \Illuminate\Support\Collection<array-key, mixed>))
+    * @param  string|array<array-key, string>|(\Closure(TValue): TPluckKeyReturn)|null  $key
+    * @return static<TPluckKeyReturn, TPluckValueReturn>
     */
    public function pluck($value, $key = null);
 }

--- a/tests/Type/GeneralTypeTest.php
+++ b/tests/Type/GeneralTypeTest.php
@@ -18,6 +18,7 @@ class GeneralTypeTest extends TypeInferenceTestCase
         yield from self::gatherAssertTypes(__DIR__ . '/data/abstract-manager.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/app-make.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/application-make.php');
+        yield from self::gatherAssertTypes(__DIR__ . '/data/arr-pluck.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/auth.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/benchmark.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/bug-1346.php');
@@ -42,7 +43,9 @@ class GeneralTypeTest extends TypeInferenceTestCase
             yield from self::gatherAssertTypes(__DIR__ . '/data/date-extension-l11.php');
         }
 
+        yield from self::gatherAssertTypes(__DIR__ . '/data/eloquent-builder-pluck.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/environment-helper.php');
+        yield from self::gatherAssertTypes(__DIR__ . '/data/enumerable-pluck.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/facades.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/form-request.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/gate-facade.php');
@@ -98,7 +101,9 @@ class GeneralTypeTest extends TypeInferenceTestCase
         }
 
         if (laravel_version_compare('12.20.0', '>=')) {
+            yield from self::gatherAssertTypes(__DIR__ . '/data/arr-pluck-l12-20.php');
             yield from self::gatherAssertTypes(__DIR__ . '/data/facades-l12-20.php');
+            yield from self::gatherAssertTypes(__DIR__ . '/data/collection-stubs-l12-20.php');
         }
 
         //##############################################################################################################

--- a/tests/Type/data/arr-pluck-l12-20.php
+++ b/tests/Type/data/arr-pluck-l12-20.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EloquentBuilderPluck;
+
+use App\User;
+use Illuminate\Support\Arr;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * @param  array<int, array{id: int, name: string}>  $array
+ * @param  iterable<array{user: array{id: int, name: string}}>  $iterable
+ * @param  list<array{user: User}>  $list
+ */
+function test(
+    array $array,
+    iterable $iterable,
+    array $list,
+): void {
+    assertType('array<int, string>', Arr::pluck($array, 'name'));
+    assertType('array<string, string>', Arr::pluck($array, 'name', 'name'));
+    assertType('array<int, string>', Arr::pluck($array, function ($l) {
+        assertType('array{id: int, name: string}', $l);
+        assertType('string', $l['name']);
+
+        return $l['name'];
+    }));
+    assertType('array<int, string>', Arr::pluck($array, fn ($l) => $l['name']));
+    assertType('array<string, string>', Arr::pluck($array, fn ($l) => $l['name'], fn ($l) => $l['name']));
+
+    assertType('array<int, string>', Arr::pluck($iterable, 'user.name'));
+    assertType('array<string, string>', Arr::pluck($iterable, 'user.name', 'user.name'));
+    assertType('array<int, string>', Arr::pluck($iterable, function ($l) {
+        assertType('array{user: array{id: int, name: string}}', $l);
+
+        return $l['user']['name'];
+    }));
+    assertType('array<string, string>', Arr::pluck($iterable, fn ($l) => $l['user']['name'], fn ($l) => $l['user']['name']));
+
+    assertType('array<int, string>', Arr::pluck($list, 'user.name'));
+    assertType('array<string, string>', Arr::pluck($list, 'user.name', 'user.name'));
+    assertType('array<int, string>', Arr::pluck($list, ['user', 'name']));
+    assertType('array<string, string>', Arr::pluck($list, ['user', 'name'], ['user', 'name']));
+    assertType('array<int, string>', Arr::pluck($list, function ($l) {
+        assertType('array{user: App\User}', $l);
+
+        return $l['user']->name;
+    }));
+    assertType('array<string, string>', Arr::pluck($list, fn ($l) => $l['user']->name, fn ($l) => $l['user']->name));
+}

--- a/tests/Type/data/arr-pluck.php
+++ b/tests/Type/data/arr-pluck.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EloquentBuilderPluck;
+
+use App\User;
+use Illuminate\Support\Arr;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * @param  array<int, array{id: int, name: string}>  $array
+ * @param  iterable<array{user: array{id: int, name: string}}>  $iterable
+ * @param  list<array{user: User}>  $list
+ */
+function test(
+    array $array,
+    iterable $iterable,
+    array $list,
+): void {
+    assertType('array<int, string>', Arr::pluck($array, 'name'));
+    assertType('array<string, string>', Arr::pluck($array, 'name', 'name'));
+
+    assertType('array<int, string>', Arr::pluck($iterable, 'user.name'));
+    assertType('array<string, string>', Arr::pluck($iterable, 'user.name', 'user.name'));
+
+    assertType('array<int, string>', Arr::pluck($list, 'user.name'));
+    assertType('array<string, string>', Arr::pluck($list, 'user.name', 'user.name'));
+    assertType('array<int, string>', Arr::pluck($list, ['user', 'name']));
+    assertType('array<string, string>', Arr::pluck($list, ['user', 'name'], ['user', 'name']));
+}

--- a/tests/Type/data/collection-filter.php
+++ b/tests/Type/data/collection-filter.php
@@ -64,5 +64,5 @@ function test(User $user, SupportCollection $users, SupportCollection $mixedColl
         assertType('App\Account', $account);
     });
 
-    assertType("Illuminate\Support\Collection<(int|string), mixed~(0|0.0|''|'0'|array{}|false|null)>", $mixedCollection->pluck('foo')->filter());
+    assertType("Illuminate\Support\Collection<int, mixed~(0|0.0|''|'0'|array{}|false|null)>", $mixedCollection->pluck('foo')->filter());
 }

--- a/tests/Type/data/collection-generic-static-methods.php
+++ b/tests/Type/data/collection-generic-static-methods.php
@@ -69,8 +69,8 @@ function test(
     assertType('Illuminate\Support\Collection<int, int>', $collection->keys());
     assertType('Illuminate\Support\Collection<int, string>', $items->keys());
 
-    assertType('Illuminate\Support\Collection<(int|string), mixed>', $collection->pluck(['email']));
-    assertType('Illuminate\Support\Collection<(int|string), mixed>', $items->pluck('1'));
+    assertType('Illuminate\Support\Collection<int, string>', $collection->pluck(['email']));
+    assertType('Illuminate\Support\Collection<int, mixed>', $items->pluck('foo'));
 
     assertType('Illuminate\Support\Collection<int, int>', $customEloquentCollection->map(fn (Transaction $transaction): int => $transaction->id));
     assertType('Illuminate\Support\Collection<int, int>', $secondCustomEloquentCollection->map(fn (User $user): int => $user->id));

--- a/tests/Type/data/collection-stubs-l12-20.php
+++ b/tests/Type/data/collection-stubs-l12-20.php
@@ -7,7 +7,7 @@ use function PHPStan\Testing\assertType;
 
 function test(): void
 {
-    assertType('Illuminate\Support\Collection<(int|string), non-falsy-string>', User::get()->pluck(fn (User $user) => "$user->id - $user->email", 'id'));
-    assertType('Illuminate\Support\Collection<string, mixed>', User::get()->pluck('id', fn (User $user) => "$user->id - $user->email"));
-    assertType('Illuminate\Support\Collection<string, string>', User::get()->pluck(fn (User $user) => $user->email, fn (User $user) => "$user->id - $user->email"));
+    assertType('Illuminate\Support\Collection<int, non-falsy-string>', User::get()->pluck(fn (User $user) => "$user->id - $user->email", 'id'));
+    assertType('Illuminate\Support\Collection<non-falsy-string, int>', User::get()->pluck('id', fn (User $user) => "$user->id - $user->email"));
+    assertType('Illuminate\Support\Collection<non-falsy-string, string>', User::get()->pluck(fn (User $user) => $user->email, fn (User $user) => "$user->id - $user->email"));
 }

--- a/tests/Type/data/collection-stubs.php
+++ b/tests/Type/data/collection-stubs.php
@@ -36,7 +36,7 @@ function test(
     assertType('App\User|null', $collection->find(1));
     assertType('App\User|false', $collection->find(1, false));
 
-    assertType('Illuminate\Support\Collection<(int|string), mixed>', $collection->pluck('id'));
+    assertType('Illuminate\Support\Collection<int, int>', $collection->pluck('id'));
 
     assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', User::all()->mapInto(User::class));
     assertType('Illuminate\Database\Eloquent\Collection<int, App\User>', $collection->flatMap(function (User $user, int $id): array {

--- a/tests/Type/data/eloquent-builder-l11-42.php
+++ b/tests/Type/data/eloquent-builder-l11-42.php
@@ -277,7 +277,7 @@ function test(
         ->oldest(\Illuminate\Support\Facades\DB::raw('created_at'))
         ->toBase()
     );
-    assertType('Illuminate\Support\Collection<(int|string), mixed>', User::query()
+    assertType('Illuminate\Support\Collection<int, mixed>', User::query()
         ->whereNull('name')
         ->pluck(\Illuminate\Support\Facades\DB::raw('created_at'))
         ->toBase()

--- a/tests/Type/data/eloquent-builder-pluck.php
+++ b/tests/Type/data/eloquent-builder-pluck.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EloquentBuilderPluck;
+
+use App\User;
+use Illuminate\Database\Eloquent\Builder;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * @param Builder<User> $users
+ */
+function test(Builder $users): void {
+    assertType('Illuminate\Support\Collection<int, string>', $users->pluck('name'));
+    assertType('Illuminate\Support\Collection<string, string>', $users->pluck('name', 'name'));
+}

--- a/tests/Type/data/eloquent-builder.php
+++ b/tests/Type/data/eloquent-builder.php
@@ -277,7 +277,7 @@ function test(
         ->oldest(\Illuminate\Support\Facades\DB::raw('created_at'))
         ->toBase()
     );
-    assertType('Illuminate\Support\Collection<(int|string), mixed>', User::query()
+    assertType('Illuminate\Support\Collection<int, mixed>', User::query()
         ->whereNull('name')
         ->pluck(\Illuminate\Support\Facades\DB::raw('created_at'))
         ->toBase()

--- a/tests/Type/data/enumerable-pluck.php
+++ b/tests/Type/data/enumerable-pluck.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EloquentBuilderPluck;
+
+use App\Post;
+use App\User;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Support\Collection;
+use Illuminate\Support\LazyCollection;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * @param  EloquentCollection<int, User>  $users
+ * @param  Collection<int, array{user: array{id: int, name: string}}>  $arrays
+ * @param  EloquentCollection<int, Post>  $posts
+ * @param  LazyCollection<int, User>  $lazyUsers
+ */
+function test(
+    EloquentCollection $users,
+    Collection $arrays,
+    EloquentCollection $posts,
+    LazyCollection $lazyUsers,
+): void {
+    assertType('Illuminate\Support\Collection<int, string>', $users->pluck('name'));
+    assertType('Illuminate\Support\Collection<string, string>', $users->pluck('name', 'name'));
+
+    assertType('Illuminate\Support\Collection<int, string>', $arrays->pluck('user.name'));
+    assertType('Illuminate\Support\Collection<string, string>', $arrays->pluck('user.name', 'user.name'));
+
+    assertType('Illuminate\Support\Collection<int, string>', $users->pluck(fn ($u) => $u->name));
+    assertType('Illuminate\Support\Collection<string, string>', $users->pluck(fn ($u) => $u->name, fn ($u) => $u->name));
+    assertType('Illuminate\Support\Collection<string, string>', $users->pluck(function ($u) { return $u->name; }, function ($u) { return $u->name; }));
+
+    assertType('Illuminate\Support\Collection<int, string>', $posts->pluck('user.name'));
+    assertType('Illuminate\Support\Collection<string, string>', $posts->pluck('user.name', 'user.name'));
+    assertType('Illuminate\Support\Collection<int, string>', $posts->pluck(['user', 'name']));
+    assertType('Illuminate\Support\Collection<string, string>', $posts->pluck(['user', 'name'], ['user', 'name']));
+
+    assertType('Illuminate\Support\LazyCollection<int, string>', $lazyUsers->pluck('name'));
+    assertType('Illuminate\Support\LazyCollection<string, string>', $lazyUsers->pluck('name', 'name'));
+}


### PR DESCRIPTION
Hello!

This adds `pluck` support to the Collection, Builder, and Arr classes:

```php
// before
User::pluck('name', 'id');        // Collection<(int|string), mixed>
User::all()->pluck('name', 'id'); // Collection<(int|string), mixed>
Arr::pluck($users, 'name', 'id'); // array<int, User> INCORRECT!

// after
User::pluck('name', 'id');        // Collection<int, string>
User::all()->pluck('name', 'id'); // Collection<int, string>
Arr::pluck($users, 'name', 'id'); // array<int, string>
```

Thanks!