### PR TITLE
Handle wildcard string in GenericModelPropertyType

### DIFF
--- a/src/Types/ModelProperty/GenericModelPropertyType.php
+++ b/src/Types/ModelProperty/GenericModelPropertyType.php
@@ -58,6 +58,11 @@ class GenericModelPropertyType extends StringType
 
         if (count($type->getConstantStrings()) === 1) {
             $givenString = $type->getConstantStrings()[0]->getValue();
+
+            if ($givenString === '*') {
+                return AcceptsResult::createNo();
+            }
+
             $genericType = $this->getGenericType();
 
             if ($genericType instanceof MixedType) {
@@ -115,6 +120,10 @@ class GenericModelPropertyType extends StringType
         $constantStrings = $type->getConstantStrings();
 
         if (count($constantStrings) === 1) {
+            if ($constantStrings[0]->getValue() === '*') {
+                return IsSuperTypeOfResult::createNo();
+            }
+
             if (! $this->getGenericType()->hasInstanceProperty($constantStrings[0]->getValue())->yes()) {
                 return IsSuperTypeOfResult::createNo();
             }

--- a/tests/Type/GenericModelPropertyTypeTest.php
+++ b/tests/Type/GenericModelPropertyTypeTest.php
@@ -101,6 +101,15 @@ class GenericModelPropertyTypeTest extends PHPStanTestCase
             GenericModelPropertyType::class,
             'model property of App\User',
         ];
+
+        yield [
+            static fn ($container) => [
+                new GenericModelPropertyType(new ObjectType(User::class), $container->getByType(ModelPropertyHelper::class)),
+                new ConstantStringType('*'),
+            ],
+            UnionType::class,
+            "'*'|model property of App\User",
+        ];
     }
 
     /** @param class-string<Type> $expectedTypeClass */


### PR DESCRIPTION
Add check for wildcard string '*' in GenericModelPropertyType.

- [x] Added or updated tests
- [ ] Documented user facing changes

Fixes #2332

