### PR TITLE
fix: Add support for incrementQuietly() and decrementQuietly()

### DIFF
--- a/src/Methods/ModelForwardsCallsExtension.php
+++ b/src/Methods/ModelForwardsCallsExtension.php
@@ -77,7 +77,7 @@ final class ModelForwardsCallsExtension implements MethodsClassReflectionExtensi
 
         $builderName = $this->builderHelper->determineBuilderName($classReflection->getName());
 
-        if (in_array($methodName, ['increment', 'decrement'], true)) {
+        if (in_array($methodName, ['increment', 'decrement', 'incrementQuietly', 'decrementQuietly'], true)) {
             $methodReflection = $classReflection->getNativeMethod($methodName);
 
             return new class ($classReflection, $methodName, $methodReflection) implements MethodReflection

--- a/stubs/common/EloquentBuilder.stub
+++ b/stubs/common/EloquentBuilder.stub
@@ -439,6 +439,16 @@ class Builder
     public function increment($column, $amount = 1, array $extra = []);
 
     /**
+     * Increment a column's value by a given amount without raising any events.
+     *
+     * @param  model-property<TModel>|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @param  float|int  $amount
+     * @param  array<model-property<TModel>, mixed>  $extra
+     * @return int
+     */
+    public function incrementQuietly($column, $amount = 1, array $extra = []);
+
+    /**
      * Decrement a column's value by a given amount.
      *
      * @param  model-property<TModel>|\Illuminate\Contracts\Database\Query\Expression  $column
@@ -447,6 +457,16 @@ class Builder
      * @return int
      */
     public function decrement($column, $amount = 1, array $extra = []);
+
+    /**
+     * Decrement a column's value by a given amount without raising any events.
+     *
+     * @param  model-property<TModel>|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @param  float|int  $amount
+     * @param  array<model-property<TModel>, mixed>  $extra
+     * @return int
+     */
+    public function decrementQuietly($column, $amount = 1, array $extra = []);
 
     /**
      * Qualify the given column name by the model's table.

--- a/tests/Integration/data/model-builder.php
+++ b/tests/Integration/data/model-builder.php
@@ -43,5 +43,8 @@ function test(User|Account $userOrAccount): void
     Team::query()->where('name', 'Team A')->orderBy('name')->get();
 
     assertType('int', $userOrAccount->increment('counter'));
+    assertType('int', $userOrAccount->incrementQuietly('counter'));
+
     assertType('int', $userOrAccount->decrement('counter'));
+    assertType('int', $userOrAccount->decrementQuietly('counter'));
 }

--- a/tests/Type/data/model.php
+++ b/tests/Type/data/model.php
@@ -115,7 +115,9 @@ function test(
     }));
 
     assertType('int', $user->increment('counter'));
+    assertType('int', $user->incrementQuietly('counter'));
     assertType('int', $user->decrement('counter'));
+    assertType('int', $user->decrementQuietly('counter'));
 
     assertType('App\User|null', User::first());
     assertType('App\User', User::make([]));


### PR DESCRIPTION
Laravel exposes these methods via `Model::__call()` since [v10.14.0](https://github.com/laravel/framework/commit/42173c82a477ade12c9fc2acd6d586e39c370b45), but Larastan was reporting them as protected.
This update adds them to the forwarded model method handling in ModelForwardsCallsExtension, eliminating false positives in static analysis.

Fixes #2423