### PR TITLE
feat: narrow getCasts and getTouchedRelations return types

### DIFF
--- a/stubs/common/Database/Eloquent/Concerns/HasAttributes.stub
+++ b/stubs/common/Database/Eloquent/Concerns/HasAttributes.stub
@@ -3,12 +3,12 @@
 namespace Illuminate\Database\Eloquent\Concerns;
 
 /** @phpstan-require-extends \Illuminate\Database\Eloquent\Model */
-trait HasRelationships
+trait HasAttributes
 {
     /**
-     * Get the relationships that are touched on save.
+     * Get the attributes that should be cast.
      *
-     * @return list<string>
+     * @return array<string, string>
      */
-    public function getTouchedRelations();
+    public function getCasts();
 }

--- a/tests/Type/GeneralTypeTest.php
+++ b/tests/Type/GeneralTypeTest.php
@@ -44,6 +44,7 @@ class GeneralTypeTest extends TypeInferenceTestCase
             yield from self::gatherAssertTypes(__DIR__ . '/data/date-extension-l11.php');
         }
 
+        yield from self::gatherAssertTypes(__DIR__ . '/data/eloquent-getter-types.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/environment-helper.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/form-request.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/gate-facade.php');

--- a/tests/Type/data/eloquent-getter-types.php
+++ b/tests/Type/data/eloquent-getter-types.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace EloquentGetterTypes;
+
+use App\User;
+
+use function PHPStan\Testing\assertType;
+
+function test(User $user): void
+{
+    assertType('array<string, string>', $user->getCasts());
+    assertType('list<string>', $user->getTouchedRelations());
+}


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**
`Model::getCasts()` and `Model::getTouchedRelations()` are typed as a bare `@return array` in the framework, so PHPStan widens them to `array`. This adds stubs narrowing them:                                                                                                                                                                                                                                                      
  - `getCasts()` → `array<string, string>`                                                                                                                                  
  - `getTouchedRelations()` → `list<string>`

<!-- Detail the changes in behaviour this PR introduces. -->

**Breaking changes**
None - strict narrowings of an existing `array` return type.

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
