### PR TITLE
feat: add ResponseInterface mixin to Response stub

### DIFF
--- a/stubs/12.41.0/Http/PendingRequest.stub
+++ b/stubs/12.41.0/Http/PendingRequest.stub
@@ -91,6 +91,7 @@ namespace Illuminate\Http\Client
 
     /**
      * @implements \ArrayAccess<array-key, mixed>
+     * @mixin \Psr\Http\Message\ResponseInterface
      */
     class Response implements \ArrayAccess, \Stringable {}
 

--- a/stubs/common/Http/PendingRequest.stub
+++ b/stubs/common/Http/PendingRequest.stub
@@ -91,6 +91,7 @@ namespace Illuminate\Http\Client
 
     /**
      * @implements \ArrayAccess<array-key, mixed>
+     * @mixin \Psr\Http\Message\ResponseInterface
      */
     class Response implements \ArrayAccess, \Stringable {}
 

--- a/tests/Type/data/facades-l12-41.php
+++ b/tests/Type/data/facades-l12-41.php
@@ -19,6 +19,8 @@ function test(): void
     assertType('Illuminate\Http\Client\Response', Http::timeout(30)->get('https://example.test'));
     assertType('Illuminate\Http\Client\Response', Http::withHeaders(['X-Foo' => 'bar'])->post('https://example.test'));
 
+    assertType('int', Http::get('https://example.test')->getStatusCode());
+
     assertType('Illuminate\Http\Client\Promises\LazyPromise', Http::async()->get('https://example.test'));
     assertType('Illuminate\Http\Client\Promises\LazyPromise', Http::async()->post('https://example.test'));
     assertType('Illuminate\Http\Client\Promises\LazyPromise', Http::async()->send('GET', 'https://example.test'));

--- a/tests/Type/data/facades.php
+++ b/tests/Type/data/facades.php
@@ -61,6 +61,8 @@ function test(): void
     assertType('Illuminate\Http\Client\Response', Http::timeout(30)->get('https://example.test'));
     assertType('Illuminate\Http\Client\Response', Http::withHeaders(['X-Foo' => 'bar'])->post('https://example.test'));
 
+    assertType('int', Http::get('https://example.test')->getStatusCode());
+
     assertType('GuzzleHttp\Promise\PromiseInterface', Http::async()->get('https://example.test'));
     assertType('GuzzleHttp\Promise\PromiseInterface', Http::async()->post('https://example.test'));
     assertType('GuzzleHttp\Promise\PromiseInterface', Http::async()->send('GET', 'https://example.test'));


### PR DESCRIPTION
- [x] Added or updated tests

Resolves #2419

**Changes**

I've added the `ResponseInterface` as a mixin for the `Response` class just like [Laravel](https://github.com/laravel/framework/blob/12.x/src/Illuminate/Http/Client/Response.php#L15) has.

**Breaking changes**

No breaking changes have been introduced.
