### PR TITLE
fix: Correctly detect legacy getComputedAttribute methods when a same-named public method exists

### DIFF
--- a/src/Properties/ModelPropertyHelper.php
+++ b/src/Properties/ModelPropertyHelper.php
@@ -168,27 +168,25 @@ class ModelPropertyHelper
 
         $camelCase = Str::camel($propertyName);
 
-        if (! $classReflection->hasNativeMethod($camelCase)) {
-            return $classReflection->hasNativeMethod('get' . Str::studly($propertyName) . 'Attribute');
+        if ($classReflection->hasNativeMethod($camelCase)) {
+            $methodReflection = $classReflection->getNativeMethod($camelCase);
+
+            if (! $methodReflection->isPublic() && ! $methodReflection->isPrivate()) {
+                $returnType = $methodReflection->getVariants()[0]->getReturnType();
+
+                if (! $strictGenerics) {
+                    if ((new ObjectType(Attribute::class))->isSuperTypeOf($returnType)->yes()) {
+                        return true;
+                    }
+                } elseif ($returnType->getObjectClassReflections() !== [] && $returnType->getObjectClassReflections()[0]->isGeneric()) {
+                    if ((new GenericObjectType(Attribute::class, [new MixedType(), new MixedType()]))->isSuperTypeOf($returnType)->yes()) {
+                        return true;
+                    }
+                }
+            }
         }
 
-        $methodReflection = $classReflection->getNativeMethod($camelCase);
-
-        if ($methodReflection->isPublic() || $methodReflection->isPrivate()) {
-            return false;
-        }
-
-        $returnType = $methodReflection->getVariants()[0]->getReturnType();
-
-        if (! $strictGenerics) {
-            return (new ObjectType(Attribute::class))->isSuperTypeOf($returnType)->yes();
-        }
-
-        if ($returnType->getObjectClassReflections() === [] || ! $returnType->getObjectClassReflections()[0]->isGeneric()) {
-            return false;
-        }
-
-        return (new GenericObjectType(Attribute::class, [new MixedType(), new MixedType()]))->isSuperTypeOf($returnType)->yes();
+        return $classReflection->hasNativeMethod('get' . Str::studly($propertyName) . 'Attribute');
     }
 
     public function getAccessor(ClassReflection $classReflection, string $propertyName): ModelProperty

--- a/tests/Rules/ModelAppendsRuleTest.php
+++ b/tests/Rules/ModelAppendsRuleTest.php
@@ -25,6 +25,11 @@ class ModelAppendsRuleTest extends RuleTestCase
         ]);
     }
 
+    public function testLegacyAccessorWithSameNamePublicMethod(): void
+    {
+        $this->analyse([__DIR__ . '/data/ModelAppendsLegacyAccessor.php'], []);
+    }
+
     /** @return string[] */
     public static function getAdditionalConfigFiles(): array
     {

--- a/tests/Rules/data/ModelAppendsLegacyAccessor.php
+++ b/tests/Rules/data/ModelAppendsLegacyAccessor.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Rules\Data;
+
+use Illuminate\Database\Eloquent\Model;
+
+class UserWithLegacyAccessor extends Model
+{
+    /** @var array<int, string> */
+    protected $appends = ['link'];
+
+    public function getLinkAttribute(): string
+    {
+        return $this->link();
+    }
+
+    public function link(): string
+    {
+        return 'user/' . $this->slug;
+    }
+}


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes

**Changes**

`ModelAppendsRule` was incorrectly reporting a "does not exist in model" error for properties in `$appends` that use the legacy `getXAttribute()` style when a public method with the same camelCase name also exists on the model.

`ModelPropertyHelper::hasAccessor()` bailed out early with `false` when a camelCase method matching the property name was found but had public or private visibility - without falling through to check for the legacy style attributes. This was inconsistent with `getAccessor()`, which already handled this correctly via an inner if block that falls through.

Example that previously produced a false positive error

```php
class User extends Model
{
    protected $appends = ['link'];

    public function getLinkAttribute(): string
    {
        return $this->link();
    }

    public function link(): string
    {
        return url('user/' . $this->slug);
    }
}
```

Previously reported: `Property 'link' does not exist in model.` (`rules.modelAppends`)

**Breaking changes**

None.
