### PR TITLE
Fix crash when laravel/helpers is not installed

### DIFF
--- a/src/Rules/NoEnvCallsOutsideOfConfigRule.php
+++ b/src/Rules/NoEnvCallsOutsideOfConfigRule.php
@@ -44,9 +44,11 @@ class NoEnvCallsOutsideOfConfigRule implements Rule
 
         $path = $this->resolve('path.config');
 
-        if ($path !== null) {
-            $this->configDirectories = [(string) $path];
+        if ($path === null) {
+            return;
         }
+
+        $this->configDirectories = [(string) $path];
     }
 
     public function getNodeType(): string

--- a/src/Rules/NoEnvCallsOutsideOfConfigRule.php
+++ b/src/Rules/NoEnvCallsOutsideOfConfigRule.php
@@ -14,7 +14,6 @@ use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleError;
 use PHPStan\Rules\RuleErrorBuilder;
 
-use function config_path;
 use function count;
 use function glob;
 use function is_dir;
@@ -43,7 +42,11 @@ class NoEnvCallsOutsideOfConfigRule implements Rule
             return;
         }
 
-        $this->configDirectories = [config_path()]; // @phpstan-ignore-line
+        $path = $this->resolve('path.config');
+
+        if ($path !== null) {
+            $this->configDirectories = [(string) $path];
+        }
     }
 
     public function getNodeType(): string


### PR DESCRIPTION
`NoEnvCallsOutsideOfConfigRule` called `config_path()` directly which requires the `laravel/helpers` package. In projects that use `illuminate/*` packages without `laravel/helpers` (e.g. library packages that integrate with Laravel), this caused an internal error:

```
Internal error: Call to undefined function config_path()
```

The class already uses the `HasContainer` trait which has a `resolve()` method. Replaced the `config_path()` call with `$this->resolve('path.config')`, which reads the same path binding that Laravel registers in its container.

If `path.config` is not bound (e.g. outside a full app context), `resolve()` returns null and `configDirectories` stays empty -- same result as before when `config_path()` was unavailable.

Closes #2274