### PR TITLE
fix: invalid parameter name

### DIFF
--- a/src/Reflection/DynamicWhereParameterReflection.php
+++ b/src/Reflection/DynamicWhereParameterReflection.php
@@ -13,7 +13,7 @@ class DynamicWhereParameterReflection implements ParameterReflection
 {
     public function getName(): string
     {
-        return 'dynamic-where-parameter';
+        return 'value';
     }
 
     public function isOptional(): bool


### PR DESCRIPTION
Hello!

I added some rules to [Rector](https://x.com/calebdw/status/2057548272307245071) and this is causing errors because dashes (`-`) are illegal in php parameter names. I also shortened it because there's  no reason for it to be so long

Thanks!