### PR TITLE
fix: mark macro methods as static only if the closure is static

### DIFF
--- a/e2e/filamentphp-filament.baseline.neon
+++ b/e2e/filamentphp-filament.baseline.neon
@@ -1,151 +1,25 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			message: '#^Static call to instance method Illuminate\\Support\\Str\:\:sanitizeHtml\(\)\.$#'
+			identifier: method.staticCall
 			count: 1
-			path: ../../e2e/packages/actions/src/Commands/MakeExporterCommand.php
+			path: ../../e2e/packages/forms/src/Components/RichEditor/RichContentRenderer.php
 
 		-
-			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			message: '#^Static call to instance method Illuminate\\Support\\Str\:\:sanitizeHtml\(\)\.$#'
+			identifier: method.staticCall
 			count: 1
-			path: ../../e2e/packages/actions/src/Commands/MakeImporterCommand.php
+			path: ../../e2e/packages/infolists/src/Components/TextEntry.php
 
 		-
-			message: "#^Parameter \\#1 \\$related of method Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:belongsTo\\(\\) expects class\\-string\\<Illuminate\\\\Database\\\\Eloquent\\\\Model\\>, string given\\.$#"
+			message: '#^Static call to instance method Illuminate\\Support\\Str\:\:sanitizeHtml\(\)\.$#'
+			identifier: method.staticCall
 			count: 1
-			path: ../../e2e/packages/actions/src/Exports/Models/Export.php
+			path: ../../e2e/packages/tables/src/Columns/Summarizers/Summarizer.php
 
 		-
-			message: "#^Unable to resolve the template type TRelatedModel in call to method Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:belongsTo\\(\\)$#"
-			count: 2
-			path: ../../e2e/packages/actions/src/Exports/Models/Export.php
-
-		-
-			message: "#^Parameter \\#1 \\$related of method Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:belongsTo\\(\\) expects class\\-string\\<Illuminate\\\\Database\\\\Eloquent\\\\Model\\>, string given\\.$#"
+			message: '#^Static call to instance method Illuminate\\Support\\Str\:\:sanitizeHtml\(\)\.$#'
+			identifier: method.staticCall
 			count: 1
-			path: ../../e2e/packages/actions/src/Imports/Models/Import.php
-
-		-
-			message: "#^Unable to resolve the template type TRelatedModel in call to method Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:belongsTo\\(\\)$#"
-			count: 2
-			path: ../../e2e/packages/actions/src/Imports/Models/Import.php
-
-		-
-			message: "#^Access to an undefined property Filament\\\\Actions\\\\Contracts\\\\HasActions\\:\\:\\$mountedActions\\.$#"
-			count: 2
-			path: ../../e2e/packages/actions/src/Testing/TestsActions.php
-
-		-
-			message: "#^Access to an undefined property Filament\\\\Actions\\\\Contracts\\\\HasActions\\:\\:\\$mountedActionsData\\.$#"
-			count: 6
-			path: ../../e2e/packages/actions/src/Testing/TestsActions.php
-
-		-
-			message: "#^Call to an undefined method Filament\\\\Actions\\\\Contracts\\\\HasActions\\:\\:getId\\(\\)\\.$#"
-			count: 2
-			path: ../../e2e/packages/actions/src/Testing/TestsActions.php
-
-		-
-			message: "#^Call to an undefined method Filament\\\\Actions\\\\Contracts\\\\HasActions\\:\\:getMountedAction\\(\\)\\.$#"
-			count: 2
-			path: ../../e2e/packages/actions/src/Testing/TestsActions.php
-
-		-
-			message: "#^Unreachable statement \\- code above always terminates\\.$#"
-			count: 1
-			path: ../../e2e/packages/forms/src/Commands/MakeFormCommand.php
-
-		-
-			message: "#^Parameter \\#2 \\$callback of method Illuminate\\\\Support\\\\Collection\\<string,float\\|string\\|true\\>\\:\\:when\\(\\) expects \\(callable\\(Illuminate\\\\Support\\\\Collection\\<string, float\\|string\\|true\\>, bool\\)\\: Illuminate\\\\Support\\\\Collection\\<string, bool\\|float\\|string\\>\\)\\|null, Closure\\(Illuminate\\\\Support\\\\Collection\\)\\: Illuminate\\\\Support\\\\Collection\\<string, float\\|string\\|true\\> given\\.$#"
-			count: 1
-			path: ../../e2e/packages/forms/src/Components/FileUpload.php
-
-		-
-			message: "#^Access to an undefined property Filament\\\\Forms\\\\Contracts\\\\HasForms\\:\\:\\$mountedFormComponentActions\\.$#"
-			count: 2
-			path: ../../e2e/packages/forms/src/Testing/TestsComponentActions.php
-
-		-
-			message: "#^Access to an undefined property Filament\\\\Forms\\\\Contracts\\\\HasForms\\:\\:\\$mountedFormComponentActionsData\\.$#"
-			count: 6
-			path: ../../e2e/packages/forms/src/Testing/TestsComponentActions.php
-
-		-
-			message: "#^Call to an undefined method Filament\\\\Forms\\\\Contracts\\\\HasForms\\:\\:getCachedForms\\(\\)\\.$#"
-			count: 1
-			path: ../../e2e/packages/forms/src/Testing/TestsComponentActions.php
-
-		-
-			message: "#^Call to an undefined method Filament\\\\Forms\\\\Contracts\\\\HasForms\\:\\:getId\\(\\)\\.$#"
-			count: 2
-			path: ../../e2e/packages/forms/src/Testing/TestsComponentActions.php
-
-		-
-			message: "#^Call to an undefined method Filament\\\\Forms\\\\Contracts\\\\HasForms\\:\\:getMountedFormComponentAction\\(\\)\\.$#"
-			count: 2
-			path: ../../e2e/packages/forms/src/Testing/TestsComponentActions.php
-
-		-
-			message: "#^Access to an undefined property Filament\\\\Infolists\\\\Contracts\\\\HasInfolists\\:\\:\\$mountedInfolistActions\\.$#"
-			count: 2
-			path: ../../e2e/packages/infolists/src/Testing/TestsActions.php
-
-		-
-			message: "#^Access to an undefined property Filament\\\\Infolists\\\\Contracts\\\\HasInfolists\\:\\:\\$mountedInfolistActionsData\\.$#"
-			count: 6
-			path: ../../e2e/packages/infolists/src/Testing/TestsActions.php
-
-		-
-			message: "#^Call to an undefined method Filament\\\\Infolists\\\\Contracts\\\\HasInfolists\\:\\:getId\\(\\)\\.$#"
-			count: 2
-			path: ../../e2e/packages/infolists/src/Testing/TestsActions.php
-
-		-
-			message: "#^Call to an undefined method Filament\\\\Infolists\\\\Contracts\\\\HasInfolists\\:\\:getMountedInfolistAction\\(\\)\\.$#"
-			count: 2
-			path: ../../e2e/packages/infolists/src/Testing/TestsActions.php
-
-		-
-			message: "#^Unreachable statement \\- code above always terminates\\.$#"
-			count: 1
-			path: ../../e2e/packages/panels/src/Commands/MakeResourceCommand.php
-
-		-
-			message: "#^Unable to resolve the template type TMapValue in call to method Illuminate\\\\Support\\\\Collection\\<\\(int\\|string\\),string\\>\\:\\:map\\(\\)$#"
-			count: 1
-			path: ../../e2e/packages/spatie-laravel-tags-plugin/src/Forms/Components/SpatieTagsInput.php
-
-		-
-			message: "#^Access to an undefined property Filament\\\\Tables\\\\Contracts\\\\HasTable\\:\\:\\$mountedTableActions\\.$#"
-			count: 2
-			path: ../../e2e/packages/tables/src/Testing/TestsActions.php
-
-		-
-			message: "#^Access to an undefined property Filament\\\\Tables\\\\Contracts\\\\HasTable\\:\\:\\$mountedTableActionsData\\.$#"
-			count: 6
-			path: ../../e2e/packages/tables/src/Testing/TestsActions.php
-
-		-
-			message: "#^Call to an undefined method Filament\\\\Tables\\\\Contracts\\\\HasTable\\:\\:getId\\(\\)\\.$#"
-			count: 2
-			path: ../../e2e/packages/tables/src/Testing/TestsActions.php
-
-		-
-			message: "#^Access to an undefined property Filament\\\\Tables\\\\Contracts\\\\HasTable\\:\\:\\$mountedTableBulkAction\\.$#"
-			count: 1
-			path: ../../e2e/packages/tables/src/Testing/TestsBulkActions.php
-
-		-
-			message: "#^Call to an undefined method Filament\\\\Tables\\\\Contracts\\\\HasTable\\:\\:getId\\(\\)\\.$#"
-			count: 2
-			path: ../../e2e/packages/tables/src/Testing/TestsBulkActions.php
-
-		-
-			message: "#^Call to an undefined method Filament\\\\Tables\\\\Contracts\\\\HasTable\\:\\:getId\\(\\)\\.$#"
-			count: 2
-			path: ../../e2e/packages/tables/src/Testing/TestsColumns.php
-
-		-
-			message: "#^Call to an undefined method Filament\\\\Tables\\\\Contracts\\\\HasTable\\:\\:getId\\(\\)\\.$#"
-			count: 2
-			path: ../../e2e/packages/tables/src/Testing/TestsRecords.php
+			path: ../../e2e/packages/tables/src/Columns/TextColumn.php

--- a/e2e/monicahq-monica.baseline.neon
+++ b/e2e/monicahq-monica.baseline.neon
@@ -1,16 +1,7 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Parameter \\#1 \\$address of static method App\\\\Helpers\\\\MapHelper\\:\\:getMapLink\\(\\) expects App\\\\Models\\\\Address, Illuminate\\\\Database\\\\Eloquent\\\\Model given\\.$#"
+			message: '#^Static call to instance method Illuminate\\Support\\Str\:\:markdownExternalLink\(\)\.$#'
+			identifier: method.staticCall
 			count: 1
-			path: ../../e2e/app/Domains/Contact/ManageContactFeed/Web/ViewHelpers/Actions/ActionFeedAddress.php
-
-		-
-			message: "#^Call to an undefined method Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\HasMany\\<App\\\\Models\\\\Contact, App\\\\Models\\\\Vault\\>\\:\\:unsearchable\\(\\)\\.$#"
-			count: 1
-			path: ../../e2e/app/Models/Vault.php
-
-		-
-			message: "#^Call to an undefined method Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\HasMany\\<App\\\\Models\\\\Note, App\\\\Models\\\\Contact\\>\\:\\:unsearchable\\(\\)\\.$#"
-			count: 1
-			path: ../../e2e/app/Models/Vault.php
+			path: ../../e2e/app/Http/Middleware/HandleInertiaRequests.php

--- a/extension.neon
+++ b/extension.neon
@@ -666,6 +666,11 @@ services:
             - phpstan.broker.dynamicMethodReturnTypeExtension
 
     -
+        class: Larastan\Larastan\Ignore\FacadeStaticCallIgnoreExtension
+        tags:
+            - phpstan.ignoreErrorExtension
+
+    -
         class: Larastan\Larastan\Rules\NoAuthFacadeInRequestScopeRule
 
     -

--- a/src/Ignore/FacadeStaticCallIgnoreExtension.php
+++ b/src/Ignore/FacadeStaticCallIgnoreExtension.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Larastan\Larastan\Ignore;
+
+use Illuminate\Support\Facades\Facade;
+use PhpParser\Node;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PHPStan\Analyser\Error;
+use PHPStan\Analyser\IgnoreErrorExtension;
+use PHPStan\Analyser\Scope;
+use PHPStan\Type\ObjectType;
+
+final class FacadeStaticCallIgnoreExtension implements IgnoreErrorExtension
+{
+    public function shouldIgnore(Error $error, Node $node, Scope $scope): bool
+    {
+        if ($error->getIdentifier() !== 'method.staticCall') {
+            return false;
+        }
+
+        if (
+            ! $node instanceof StaticCall
+            || ! $node->name instanceof Identifier
+        ) {
+            return false;
+        }
+
+        $type = $node->class instanceof Name
+            ? $scope->resolveTypeByName($node->class)
+            : $scope->getType($node->class);
+
+        if (! (new ObjectType(Facade::class))->isSuperTypeOf($type)->yes()) {
+            return false;
+        }
+
+        $method = $node->name->toString();
+
+        foreach ($type->getObjectClassReflections() as $classReflection) {
+            if ($classReflection->hasNativeMethod($method)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Methods/Macro.php
+++ b/src/Methods/Macro.php
@@ -20,11 +20,6 @@ use function array_key_exists;
 final class Macro implements MethodReflection
 {
     /**
-     * The is static.
-     */
-    private bool $isStatic = false;
-
-    /**
      * Map of macro methods and thrown exception classes.
      *
      * @var string[]
@@ -34,7 +29,7 @@ final class Macro implements MethodReflection
         'validateWithBag' => ValidationException::class,
     ];
 
-    public function __construct(private ClassReflection $classReflection, private string $methodName, private ClosureType $closureType)
+    public function __construct(private ClassReflection $classReflection, private string $methodName, private ClosureType $closureType, private bool $isStatic = false)
     {
     }
 
@@ -66,14 +61,6 @@ final class Macro implements MethodReflection
     public function isStatic(): bool
     {
         return $this->isStatic;
-    }
-
-    /**
-     * Set the is static value.
-     */
-    public function setIsStatic(bool $isStatic): void
-    {
-        $this->isStatic = $isStatic;
     }
 
     public function getDocComment(): string|null

--- a/src/Methods/MacroMethodsClassReflectionExtension.php
+++ b/src/Methods/MacroMethodsClassReflectionExtension.php
@@ -25,6 +25,7 @@ use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\Type\ClosureTypeFactory;
 use ReflectionException;
+use ReflectionFunction;
 use Throwable;
 
 use function array_key_exists;
@@ -167,9 +168,9 @@ class MacroMethodsClassReflectionExtension implements MethodsClassReflectionExte
                         $macroClassReflection,
                         $methodName,
                         $this->closureTypeFactory->fromClosureObject($macroDefinition),
+                        /** @phpstan-ignore phpstanApi.runtimeReflection */
+                        (new ReflectionFunction($macroDefinition))->isStatic(),
                     );
-
-                    $methodReflection->setIsStatic(true);
                 }
 
                 $this->methods[$classReflection->getName() . '-' . $methodName] = $methodReflection;

--- a/tests/Integration/IntegrationTest.php
+++ b/tests/Integration/IntegrationTest.php
@@ -37,6 +37,7 @@ class IntegrationTest extends PHPStanTestCase
         yield [__DIR__ . '/data/model-factories.php'];
         yield [__DIR__ . '/data/blade-view.php'];
         yield [__DIR__ . '/data/helpers.php'];
+        yield [__DIR__ . '/data/facade-static-call.php', [9 => ['Static call to instance method App\Facades\Importer::facadeMethod().']]];
 
         yield [
             __DIR__ . '/data/model-property-builder.php',

--- a/tests/Integration/data/facade-static-call.php
+++ b/tests/Integration/data/facade-static-call.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace FacadeStaticCall;
+
+use App\Facades\Importer;
+
+Importer::foo();
+Importer::getKey();
+Importer::facadeMethod();

--- a/tests/application/app/Facades/Importer.php
+++ b/tests/application/app/Facades/Importer.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Facades;
+
+use App\Importer as Instance;
+use Illuminate\Support\Facades\Facade;
+use Illuminate\Support\Str;
+
+class Importer extends Facade
+{
+    protected static function getFacadeAccessor(): string
+    {
+        return Instance::class;
+    }
+
+    public function facadeMethod(): string
+    {
+        return Str::random(5);
+    }
+}

--- a/tests/application/app/Importer.php
+++ b/tests/application/app/Importer.php
@@ -5,9 +5,12 @@ declare(strict_types=1);
 namespace App;
 
 use Illuminate\Support\Str;
+use Illuminate\Support\Traits\Macroable;
 
 class Importer
 {
+    use Macroable;
+
     /** @var bool */
     public $isImported;
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Importer;
 use Illuminate\Auth\RequestGuard;
 use Illuminate\Auth\SessionGuard;
 use Illuminate\Database\Eloquent\Builder;
@@ -35,6 +36,8 @@ Str::macro('asciiAliasMacro', Str::class . '::ascii');
 
 
 Cache::macro('rememberIf', static fn ($cond, $key, $ttl, $callback): mixed => $cond ? Cache::remember($key, $ttl, $callback) : $callback());
+
+Importer::macro('foo', fn () => $this);
 
 class CustomCollectionMacro
 {


### PR DESCRIPTION
Hello!

This resolves https://github.com/larastan/larastan/discussions/2397 by only marking macros as static if the closure is static. This allows the user to control whether they want the closure to act like a static or an instance method.

Additionally, this add an [ignoreError](https://phpstan.org/developing-extensions/ignore-error-extensions) extension to automatically ignore static calls on facades (that don't exist on the facade) as these are always instance methods

CC: @dansan92

Thanks!
