### PR TITLE
fix: Allow mixins to support Eloquent computed attributes

### DIFF
--- a/src/Properties/ModelPropertyHelper.php
+++ b/src/Properties/ModelPropertyHelper.php
@@ -12,8 +12,6 @@ use PHPStan\PhpDoc\TypeStringResolver;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\Type\Constant\ConstantStringType;
-use PHPStan\Type\Generic\GenericObjectType;
-use PHPStan\Type\MixedType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\TypeCombinator;
@@ -184,11 +182,7 @@ class ModelPropertyHelper
             return (new ObjectType(Attribute::class))->isSuperTypeOf($returnType)->yes();
         }
 
-        if ($returnType->getObjectClassReflections() === [] || ! $returnType->getObjectClassReflections()[0]->isGeneric()) {
-            return false;
-        }
-
-        return (new GenericObjectType(Attribute::class, [new MixedType(), new MixedType()]))->isSuperTypeOf($returnType)->yes();
+        return (new ObjectType(Attribute::class))->isSuperTypeOf($returnType)->yes();
     }
 
     public function getAccessor(ClassReflection $classReflection, string $propertyName): ModelProperty

--- a/tests/Type/GeneralTypeTest.php
+++ b/tests/Type/GeneralTypeTest.php
@@ -45,6 +45,7 @@ class GeneralTypeTest extends TypeInferenceTestCase
         }
 
         yield from self::gatherAssertTypes(__DIR__ . '/data/eloquent-getter-types.php');
+        yield from self::gatherAssertTypes(__DIR__ . '/data/json-resource-mixin-accessor.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/environment-helper.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/form-request.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/gate-facade.php');

--- a/tests/Type/data/json-resource-mixin-accessor.php
+++ b/tests/Type/data/json-resource-mixin-accessor.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace JsonResourceMixinAccessor;
+
+use App\UserResource;
+
+use function PHPStan\Testing\assertType;
+
+function test(UserResource $resource): void
+{
+    // Computed Attribute without explicit generics should resolve through @mixin (type is mixed)
+    assertType('mixed', $resource->newStyleAttribute);
+
+    // Computed Attribute with explicit generics should resolve through @mixin with correct type
+    assertType('int', $resource->stringButInt);
+}

--- a/tests/Type/data/model-properties.php
+++ b/tests/Type/data/model-properties.php
@@ -34,7 +34,7 @@ function test(
     RoleUser $roleUser,
     ModelWithCasts $modelWithCasts
 ): void {
-    assertType('*ERROR*', $user->newStyleAttribute); // Doesn't have generic type, so we treat as it doesnt exist
+    assertType('mixed', $user->newStyleAttribute); // No explicit generic types, so the property type is mixed
     assertType('int', $user->stringButInt);
     assertType('string', $user->email);
     assertType('array', $user->allowed_ips);


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes

**Changes**

Fixes a scenario where Eloquent computed attributes (e.g. `protected function isExpired(): Attribute` without generics are not resolved when accessed through a `@mixin` annotation - the typical pattern in `JsonResource` classes and other places.

This change treats them as existing but with a `mixed` type.

Here is a scenario that would have previously not worked, but does with these changes:

```php
/** @mixin User */
class UserResource extends JsonResource
{
    public function toArray($request)
    {
        return [
            'computed_value' => $this->computed_value,
        ];
    }
}

class User extends Authenticatable
{
    protected function computedValue(): Attribute
    {
        return Attribute::make(
            fn ($value) => $value,
            fn ($value) => $value,
        );
    }
}
```

**Breaking changes**

Computed attributes declared with a raw `Attribute` return type were previously treated as non-existent by Larastan. They are now visible as mixed-typed properties (unless they have generics). At higher levels (8+) this may surface new mixed-related errors for code that was previously hidden - the fix is to add `@return Attribute<TGet, TSet>` to the method.
