### PR TITLE
[3.x] Add Collection::select() type stub

### DIFF
--- a/stubs/common/Collection.stub
+++ b/stubs/common/Collection.stub
@@ -76,6 +76,14 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * @return static<($keyBy is string ? array-key : ($keyBy is array ? array-key : TNewKey)), TValue>
      */
     public function keyBy($keyBy);
+
+    /**
+     * Select specific values from the items within the collection.
+     *
+     * @param  \Illuminate\Support\Enumerable<array-key, array-key>|array<array-key, array-key>|string|null  $keys
+     * @return static
+     */
+    public function select($keys);
 }
 
 /**
@@ -100,4 +108,12 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * @return static<array-key, TCombineValue>
      */
     public function combine($values);
+
+    /**
+     * Select specific values from the items within the collection.
+     *
+     * @param  \Illuminate\Support\Enumerable<array-key, array-key>|array<array-key, array-key>|string|null  $keys
+     * @return static
+     */
+    public function select($keys);
 }

--- a/tests/Type/CollectionDynamicReturnTypeExtensionTest.php
+++ b/tests/Type/CollectionDynamicReturnTypeExtensionTest.php
@@ -14,6 +14,7 @@ class CollectionDynamicReturnTypeExtensionTest extends TypeInferenceTestCase
     {
         yield from self::gatherAssertTypes(__DIR__ . '/data/collection-filter.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/collection-reject.php');
+        yield from self::gatherAssertTypes(__DIR__ . '/data/collection-select.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/collection-where-not-null.php');
     }
 

--- a/tests/Type/data/collection-select.php
+++ b/tests/Type/data/collection-select.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace CollectionSelect;
+
+use function PHPStan\Testing\assertType;
+
+function test(): void
+{
+    $users = collect([
+        ['name' => 'Taylor Otwell', 'role' => 'Developer', 'status' => 'active'],
+        ['name' => 'Neil Carlo Sucuangco', 'role' => 'Researcher', 'status' => 'active'],
+    ]);
+
+    assertType('Illuminate\Support\Collection<int, array{name: string, role: string, status: string}>', $users);
+    assertType('Illuminate\Support\Collection<int, array{name: string, role: string, status: string}>', $users->select(['name', 'role']));
+
+    assertType('Illuminate\Support\Collection<int, array{name: string, role: string, status: string}>', $users->select('name'));
+
+    assertType('Illuminate\Support\Collection<int, array{name: string, role: string, status: string}>', $users->select(null));
+
+    $numbers = collect([
+        [0 => 'a', 1 => 'b', 2 => 'c'],
+        [0 => 'd', 1 => 'e', 2 => 'f'],
+    ]);
+
+    assertType('Illuminate\Support\Collection<int, array{string, string, string}>', $numbers);
+    assertType('Illuminate\Support\Collection<int, array{string, string, string}>', $numbers->select([0, 2]));
+
+    $mixed = collect([
+        [0 => 'a', 'name' => 'John', 'age' => 30],
+        [0 => 'b', 'name' => 'Jane', 'age' => 25],
+    ]);
+
+    assertType('Illuminate\Support\Collection<int, array{0: string, name: string, age: int}>', $mixed);
+    assertType('Illuminate\Support\Collection<int, array{0: string, name: string, age: int}>', $mixed->select([0, 'name']));
+
+    $keys = collect(['name', 'role']);
+    assertType('Illuminate\Support\Collection<int, array{name: string, role: string, status: string}>', $users->select($keys));
+}
+


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes

Resolves #2385

**Changes**

Adds missing type stubs for the `Collection::select()` and `LazyCollection::select()` methods to fix incorrect PHPStan type inference reported in [#2385](https://github.com/larastan/larastan/issues/2385).