### PR TITLE
fix: apply Eloquent PHP attributes when resolving model metadata

### DIFF
--- a/src/Properties/ModelCastHelper.php
+++ b/src/Properties/ModelCastHelper.php
@@ -61,6 +61,7 @@ use function array_map;
 use function array_merge;
 use function class_exists;
 use function explode;
+use function method_exists;
 use function str_replace;
 
 class ModelCastHelper
@@ -255,6 +256,10 @@ class ModelCastHelper
         try {
             /** @var Model $modelInstance */
             $modelInstance = $modelClassReflection->getNativeReflection()->newInstanceWithoutConstructor();
+            // @phpstan-ignore function.alreadyNarrowedType (method exists only since Laravel 13)
+            if (method_exists($modelInstance, 'initializeModelAttributes')) {
+                $modelInstance->initializeModelAttributes();
+            }
         } catch (ReflectionException) {
             throw new ShouldNotHappenException();
         }

--- a/src/Properties/ModelPropertyHelper.php
+++ b/src/Properties/ModelPropertyHelper.php
@@ -70,8 +70,7 @@ class ModelPropertyHelper
         }
 
         try {
-            /** @var Model $modelInstance */
-            $modelInstance = $classReflectionOrTable->getNativeReflection()->newInstanceWithoutConstructor();
+            $modelInstance = $this->newModelInstance($classReflectionOrTable);
         } catch (ReflectionException) {
             return false;
         }
@@ -92,8 +91,7 @@ class ModelPropertyHelper
     public function getDatabaseProperty(ClassReflection $classReflection, string $propertyName): ModelProperty
     {
         try {
-            /** @var Model $modelInstance */
-            $modelInstance = $classReflection->getNativeReflection()->newInstanceWithoutConstructor();
+            $modelInstance = $this->newModelInstance($classReflection);
         } catch (ReflectionException) {
             throw new ShouldNotHappenException();
         }
@@ -253,5 +251,18 @@ class ModelPropertyHelper
         }
 
         return in_array($propertyName, $dates, true);
+    }
+
+    /** @throws ReflectionException */
+    private function newModelInstance(ClassReflection $classReflection): Model
+    {
+        /** @var Model $instance */
+        $instance = $classReflection->getNativeReflection()->newInstanceWithoutConstructor();
+        // @phpstan-ignore function.alreadyNarrowedType (method exists only since Laravel 13)
+        if (method_exists($instance, 'initializeModelAttributes')) {
+            $instance->initializeModelAttributes();
+        }
+
+        return $instance;
     }
 }

--- a/src/Properties/SchemaAggregator.php
+++ b/src/Properties/SchemaAggregator.php
@@ -18,6 +18,7 @@ use function array_merge;
 use function class_basename;
 use function count;
 use function is_string;
+use function method_exists;
 use function property_exists;
 use function strtolower;
 
@@ -415,6 +416,10 @@ final class SchemaAggregator
         try {
             /** @var Model $modelInstance */
             $modelInstance = $classReflection->getNativeReflection()->newInstanceWithoutConstructor();
+            // @phpstan-ignore function.alreadyNarrowedType (method exists only since Laravel 13)
+            if (method_exists($modelInstance, 'initializeModelAttributes')) {
+                $modelInstance->initializeModelAttributes();
+            }
         } catch (ReflectionException) {
             return null;
         }

--- a/tests/Unit/MigrationHelperTest.php
+++ b/tests/Unit/MigrationHelperTest.php
@@ -12,6 +12,7 @@ use PHPStan\Testing\PHPStanTestCase;
 use PHPUnit\Framework\Attributes\Test;
 
 use function array_keys;
+use function class_exists;
 
 class MigrationHelperTest extends PHPStanTestCase
 {
@@ -267,5 +268,32 @@ class MigrationHelperTest extends PHPStanTestCase
         self::assertArrayHasKey('id', $tables['users']->columns);
         self::assertArrayHasKey('name', $tables['users']->columns);
         self::assertArrayHasKey('email', $tables['users']->columns);
+    }
+
+    #[Test]
+    public function it_resolves_foreign_id_for_column_type_using_table_php_attribute(): void
+    {
+        if (! class_exists('Illuminate\Database\Eloquent\Attributes\Table')) {
+            $this->markTestSkipped('Eloquent PHP attributes require Laravel 13+.');
+        }
+
+        $migrationHelper = new MigrationHelper(
+            $this->parser,
+            [
+                __DIR__ . '/data/basic_migration',
+                __DIR__ . '/data/migration_with_foreign_id_for',
+            ],
+            $this->fileHelper,
+            false,
+            $this->reflectionProvider,
+        );
+
+        $tables = $migrationHelper->initializeTables();
+
+        // foreignIdFor(Member::class) resolves Member's table via initializeModelAttributes().
+        // Member maps to 'users' (via #[Table]), so member_id inherits the type of users.id
+        // which is non-negative-int. Without the fix, Member would resolve to the non-existent
+        // 'members' table and the column would fall back to 'int'.
+        self::assertSame('non-negative-int', $tables['articles']->columns['member_id']->readableType);
     }
 }

--- a/tests/Unit/ModelCastHelperTest.php
+++ b/tests/Unit/ModelCastHelperTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use App\MemberWithCustomKey;
+use Larastan\Larastan\Properties\ModelCastHelper;
+use PHPStan\Analyser\ScopeFactory;
+use PHPStan\Parser\Parser;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Testing\PHPStanTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+
+use function class_exists;
+
+#[CoversClass(ModelCastHelper::class)]
+class ModelCastHelperTest extends PHPStanTestCase
+{
+    private ReflectionProvider $reflectionProvider;
+
+    private Parser $parser;
+
+    public function setUp(): void
+    {
+        if (! class_exists('Illuminate\Database\Eloquent\Attributes\Table')) {
+            $this->markTestSkipped('Eloquent PHP attributes require Laravel 13+.');
+        }
+
+        $this->reflectionProvider = $this->createReflectionProvider();
+        $this->parser             = self::getContainer()->getService('currentPhpVersionSimpleDirectParser');
+    }
+
+    #[Test]
+    public function it_uses_custom_primary_key_from_table_php_attribute_when_resolving_casts(): void
+    {
+        $modelCastHelper = new ModelCastHelper(
+            $this->reflectionProvider,
+            $this->parser,
+            false,
+            self::getContainer()->getByType(ScopeFactory::class),
+        );
+
+        $classReflection = $this->reflectionProvider->getClass(MemberWithCustomKey::class);
+
+        // The model uses #[Table(key: 'uuid', keyType: 'string')], so getCasts() returns
+        // ['uuid' => 'string']. Without initializeModelAttributes(), primaryKey stays 'id'
+        // and the cast for 'uuid' is never registered.
+        self::assertSame('string', $modelCastHelper->getCastForProperty($classReflection, 'uuid'));
+        self::assertNull($modelCastHelper->getCastForProperty($classReflection, 'id'));
+    }
+
+    /** @return string[] */
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/../phpstan-tests.neon'];
+    }
+}

--- a/tests/Unit/ModelPropertyHelperTest.php
+++ b/tests/Unit/ModelPropertyHelperTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use App\Member;
+use Larastan\Larastan\Properties\MigrationCache;
+use Larastan\Larastan\Properties\MigrationHelper;
+use Larastan\Larastan\Properties\ModelCastHelper;
+use Larastan\Larastan\Properties\ModelPropertyHelper;
+use Larastan\Larastan\Properties\Schema\MySqlDataTypeToPhpTypeConverter;
+use Larastan\Larastan\Properties\SquashedMigrationHelper;
+use PHPStan\Analyser\ScopeFactory;
+use PHPStan\File\FileHelper;
+use PHPStan\Parser\Parser;
+use PHPStan\PhpDoc\TypeStringResolver;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Testing\PHPStanTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use ReflectionClass;
+
+use function class_exists;
+use function sys_get_temp_dir;
+
+#[CoversClass(ModelPropertyHelper::class)]
+class ModelPropertyHelperTest extends PHPStanTestCase
+{
+    private ReflectionProvider $reflectionProvider;
+
+    private Parser $parser;
+
+    private FileHelper $fileHelper;
+
+    public function setUp(): void
+    {
+        if (! class_exists('Illuminate\Database\Eloquent\Attributes\Table')) {
+            $this->markTestSkipped('Eloquent PHP attributes require Laravel 13+.');
+        }
+
+        $this->reflectionProvider = $this->createReflectionProvider();
+        $this->parser             = self::getContainer()->getService('currentPhpVersionSimpleDirectParser');
+        $this->fileHelper         = self::getContainer()->getByType(FileHelper::class);
+    }
+
+    #[Test]
+    public function it_applies_table_php_attribute_after_initialize_model_attributes(): void
+    {
+        $reflection = new ReflectionClass(Member::class);
+        $instance   = $reflection->newInstanceWithoutConstructor();
+
+        // Without initializeModelAttributes() the #[Table] attribute is ignored and Laravel
+        // derives the table name from the class name instead.
+        self::assertNotSame('users', $instance->getTable());
+
+        $instance->initializeModelAttributes();
+
+        self::assertSame('users', $instance->getTable());
+    }
+
+    #[Test]
+    public function it_uses_custom_table_name_from_table_php_attribute_when_checking_database_property(): void
+    {
+        $modelPropertyHelper = $this->buildModelPropertyHelper(
+            [__DIR__ . '/data/basic_migration'],
+        );
+
+        $classReflection = $this->reflectionProvider->getClass(Member::class);
+
+        // The model uses #[Table(name: 'users')], not the default 'members' derived from
+        // the class name. The fix ensures initializeModelAttributes() is called so the correct
+        // table is resolved and columns from the users table are found.
+        self::assertTrue($modelPropertyHelper->hasDatabaseProperty($classReflection, 'email'));
+        self::assertFalse($modelPropertyHelper->hasDatabaseProperty($classReflection, 'nonexistent_column'));
+    }
+
+    /** @param string[] $migrationPaths */
+    private function buildModelPropertyHelper(array $migrationPaths): ModelPropertyHelper
+    {
+        $migrationHelper = new MigrationHelper(
+            $this->parser,
+            $migrationPaths,
+            $this->fileHelper,
+            false,
+            $this->reflectionProvider,
+        );
+
+        $squashedMigrationHelper = new SquashedMigrationHelper(
+            [],
+            $this->fileHelper,
+            new MySqlDataTypeToPhpTypeConverter(),
+            self::getContainer()->getService('sqlParser'),
+            false,
+        );
+
+        $modelCastHelper = new ModelCastHelper(
+            $this->reflectionProvider,
+            $this->parser,
+            false,
+            self::getContainer()->getByType(ScopeFactory::class),
+        );
+
+        return new ModelPropertyHelper(
+            self::getContainer()->getByType(TypeStringResolver::class),
+            $migrationHelper,
+            $squashedMigrationHelper,
+            $modelCastHelper,
+            new MigrationCache(sys_get_temp_dir(), false),
+        );
+    }
+
+    /** @return string[] */
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/../phpstan-tests.neon'];
+    }
+}

--- a/tests/Unit/data/migration_with_foreign_id_for/2020_01_31_000000_create_articles_table.php
+++ b/tests/Unit/data/migration_with_foreign_id_for/2020_01_31_000000_create_articles_table.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Data\MigrationWithForeignIdFor;
+
+use App\Member;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateArticlesTable extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('articles', static function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('title');
+            $table->foreignIdFor(Member::class);
+            $table->timestamps();
+        });
+    }
+}

--- a/tests/application/app/Member.php
+++ b/tests/application/app/Member.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Attributes\Table;
+use Illuminate\Database\Eloquent\Model;
+
+#[Table(name: 'users')]
+class Member extends Model
+{
+}

--- a/tests/application/app/MemberWithCustomKey.php
+++ b/tests/application/app/MemberWithCustomKey.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Attributes\Table;
+use Illuminate\Database\Eloquent\Model;
+
+#[Table(name: 'users', key: 'uuid', keyType: 'string')]
+class MemberWithCustomKey extends Model
+{
+}


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes

Resolves #2463

**Changes**

Larastan creates model instances using `ReflectionClass::newInstanceWithoutConstructor()` to avoid
side effects. This skips the Eloquent constructor, which normally calls
`initializeModelAttributes()` — the method responsible for applying PHP 8 attributes such as
`#[Table]`, `#[ObservedBy]`, `#[WithoutTimestamps]`, and others introduced in Laravel 13. As a
result, attributes were silently ignored, causing false positives such as:

```
Access to an undefined property App\Models\Account::$user_id.
```

or incorrect primary key types:

```
Property App\Models\Foo::$id (int) does not accept string.
Parameter $id of constructor expects string, int given.
```

A minimal reproduction:

```php
#[Table(name: 'users')]
class Member extends Model {}
```

```php
$name = Member::first()->name; // Access to an undefined property App\Models\Member::$name.
```

Larastan resolves the table name before `initializeModelAttributes()` is called, so it looks up
the non-existent `members` table (derived from the class name) instead of `users` declared via
`#[Table]`.

Fix: after `newInstanceWithoutConstructor()`, call `initializeModelAttributes()` when available,
guarded with `method_exists()` for compatibility with Laravel 11/12. Applied in four locations:
`ModelPropertyHelper::hasDatabaseProperty()`, `ModelPropertyHelper::getDatabaseProperty()`,
`ModelCastHelper::getModelCasts()`, and `SchemaAggregator::getModelReferenceType()`.

Note: on Laravel 13 PHPStan knows `initializeModelAttributes()` always exists on `Model`, so
the `method_exists()` check is marked with `@phpstan-ignore function.alreadyNarrowedType` – the
guard is intentional for cross-version compatibility, not redundant logic.

New tests (skipped on Laravel 11/12 where the feature does not exist):

- `ModelPropertyHelperTest` — verifies that `hasDatabaseProperty()` resolves columns from the
  correct table declared via `#[Table]`.
- `ModelCastHelperTest` — verifies that `getCastForProperty()` uses the primary key and key type
  declared via `#[Table(key: '...', keyType: '...')]`.
- `MigrationHelperTest` — verifies that `foreignIdFor(Member::class)` resolves to
  `non-negative-int` (from the correct table's primary key) instead of falling back to `int`.

**Breaking changes**

None.