### PR TITLE
feat: narrow getAppends and getMutatedAttributes return types

### DIFF
--- a/stubs/common/Database/Eloquent/Concerns/HasAttributes.stub
+++ b/stubs/common/Database/Eloquent/Concerns/HasAttributes.stub
@@ -11,4 +11,18 @@ trait HasAttributes
      * @return array<string, string>
      */
     public function getCasts();
+
+    /**
+     * Get the accessors that are being appended to model arrays.
+     *
+     * @return list<string>
+     */
+    public function getAppends();
+
+    /**
+     * Get the mutated attributes for a given instance.
+     *
+     * @return list<string>
+     */
+    public function getMutatedAttributes();
 }

--- a/tests/Type/data/eloquent-getter-types.php
+++ b/tests/Type/data/eloquent-getter-types.php
@@ -10,4 +10,6 @@ function test(User $user): void
 {
     assertType('array<string, string>', $user->getCasts());
     assertType('list<string>', $user->getTouchedRelations());
+    assertType('list<string>', $user->getAppends());
+    assertType('list<string>', $user->getMutatedAttributes());
 }


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**
Narrows the return types of `Model::getAppends()` and `Model::getMutatedAttributes()` from `array` to `list<string>` via the `HasAttributes` stub.            
                                                                                                                                                                                                                                         Both return lists of attribute-name strings in Laravel's source (`getAppends()` returns `$this->appends`; `getMutatedAttributes()` returns the mapped mutator cache), but are declared as plain `@return array` upstream, so PHPStan infers `array`.          

<!-- Detail the changes in behaviour this PR introduces. -->

**Breaking changes**
None.

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
