### PR TITLE
docs: update coding style guidelines in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Please review these guidelines before submitting any pull requests.
 
 ## Guidelines
 
-* Please follow the [PSR-2 Coding Style Guide](http://www.php-fig.org/psr/psr-2), enforced by [StyleCI](https://styleci.io).
+* Please follow the coding standards enforced by [PHP_CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer). You can check the code style by running `composer test:cs` and automatically format it using `./vendor/bin/phpcbf`.
 * Send a coherent commit history, making sure each individual commit in your pull request is meaningful.
 * You may need to [rebase](https://git-scm.com/book/en/v2/Git-Branching-Rebasing) to avoid merge conflicts.
 * Please remember that we follow [SemVer](http://semver.org).


### PR DESCRIPTION
- [ ] Added or updated tests
- [x] Documented user facing changes

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

This PR updates the coding style guidelines in `CONTRIBUTING.md` to reflect the actual tool currently in use.
It removes the outdated mention of StyleCI (which was removed in #1867 and subsequent commits) and replaces it with instructions for using PHP_CodeSniffer.

The goal of this documentation update is to ensure other contributors are aware of the formatting tools, so reviewers don't have to keep reminding them to run the code style checks on every PR.

**Proposed further improvements (for discussion)**

To further prevent unformatted code from being committed, would it be a good idea to introduce a simple `pre-commit` hook that alerts the user if code style checks (`composer test:cs`) fail?
This wouldn't automatically modify files (to respect developers' local environments), but just act as a reminder before the commit is created.
I haven't included it in this PR to keep it focused on the documentation, but I'd be happy to create a separate PR for that if the core team finds it useful.

**Breaking changes**

None.