### PR TITLE
[3.x] Always check for Facade methods on their fake equivalent

### DIFF
--- a/src/Methods/Pipes/Facades.php
+++ b/src/Methods/Pipes/Facades.php
@@ -51,7 +51,7 @@ final class Facades implements PipeContract
                 }
             }
 
-            if (! $found && Str::startsWith($passable->getMethodName(), 'assert')) {
+            if (! $found) {
                 $fakeFacadeClass = $this->getFake($facadeClass);
 
                 if ($passable->getReflectionProvider()->hasClass($fakeFacadeClass)) {

--- a/src/Methods/Pipes/Facades.php
+++ b/src/Methods/Pipes/Facades.php
@@ -6,7 +6,6 @@ namespace Larastan\Larastan\Methods\Pipes;
 
 use Closure;
 use Illuminate\Support\Facades\Facade;
-use Illuminate\Support\Str;
 use Larastan\Larastan\Contracts\Methods\PassableContract;
 use Larastan\Larastan\Contracts\Methods\Pipes\PipeContract;
 use Larastan\Larastan\Reflection\ReflectionHelper;

--- a/tests/Type/data/facades.php
+++ b/tests/Type/data/facades.php
@@ -48,4 +48,6 @@ function test(): void
 
     assertType('string', DummyFacade::foo());
     assertType('int', DummyFacade::bar());
+
+    assertType('array', Queue::pushed());
 }

--- a/tests/Type/data/facades.php
+++ b/tests/Type/data/facades.php
@@ -49,5 +49,5 @@ function test(): void
     assertType('string', DummyFacade::foo());
     assertType('int', DummyFacade::bar());
 
-    assertType('array', Queue::pushed());
+    assertType('Illuminate\Support\Collection', Queue::pushed());
 }


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] ~~Documented user facing changes~~

**Changes**
There are numerous functions that exist on fakes which do not begin with assert, which leads to static analysis errors when using things like this:

```php
Queue::fake();
self::assertCount(0, Queue::pushed()); // ❌ method.notFound here
```

**Breaking changes**
Not sure there's any BC here, tho I would guess that this could slow down analysis. 
