### PR TITLE
fix: resolve $this covariance false positive for relationship traits implementing interfaces

### DIFF
--- a/stubs/common/BelongsTo.stub
+++ b/stubs/common/BelongsTo.stub
@@ -1,0 +1,11 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Relations;
+
+/**
+ * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+ * @template-covariant TDeclaringModel of \Illuminate\Database\Eloquent\Model
+ *
+ * @extends \Illuminate\Database\Eloquent\Relations\Relation<TRelatedModel, TDeclaringModel, ?TRelatedModel>
+ */
+class BelongsTo extends Relation {}

--- a/stubs/common/BelongsToMany.stub
+++ b/stubs/common/BelongsToMany.stub
@@ -7,7 +7,7 @@ use Illuminate\Database\Eloquent\Model;
 
 /**
  * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
- * @template TDeclaringModel of \Illuminate\Database\Eloquent\Model
+ * @template-covariant TDeclaringModel of \Illuminate\Database\Eloquent\Model
  * @template TPivotModel of \Illuminate\Database\Eloquent\Relations\Pivot = \Illuminate\Database\Eloquent\Relations\Pivot
  * @template TAccessor of string = 'pivot'
  *

--- a/stubs/common/HasMany.stub
+++ b/stubs/common/HasMany.stub
@@ -1,0 +1,11 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Relations;
+
+/**
+ * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+ * @template-covariant TDeclaringModel of \Illuminate\Database\Eloquent\Model
+ *
+ * @extends \Illuminate\Database\Eloquent\Relations\HasOneOrMany<TRelatedModel, TDeclaringModel, \Illuminate\Database\Eloquent\Collection<int, TRelatedModel>>
+ */
+class HasMany extends HasOneOrMany {}

--- a/stubs/common/HasManyThrough.stub
+++ b/stubs/common/HasManyThrough.stub
@@ -1,0 +1,12 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Relations;
+
+/**
+ * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+ * @template TIntermediateModel of \Illuminate\Database\Eloquent\Model
+ * @template-covariant TDeclaringModel of \Illuminate\Database\Eloquent\Model
+ *
+ * @extends \Illuminate\Database\Eloquent\Relations\HasOneOrManyThrough<TRelatedModel, TIntermediateModel, TDeclaringModel, \Illuminate\Database\Eloquent\Collection<int, TRelatedModel>>
+ */
+class HasManyThrough extends HasOneOrManyThrough {}

--- a/stubs/common/HasOne.stub
+++ b/stubs/common/HasOne.stub
@@ -1,0 +1,11 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Relations;
+
+/**
+ * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+ * @template-covariant TDeclaringModel of \Illuminate\Database\Eloquent\Model
+ *
+ * @extends \Illuminate\Database\Eloquent\Relations\HasOneOrMany<TRelatedModel, TDeclaringModel, ?TRelatedModel>
+ */
+class HasOne extends HasOneOrMany {}

--- a/stubs/common/HasOneOrMany.stub
+++ b/stubs/common/HasOneOrMany.stub
@@ -4,7 +4,7 @@ namespace Illuminate\Database\Eloquent\Relations;
 
 /**
  * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
- * @template TDeclaringModel of \Illuminate\Database\Eloquent\Model
+ * @template-covariant TDeclaringModel of \Illuminate\Database\Eloquent\Model
  * @template TResult
  *
  * @extends \Illuminate\Database\Eloquent\Relations\Relation<TRelatedModel, TDeclaringModel, TResult>

--- a/stubs/common/HasOneOrManyThrough.stub
+++ b/stubs/common/HasOneOrManyThrough.stub
@@ -5,7 +5,7 @@ namespace Illuminate\Database\Eloquent\Relations;
 /**
  * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
  * @template TIntermediateModel of \Illuminate\Database\Eloquent\Model
- * @template TDeclaringModel of \Illuminate\Database\Eloquent\Model
+ * @template-covariant TDeclaringModel of \Illuminate\Database\Eloquent\Model
  * @template TResult
  *
  * @extends \Illuminate\Database\Eloquent\Relations\Relation<TRelatedModel, TIntermediateModel, TResult>

--- a/stubs/common/HasOneThrough.stub
+++ b/stubs/common/HasOneThrough.stub
@@ -1,0 +1,12 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Relations;
+
+/**
+ * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+ * @template TIntermediateModel of \Illuminate\Database\Eloquent\Model
+ * @template-covariant TDeclaringModel of \Illuminate\Database\Eloquent\Model
+ *
+ * @extends \Illuminate\Database\Eloquent\Relations\HasOneOrManyThrough<TRelatedModel, TIntermediateModel, TDeclaringModel, ?TRelatedModel>
+ */
+class HasOneThrough extends HasOneOrManyThrough {}

--- a/stubs/common/MorphMany.stub
+++ b/stubs/common/MorphMany.stub
@@ -1,0 +1,11 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Relations;
+
+/**
+ * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+ * @template-covariant TDeclaringModel of \Illuminate\Database\Eloquent\Model
+ *
+ * @extends \Illuminate\Database\Eloquent\Relations\MorphOneOrMany<TRelatedModel, TDeclaringModel, \Illuminate\Database\Eloquent\Collection<int, TRelatedModel>>
+ */
+class MorphMany extends MorphOneOrMany {}

--- a/stubs/common/MorphOne.stub
+++ b/stubs/common/MorphOne.stub
@@ -1,0 +1,11 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Relations;
+
+/**
+ * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+ * @template-covariant TDeclaringModel of \Illuminate\Database\Eloquent\Model
+ *
+ * @extends \Illuminate\Database\Eloquent\Relations\MorphOneOrMany<TRelatedModel, TDeclaringModel, ?TRelatedModel>
+ */
+class MorphOne extends MorphOneOrMany {}

--- a/stubs/common/MorphOneOrMany.stub
+++ b/stubs/common/MorphOneOrMany.stub
@@ -1,0 +1,12 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Relations;
+
+/**
+ * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+ * @template-covariant TDeclaringModel of \Illuminate\Database\Eloquent\Model
+ * @template TResult
+ *
+ * @extends \Illuminate\Database\Eloquent\Relations\HasOneOrMany<TRelatedModel, TDeclaringModel, TResult>
+ */
+abstract class MorphOneOrMany extends HasOneOrMany {}

--- a/stubs/common/MorphTo.stub
+++ b/stubs/common/MorphTo.stub
@@ -1,0 +1,11 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Relations;
+
+/**
+ * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+ * @template-covariant TDeclaringModel of \Illuminate\Database\Eloquent\Model
+ *
+ * @extends \Illuminate\Database\Eloquent\Relations\BelongsTo<TRelatedModel, TDeclaringModel>
+ */
+class MorphTo extends BelongsTo {}

--- a/stubs/common/MorphToMany.stub
+++ b/stubs/common/MorphToMany.stub
@@ -6,7 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 
 /**
  * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
- * @template TDeclaringModel of \Illuminate\Database\Eloquent\Model
+ * @template-covariant TDeclaringModel of \Illuminate\Database\Eloquent\Model
  * @template TPivotModel of \Illuminate\Database\Eloquent\Relations\Pivot = \Illuminate\Database\Eloquent\Relations\MorphPivot
  * @template TAccessor of string = 'pivot'
  *

--- a/stubs/common/Relation.stub
+++ b/stubs/common/Relation.stub
@@ -6,7 +6,7 @@ use Illuminate\Database\Eloquent\Builder;
 
 /**
  * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
- * @template TDeclaringModel of \Illuminate\Database\Eloquent\Model
+ * @template-covariant TDeclaringModel of \Illuminate\Database\Eloquent\Model
  * @template TResult
  */
 abstract class Relation
@@ -36,7 +36,7 @@ abstract class Relation
      * Essentially, these queries compare on column names like whereColumn.
      *
      * @param  \Illuminate\Database\Eloquent\Builder<TRelatedModel>  $query
-     * @param  \Illuminate\Database\Eloquent\Builder<TDeclaringModel>  $parentQuery
+     * @param  \Illuminate\Database\Eloquent\Builder<\Illuminate\Database\Eloquent\Model>  $parentQuery
      * @param  array<model-property<TRelatedModel>>|model-property<TRelatedModel>  $columns
      * @return \Illuminate\Database\Eloquent\Builder<TRelatedModel>
      */

--- a/tests/Type/GeneralTypeTest.php
+++ b/tests/Type/GeneralTypeTest.php
@@ -69,6 +69,7 @@ class GeneralTypeTest extends TypeInferenceTestCase
         yield from self::gatherAssertTypes(__DIR__ . '/data/validator.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/view-exists.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/view.php');
+        yield from self::gatherAssertTypes(__DIR__ . '/data/trait-interface-relation-covariance.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/where-relation.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/bug-1997.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/bug-1819.php');

--- a/tests/Type/data/trait-interface-relation-covariance.php
+++ b/tests/Type/data/trait-interface-relation-covariance.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace TraitInterfaceRelationCovariance;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+
+use function PHPStan\Testing\assertType;
+
+class Comment extends Model {}
+
+class Account extends Model {}
+
+class User extends Model {}
+
+interface HasComments
+{
+    /** @return MorphMany<Comment, static> */
+    public function comments(): MorphMany;
+}
+
+interface HasAccounts
+{
+    /** @return HasMany<Account, static> */
+    public function accounts(): HasMany;
+}
+
+interface HasOwner
+{
+    /** @return BelongsTo<User, static> */
+    public function owner(): BelongsTo;
+}
+
+trait Commentable
+{
+    /** @return MorphMany<Comment, $this> */
+    public function comments(): MorphMany
+    {
+        return $this->morphMany(Comment::class, 'commentable');
+    }
+}
+
+trait Accountable
+{
+    /** @return HasMany<Account, $this> */
+    public function accounts(): HasMany
+    {
+        return $this->hasMany(Account::class);
+    }
+}
+
+trait Ownable
+{
+    /** @return BelongsTo<User, $this> */
+    public function owner(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}
+
+class Post extends Model implements HasComments, HasAccounts, HasOwner
+{
+    use Commentable;
+    use Accountable;
+    use Ownable;
+}
+
+function test(Post $post): void
+{
+    assertType(
+        'Illuminate\Database\Eloquent\Relations\MorphMany<TraitInterfaceRelationCovariance\Comment, TraitInterfaceRelationCovariance\Post>',
+        $post->comments()
+    );
+    assertType(
+        'Illuminate\Database\Eloquent\Relations\HasMany<TraitInterfaceRelationCovariance\Account, TraitInterfaceRelationCovariance\Post>',
+        $post->accounts()
+    );
+    assertType(
+        'Illuminate\Database\Eloquent\Relations\BelongsTo<TraitInterfaceRelationCovariance\User, TraitInterfaceRelationCovariance\Post>',
+        $post->owner()
+    );
+}


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes - **_No user changes required_**

## Related
- larastan/larastan#2071
- larastan/larastan#2094
- phpstan/phpstan#11707
- phpstan/phpstan#11857

## Problem

When a trait defines Eloquent relationship methods (e.g., `morphMany`, `hasMany`) and a model uses that trait to satisfy an interface contract, PHPStan reports false `return.type` and `generics.notSubtype` errors. This occurs because Larastan infers the relationship's `TDeclaringModel` as `$this(ConcreteModel)`, which PHPStan's invariant template check rejects as incompatible with the interface's declared return type, even though they resolve to the same class at runtime.

Defining Eloquent relationships in traits is a common pattern in Laravel applications where polymorphic behavior is shared (e.g., commentable, taggable, likeable models).

## Expected behavior

PHPStan should recognize that when a final model class uses a trait to implement an interface, and the trait calls `$this->morphMany(...)`, the inferred `MorphMany<X, $this(Post)>` satisfies `MorphMany<X, Post>` (or `MorphMany<X, static>`) from the interface, as `$this` on a final class can only be that class.

Even for non-final classes, `$this(Post)` is a subtype of `Post`, and since relationship generics are read-only in practice, covariance is a safe choice here.

## Changes

Mark `TDeclaringModel` as `@template-covariant` on all Eloquent relationship class stubs (`Relation`, `HasMany`, `HasOne`, `BelongsTo`, `MorphMany`, `MorphOne`, `MorphOneOrMany`, `MorphTo`, `BelongsToMany`, `MorphToMany`, `HasOneOrMany`, `HasOneOrManyThrough`, `HasManyThrough`, `HasOneThrough`).

This resolves false `return.type` and `generics.notSubtype` errors when a trait defines relationship methods with `@return MorphMany<Comment, $this>` (or similar) and a model uses that trait to satisfy an interface declaring `@return MorphMany<Comment, static>`. PHPStan rejected the inferred `$this(Post)` as incompatible with `Post` because `TDeclaringModel` was invariant.

Concrete relationship classes that previously had no stubs now have minimal ones declaring `@template-covariant TDeclaringModel`, since template variance does not propagate from parent to child classes.

## Breaking changes

None. Code that previously required `@phpstan-ignore` rules will now pass. No existing valid code is affected.
