### PR TITLE
@phpstan-pure stub Illuminate\Auth\Access\Response helpers

### DIFF
--- a/stubs/common/Gate.stub
+++ b/stubs/common/Gate.stub
@@ -1,7 +1,7 @@
 <?php
 
 namespace Illuminate\Contracts\Auth\Access
-    {
+{
 
     interface Gate
     {
@@ -27,5 +27,49 @@ namespace Illuminate\Auth\Access
          * @return \Illuminate\Contracts\Auth\Access\Gate
          */
         public function forUser($user);
+    }
+
+    class Response
+    {
+        /**
+         * Create a new "allow" Response.
+         *
+         * @phpstan-pure
+         * @param  string|null  $message
+         * @param  mixed  $code
+         * @return \Illuminate\Auth\Access\Response
+         */
+        public static function allow($message = null, $code = null);
+
+        /**
+         * Create a new "deny" Response.
+         *
+         * @phpstan-pure
+         * @param  string|null  $message
+         * @param  mixed  $code
+         * @return \Illuminate\Auth\Access\Response
+         */
+        public static function deny($message = null, $code = null);
+
+        /**
+         * Create a new "deny" Response with a HTTP status code.
+         *
+         * @phpstan-pure
+         * @param  int  $status
+         * @param  string|null  $message
+         * @param  mixed  $code
+         * @return \Illuminate\Auth\Access\Response
+         */
+        public static function denyWithStatus($status, $message = null, $code = null);
+
+        /**
+         * Create a new "deny" Response with a 404 HTTP status code.
+         *
+         * @phpstan-pure
+         * @param  string|null  $message
+         * @param  mixed  $code
+         * @return \Illuminate\Auth\Access\Response
+         */
+        public static function denyAsNotFound($message = null, $code = null);
     }
 }

--- a/tests/Integration/IntegrationTest.php
+++ b/tests/Integration/IntegrationTest.php
@@ -40,6 +40,13 @@ class IntegrationTest extends PHPStanTestCase
         yield [__DIR__ . '/data/helpers.php'];
 
         yield [
+            __DIR__ . '/data/gate-helpers.php',
+            [
+                13 => ['Call to static method Illuminate\Auth\Access\Response::deny() on a separate line has no effect.'],
+            ],
+        ];
+
+        yield [
             __DIR__ . '/data/model-property-builder.php',
             [
                 15 => ['Parameter #1 $column of method Illuminate\Database\Eloquent\Builder<App\User>::firstWhere() expects array<int|model property of App\User, mixed>|(Closure(Illuminate\Database\Eloquent\Builder<App\User>): Illuminate\Database\Eloquent\Builder<App\User>)|(Closure(Illuminate\Database\Eloquent\Builder<App\User>): void)|Illuminate\Contracts\Database\Query\Expression|model property of App\User, \'foo\' given.'],

--- a/tests/Integration/data/gate-helpers.php
+++ b/tests/Integration/data/gate-helpers.php
@@ -1,0 +1,15 @@
+<?php
+
+use App\User;
+use Illuminate\Auth\Access\Response;
+
+function testGood(User $viewer): Response
+{
+    return Response::allow();
+}
+
+function testBad(?User $viewer): Response
+{
+    if (!$viewer) Response::deny(); // Should raise an error
+    return Response::allow();
+}


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes

**Changes**

Makes Laravel's `Illuminate\Auth\Access\Response` static helpers `@phpstan-pure`, to force the use of their return values.

**Breaking changes**

No breaking changes.

----

I wouldn't know how to test. Does this require tests? Can I copy from somewhere?