### PR TITLE
Fix retry helper function param type

### DIFF
--- a/stubs/common/Helpers.stub
+++ b/stubs/common/Helpers.stub
@@ -101,7 +101,7 @@ function rescue(callable $callback, $rescue = null, $report = true) {}
  * @param int|array<int, int> $times
  * @param callable(int): TValue $callback
  * @param int|callable(int, \Exception): int $sleepMilliseconds
- * @param null|callable(\Exception): bool $when
+ * @param null|callable(\Throwable): bool $when
  * @phpstan-return TValue
  *
  * @throws \Exception

--- a/tests/Integration/data/helpers.php
+++ b/tests/Integration/data/helpers.php
@@ -11,9 +11,9 @@ function retryAcceptsCallableAsSleepMilliseconds(): void
 {
     retry(5, function (int $attempt): bool {
         return false;
-    }, function (int $attempt, \Exception $e): int {
+    }, function (int $attempt, \Throwable $e): int {
         return 0;
-    }, function (\Exception $e): bool {
+    }, function (\Throwable $e): bool {
         return true;
     });
 }


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

Fixed the sleepMilliseconds param return type to match the laravel framework.
From 
` * @param int|callable(int, \Exception): int $sleepMilliseconds`
to
` * @param int|callable(int, \Throwable): int $sleepMilliseconds`

https://github.com/laravel/framework/blob/edefe15d3cfb121448be1dcac44d65c926e54156/src/Illuminate/Support/helpers.php#L306

**Breaking changes**
N/A
<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
