### PR TITLE
Fix Redis eval() parameter order in Connection stub

### DIFF
--- a/stubs/common/Redis/Connection.stub
+++ b/stubs/common/Redis/Connection.stub
@@ -8,6 +8,20 @@ namespace Illuminate\Redis\Connections {
     /**
      * @mixin \Redis
      */
-    abstract class Connection {}
+    abstract class Connection
+    {
+        /**
+         * Evaluate a LUA script serverside, from the SHA1 hash of the script instead of the script itself.
+         *
+         * Laravel's PhpRedisConnection reorders the parameters compared to the raw phpredis extension:
+         * - phpredis: eval(string $script, array $arguments, int $numkeys)
+         * - Laravel:  eval(string $script, int $numkeys, mixed ...$arguments)
+         *
+         * @see https://github.com/laravel/framework/blob/12.x/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+         *
+         * @param  mixed  ...$arguments
+         * @return mixed
+         */
+        public function eval(string $script, int $numkeys = 0, mixed ...$arguments): mixed {}
+    }
 }
-


### PR DESCRIPTION
Laravel's `PhpRedisConnection::eval()` reorders the parameters compared to the raw phpredis extension:

- **phpredis:** `eval(string $script, array $arguments, int $numkeys)`
- **Laravel:**  `eval(string $script, int $numkeys, mixed ...$arguments)`

The `Connection` stub only had `@mixin \Redis` which pulled in the phpredis signature. This caused false positives when calling `Redis::eval()` with the parameter order shown in the Laravel docs.

Added an explicit `eval()` override in the `Connection` stub to match Laravel's actual implementation in `PhpRedisConnection`.

Closes #2453