### PR TITLE
Add type narrowing for `where` method on collections

### DIFF
--- a/src/ReturnTypes/CollectionFilterRejectDynamicReturnTypeExtension.php
+++ b/src/ReturnTypes/CollectionFilterRejectDynamicReturnTypeExtension.php
@@ -26,6 +26,8 @@ use function is_string;
 
 class CollectionFilterRejectDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
 {
+    private const SUPPORTED_METHOD_NAMES = ['filter', 'reject', 'where'];
+
     public function getClass(): string
     {
         return Enumerable::class;
@@ -33,7 +35,7 @@ class CollectionFilterRejectDynamicReturnTypeExtension implements DynamicMethodR
 
     public function isMethodSupported(MethodReflection $methodReflection): bool
     {
-        return in_array($methodReflection->getName(), ['filter', 'reject'], true);
+        return in_array($methodReflection->getName(), self::SUPPORTED_METHOD_NAMES, true);
     }
 
     public function getTypeFromMethodCall(
@@ -63,15 +65,18 @@ class CollectionFilterRejectDynamicReturnTypeExtension implements DynamicMethodR
         }
 
         $methodName = $methodReflection->getName();
-        assert($methodName === 'filter' || $methodName === 'reject', 'proven in isMethodSupported');
+        assert(in_array($methodName, self::SUPPORTED_METHOD_NAMES), 'proven in isMethodSupported');
 
         if (count($methodCall->getArgs()) < 1) {
             $modifiedType = match ($methodName) {
                 'filter' => TypeCombinator::removeFalsey($valueType),
-                'reject' => TypeCombinator::removeTruthy($valueType)
+                'reject' => TypeCombinator::removeTruthy($valueType),
+                'where' => null,
             };
 
-            return new GenericObjectType($calledOnType->getObjectClassNames()[0], [$keyType, $modifiedType]);
+            return $modifiedType !== null
+                ? new GenericObjectType($calledOnType->getObjectClassNames()[0], [$keyType, $modifiedType])
+                : null;
         }
 
         $callbackArg = $methodCall->getArgs()[0]->value;
@@ -88,6 +93,9 @@ class CollectionFilterRejectDynamicReturnTypeExtension implements DynamicMethodR
         } elseif ($callbackArg instanceof ArrowFunction && count($callbackArg->params) > 0) {
             $var  = $callbackArg->params[0]->var;
             $expr = $callbackArg->expr;
+        } elseif ($methodName === 'where') {
+            // where call may have non-callable as first parameter; we don't support narrowing in this case
+            return null;
         }
 
         if ($var !== null && $expr !== null) {
@@ -101,7 +109,7 @@ class CollectionFilterRejectDynamicReturnTypeExtension implements DynamicMethodR
             // @phpstan-ignore-next-line
             $scope = $scope->assignExpression($node, $valueType, $valueType);
             $scope = match ($methodName) {
-                'filter' => $scope->filterByTruthyValue($expr),
+                'filter', 'where' => $scope->filterByTruthyValue($expr),
                 'reject' => $scope->filterByFalseyValue($expr),
             };
             $valueType = $scope->getVariableType($itemVariableName);

--- a/tests/Type/CollectionDynamicReturnTypeExtensionTest.php
+++ b/tests/Type/CollectionDynamicReturnTypeExtensionTest.php
@@ -14,6 +14,7 @@ class CollectionDynamicReturnTypeExtensionTest extends TypeInferenceTestCase
     {
         yield from self::gatherAssertTypes(__DIR__ . '/data/collection-filter.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/collection-reject.php');
+        yield from self::gatherAssertTypes(__DIR__ . '/data/collection-where.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/collection-where-not-null.php');
     }
 

--- a/tests/Type/data/collection-where.php
+++ b/tests/Type/data/collection-where.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace CollectionWhere;
+
+use App\Account;
+use App\User;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Support\Collection as SupportCollection;
+
+use function PHPStan\Testing\assertType;
+
+function convertToAccount(User $user): ?Account
+{ }
+
+function dummyFilter($value)
+{
+    if ($value instanceof User) {
+        return true;
+    }
+
+    return random_int(0, 1) > 1;
+}
+
+/**
+ * @param EloquentCollection<int, User> $users
+ * @param SupportCollection<array-key, mixed> $mixedCollection
+ */
+function test(User $user, SupportCollection $users, SupportCollection $mixedCollection): void
+{
+    assertType("Illuminate\Support\Collection<(int|string), mixed>", collect()->where('foo', '<>', 1));
+
+    assertType('Illuminate\Support\Collection<int, int<3, max>>', collect([1, 2, 3, 4, 5, 6])->where(function (int $value) {
+        return $value > 2;
+    }));
+    assertType('Illuminate\Support\Collection<int, int<3, max>>', collect([1, 2, 3, 4, 5, 6])->where(fn (int $value) => $value > 2));
+
+    assertType("Illuminate\Database\Eloquent\Collection<int, App\User>", $users->where(function (User $user): bool {
+        return ! $user->blocked;
+    }));
+    assertType("Illuminate\Database\Eloquent\Collection<int, App\User>", $users->where(fn (User $user) => ! $user->blocked));
+
+    assertType(
+        'Illuminate\Support\Collection<int, App\Account>',
+        collect($users->all())
+        ->map(function (User $attachment): ?Account {
+            return convertToAccount($attachment);
+        })
+        ->where(fn($user) => $user)
+    );
+
+    $accounts = $user->accounts()->active()->get();
+    assertType('App\AccountCollection<int, App\Account>', $accounts);
+
+    assertType('App\AccountCollection<int, App\Account>', $accounts->where(function ($account) {
+        return \CollectionStubs\dummyFilter($account);
+    }));
+
+    $accounts->where(function ($account) {
+        return dummyFilter($account);
+    })
+    ->map(function ($account) {
+        assertType('App\Account', $account);
+    });
+}


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

<!-- Detail the changes in behaviour this PR introduces. -->
The `CollectionFilterRejectDynamicReturnTypeExtension` class provides inferred type-narrowing for methods on collection. This PR adds `where` with callbacks to the already supported `filter` and `reject` methods. This allows developers to prefer `where` is stylistically preferable, e.g. when chaining with other `where` type calls or to be on par with query methods or to be on par with other languages like C# LINQ, and still profit from narrowed types.

Note this could later be improved to also narrow other input types that `where` accepts, but for the purpose of this MR these situations are not considered.

**Breaking changes**

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
n/a