### PR TITLE
fix: guard against undefined LARAVEL_VERSION constant

### DIFF
--- a/src/LarastanStubFilesExtension.php
+++ b/src/LarastanStubFilesExtension.php
@@ -10,6 +10,7 @@ use Symfony\Component\Finder\Finder;
 
 use function array_keys;
 use function array_values;
+use function defined;
 use function iterator_to_array;
 use function version_compare;
 
@@ -22,7 +23,7 @@ final class LarastanStubFilesExtension implements StubFilesExtension
 
         // Include only applicable versions
         $stubDirectories
-            ->filter(static fn (SplFileInfo $directory) => version_compare($directory->getFilename(), LARAVEL_VERSION, '<='))
+            ->filter(static fn (SplFileInfo $directory) => defined('LARAVEL_VERSION') && version_compare($directory->getFilename(), LARAVEL_VERSION, '<='))
             ->sort(static fn (SplFileInfo $a, SplFileInfo $b) => version_compare($a->getFilename(), $b->getFilename()));
 
         $files = [];

--- a/tests/Unit/LarastanStubFilesExtensionTest.php
+++ b/tests/Unit/LarastanStubFilesExtensionTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use Larastan\Larastan\LarastanStubFilesExtension;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+use PHPUnit\Framework\TestCase;
+
+use function defined;
+
+class LarastanStubFilesExtensionTest extends TestCase
+{
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testGetFilesDoesNotFailWhenLaravelVersionIsUndefined(): void
+    {
+        $this->assertFalse(defined('LARAVEL_VERSION'));
+
+        $files = (new LarastanStubFilesExtension())->getFiles();
+
+        $this->assertNotEmpty($files);
+
+        foreach ($files as $file) {
+            $this->assertFileExists($file);
+            $this->assertStringEndsWith('.stub', $file);
+        }
+    }
+}


### PR DESCRIPTION
`LarastanStubFilesExtension::getFiles()` references the `LARAVEL_VERSION` constant without checking that it's defined, so analysis crashes with a fatal error whenever the Laravel application isn't bootstrapped (e.g. a package without `orchestra/testbench`). Guard it with `defined()`, matching the check already used in `BuilderHelper`.

Fixes #2480
