### PR TITLE
Resolve dynamic class strings

### DIFF
--- a/src/ReturnTypes/AppMakeDynamicReturnTypeExtension.php
+++ b/src/ReturnTypes/AppMakeDynamicReturnTypeExtension.php
@@ -28,7 +28,7 @@ final class AppMakeDynamicReturnTypeExtension implements DynamicStaticMethodRetu
         return $methodReflection->getName() === 'make' || $methodReflection->getName() === 'makeWith';
     }
 
-    public function getTypeFromStaticMethodCall(MethodReflection $methodReflection, StaticCall $methodCall, Scope $scope): Type
+    public function getTypeFromStaticMethodCall(MethodReflection $methodReflection, StaticCall $methodCall, Scope $scope): ?Type
     {
         return $this->appMakeHelper->resolveTypeFromCall($methodCall, $scope);
     }

--- a/src/ReturnTypes/AppMakeHelper.php
+++ b/src/ReturnTypes/AppMakeHelper.php
@@ -22,7 +22,7 @@ final class AppMakeHelper
 {
     use HasContainer;
 
-    public function resolveTypeFromCall(FuncCall|MethodCall|StaticCall $call, Scope $scope): Type
+    public function resolveTypeFromCall(FuncCall|MethodCall|StaticCall $call, Scope $scope): ?Type
     {
         $args = $call->getArgs();
         if (count($args) === 0) {
@@ -58,6 +58,6 @@ final class AppMakeHelper
             return TypeCombinator::union(...$types);
         }
 
-        return new MixedType();
+        return null;
     }
 }

--- a/src/ReturnTypes/ApplicationMakeDynamicReturnTypeExtension.php
+++ b/src/ReturnTypes/ApplicationMakeDynamicReturnTypeExtension.php
@@ -30,7 +30,7 @@ final class ApplicationMakeDynamicReturnTypeExtension implements DynamicMethodRe
         return in_array($methodReflection->getName(), ['make', 'makeWith', 'resolve'], true);
     }
 
-    public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): Type
+    public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): ?Type
     {
         return $this->appMakeHelper->resolveTypeFromCall($methodCall, $scope);
     }

--- a/src/ReturnTypes/ContainerMakeDynamicReturnTypeExtension.php
+++ b/src/ReturnTypes/ContainerMakeDynamicReturnTypeExtension.php
@@ -30,7 +30,7 @@ final class ContainerMakeDynamicReturnTypeExtension implements DynamicMethodRetu
         return in_array($methodReflection->getName(), ['make', 'makeWith', 'resolve'], true);
     }
 
-    public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): Type
+    public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): ?Type
     {
         return $this->appMakeHelper->resolveTypeFromCall($methodCall, $scope);
     }

--- a/src/ReturnTypes/Helpers/AppExtension.php
+++ b/src/ReturnTypes/Helpers/AppExtension.php
@@ -31,7 +31,7 @@ class AppExtension implements DynamicFunctionReturnTypeExtension
         FunctionReflection $functionReflection,
         FuncCall $functionCall,
         Scope $scope,
-    ): Type {
+    ): ?Type {
         if (count($functionCall->getArgs()) === 0) {
             return new ObjectType(Application::class);
         }

--- a/tests/Type/data/application-make.php
+++ b/tests/Type/data/application-make.php
@@ -11,19 +11,32 @@ use Illuminate\Contracts\Foundation\Application as ApplicationContract;
 use function PHPStan\Testing\assertType;
 
 /** @param class-string<Model> $model */
-function test(Application $app, ApplicationContract $app2, string $model): void
+function test(Application $app, ApplicationContract $app2, string $model, mixed $mixed): void
 {
     assertType('Illuminate\Config\Repository', $app->make(Repository::class));
     assertType('Illuminate\Config\Repository', $app->makeWith(Repository::class));
     assertType('Illuminate\Config\Repository', $app->resolve(Repository::class));
-    assertType('FailsAtRuntime', $app->resolve(FailsAtRuntime::class));
 
     assertType('Illuminate\Config\Repository', $app2->make(Repository::class));
     assertType('Illuminate\Config\Repository', $app2->makeWith(Repository::class));
     assertType('Illuminate\Config\Repository', $app2->resolve(Repository::class));
+
+    assertType('Illuminate\Database\Eloquent\Model', $app->make($model));
+    assertType('Illuminate\Database\Eloquent\Model', $app->makeWith($model));
+    assertType('Illuminate\Database\Eloquent\Model', $app->resolve($model));
+
+    assertType('Illuminate\Database\Eloquent\Model', $app2->make($model));
+    assertType('Illuminate\Database\Eloquent\Model', $app2->makeWith($model));
+    assertType('Illuminate\Database\Eloquent\Model', $app2->resolve($model));
+
+    assertType('FailsAtRuntime', $app->resolve(FailsAtRuntime::class));
     assertType('FailsAtRuntime', $app2->resolve(FailsAtRuntime::class));
 
-    assertType('mixed', $app->make($model));
-    assertType('mixed', $app->makeWith($model));
-    assertType('mixed', $app->resolve($model));
+    assertType('mixed', $app->make($mixed));
+    assertType('mixed', $app->makeWith($mixed));
+    assertType('mixed', $app->resolve($mixed));
+
+    assertType('mixed', $app2->make($mixed));
+    assertType('mixed', $app2->makeWith($mixed));
+    assertType('mixed', $app2->resolve($mixed));
 }


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes

**Changes**

This PR aims to return the correct type when resolving dynamic class strings (such as class strings in variables or properties), which are currently not supported because `mixed` is always returned if the given type isn't a constant string.

As mentioned [here](https://github.com/larastan/larastan/pull/2157#issuecomment-2564105959), returning `null` from `resolveTypeFromCall()` makes PHPStan fall back to the default return type, which is now correct for all resolution helpers and methods (`app()`, `resolve()`, `make()` and `makeWith()`). With this PR, `null` would be returned instead of `MixedType` when the given string isn't constant.

**Breaking changes**

This could potentially reveal PHPStan errors that weren't previously thrown because `mixed` was returned instead of the correct type.