### PR TITLE
fix: remove dead cases and handle nullableTimestampsTz in schema aggregator

### DIFF
--- a/src/Properties/SchemaAggregator.php
+++ b/src/Properties/SchemaAggregator.php
@@ -262,26 +262,18 @@ final class SchemaAggregator
                     }
                 }
 
-                if (
-                    $firstMethodCall->name->name === 'timestamps'
-                    || $firstMethodCall->name->name === 'timestampsTz'
-                    || $firstMethodCall->name->name === 'nullableTimestamps'
-                    || $firstMethodCall->name->name === 'nullableTimestampsTz'
-                    || $firstMethodCall->name->name === 'rememberToken'
-                ) {
-                    switch (strtolower($firstMethodCall->name->name)) {
-                        case 'remembertoken':
-                            $table->setColumn(new SchemaColumn('remember_token', 'string', $nullable));
-                            continue 2;
+                switch (strtolower($firstMethodCall->name->name)) {
+                    case 'remembertoken':
+                        $table->setColumn(new SchemaColumn('remember_token', 'string', $nullable));
+                        continue 2;
 
-                        case 'timestamps':
-                        case 'timestampstz':
-                        case 'nullabletimestamps':
-                        case 'nullabletimestampstz':
-                            $table->setColumn(new SchemaColumn('created_at', 'string', true));
-                            $table->setColumn(new SchemaColumn('updated_at', 'string', true));
-                            continue 2;
-                    }
+                    case 'timestamps':
+                    case 'timestampstz':
+                    case 'nullabletimestamps':
+                    case 'nullabletimestampstz':
+                        $table->setColumn(new SchemaColumn('created_at', 'string', true));
+                        $table->setColumn(new SchemaColumn('updated_at', 'string', true));
+                        continue 2;
                 }
 
                 $defaultsMap = [

--- a/src/Properties/SchemaAggregator.php
+++ b/src/Properties/SchemaAggregator.php
@@ -267,6 +267,10 @@ final class SchemaAggregator
                         $table->setColumn(new SchemaColumn('remember_token', 'string', $nullable));
                         continue 2;
 
+                    case 'dropremembertoken':
+                        $table->dropColumn('remember_token');
+                        continue 2;
+
                     case 'timestamps':
                     case 'timestampstz':
                     case 'nullabletimestamps':

--- a/src/Properties/SchemaAggregator.php
+++ b/src/Properties/SchemaAggregator.php
@@ -272,7 +272,7 @@ final class SchemaAggregator
                     switch (strtolower($firstMethodCall->name->name)) {
                         case 'remembertoken':
                             $table->setColumn(new SchemaColumn('remember_token', 'string', $nullable));
-                            break;
+                            continue 2;
 
                         case 'timestamps':
                         case 'timestampstz':
@@ -280,10 +280,8 @@ final class SchemaAggregator
                         case 'nullabletimestampstz':
                             $table->setColumn(new SchemaColumn('created_at', 'string', true));
                             $table->setColumn(new SchemaColumn('updated_at', 'string', true));
-                            break;
+                            continue 2;
                     }
-
-                    continue;
                 }
 
                 $defaultsMap = [

--- a/src/Properties/SchemaAggregator.php
+++ b/src/Properties/SchemaAggregator.php
@@ -270,23 +270,14 @@ final class SchemaAggregator
                     || $firstMethodCall->name->name === 'rememberToken'
                 ) {
                     switch (strtolower($firstMethodCall->name->name)) {
-                        case 'droptimestamps':
-                        case 'droptimestampstz':
-                            $table->dropColumn('created_at');
-                            $table->dropColumn('updated_at');
-                            break;
-
                         case 'remembertoken':
                             $table->setColumn(new SchemaColumn('remember_token', 'string', $nullable));
-                            break;
-
-                        case 'dropremembertoken':
-                            $table->dropColumn('remember_token');
                             break;
 
                         case 'timestamps':
                         case 'timestampstz':
                         case 'nullabletimestamps':
+                        case 'nullabletimestampstz':
                             $table->setColumn(new SchemaColumn('created_at', 'string', true));
                             $table->setColumn(new SchemaColumn('updated_at', 'string', true));
                             break;

--- a/src/Properties/SchemaAggregator.php
+++ b/src/Properties/SchemaAggregator.php
@@ -274,6 +274,12 @@ final class SchemaAggregator
                         $table->setColumn(new SchemaColumn('created_at', 'string', true));
                         $table->setColumn(new SchemaColumn('updated_at', 'string', true));
                         continue 2;
+
+                    case 'droptimestamps':
+                    case 'droptimestampstz':
+                        $table->dropColumn('created_at');
+                        $table->dropColumn('updated_at');
+                        continue 2;
                 }
 
                 $defaultsMap = [

--- a/tests/Unit/MigrationHelperTest.php
+++ b/tests/Unit/MigrationHelperTest.php
@@ -274,6 +274,21 @@ class MigrationHelperTest extends PHPStanTestCase
     }
 
     #[Test]
+    public function it_can_handle_migrations_with_drop_remember_token(): void
+    {
+        $migrationHelper = new MigrationHelper($this->parser, [
+            __DIR__ . '/data/migrations_using_drop_remember_token',
+        ], $this->fileHelper, false, $this->reflectionProvider);
+
+        $tables = $migrationHelper->initializeTables();
+
+        self::assertCount(1, $tables);
+        self::assertArrayHasKey('users', $tables);
+        self::assertCount(3, $tables['users']->columns);
+        self::assertSame(['id', 'name', 'email'], array_keys($tables['users']->columns));
+    }
+
+    #[Test]
     public function it_can_handle_migrations_with_if_statements(): void
     {
         $migrationHelper = new MigrationHelper($this->parser, [__DIR__ . '/data/conditional_migrations'], $this->fileHelper, false, $this->reflectionProvider);

--- a/tests/Unit/MigrationHelperTest.php
+++ b/tests/Unit/MigrationHelperTest.php
@@ -259,6 +259,21 @@ class MigrationHelperTest extends PHPStanTestCase
     }
 
     #[Test]
+    public function it_can_handle_migrations_with_drop_timestamps(): void
+    {
+        $migrationHelper = new MigrationHelper($this->parser, [
+            __DIR__ . '/data/migrations_using_drop_timestamps',
+        ], $this->fileHelper, false, $this->reflectionProvider);
+
+        $tables = $migrationHelper->initializeTables();
+
+        self::assertCount(1, $tables);
+        self::assertArrayHasKey('users', $tables);
+        self::assertCount(3, $tables['users']->columns);
+        self::assertSame(['id', 'name', 'email'], array_keys($tables['users']->columns));
+    }
+
+    #[Test]
     public function it_can_handle_migrations_with_if_statements(): void
     {
         $migrationHelper = new MigrationHelper($this->parser, [__DIR__ . '/data/conditional_migrations'], $this->fileHelper, false, $this->reflectionProvider);

--- a/tests/Unit/MigrationHelperTest.php
+++ b/tests/Unit/MigrationHelperTest.php
@@ -157,6 +157,21 @@ class MigrationHelperTest extends PHPStanTestCase
     }
 
     #[Test]
+    public function it_can_handle_migrations_with_nullable_timestamps_tz(): void
+    {
+        $migrationHelper = new MigrationHelper($this->parser, [__DIR__ . '/data/migrations_using_nullable_timestamps_tz'], $this->fileHelper, false, $this->reflectionProvider);
+
+        $tables = $migrationHelper->initializeTables();
+
+        self::assertCount(1, $tables);
+        self::assertArrayHasKey('users', $tables);
+        self::assertCount(5, $tables['users']->columns);
+        self::assertSame(['id', 'name', 'email', 'created_at', 'updated_at'], array_keys($tables['users']->columns));
+        self::assertSame('string', $tables['users']->columns['created_at']->readableType);
+        self::assertSame('string', $tables['users']->columns['updated_at']->readableType);
+    }
+
+    #[Test]
     public function it_can_handle_migrations_with_default_arguments(): void
     {
         $migrationHelper = new MigrationHelper($this->parser, [__DIR__ . '/data/migration_with_default_arguments'], $this->fileHelper, false, $this->reflectionProvider);

--- a/tests/Unit/data/migrations_using_drop_remember_token/2020_01_30_000000_create_users_table.php
+++ b/tests/Unit/data/migrations_using_drop_remember_token/2020_01_30_000000_create_users_table.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MigrationsUsingDropRememberToken;
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateUsersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('users', static function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('name')->nullable();
+            $table->string('email')->unique();
+            $table->rememberToken();
+        });
+
+        Schema::table('users', static function (Blueprint $table) {
+            $table->dropRememberToken();
+        });
+    }
+}

--- a/tests/Unit/data/migrations_using_drop_timestamps/2020_01_30_000000_create_users_table.php
+++ b/tests/Unit/data/migrations_using_drop_timestamps/2020_01_30_000000_create_users_table.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MigrationsUsingDropTimestamps;
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateUsersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('users', static function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('name')->nullable();
+            $table->string('email')->unique();
+            $table->timestamps();
+        });
+
+        Schema::table('users', static function (Blueprint $table) {
+            $table->dropTimestamps();
+        });
+    }
+}

--- a/tests/Unit/data/migrations_using_nullable_timestamps_tz/2020_01_30_000000_create_users_table.php
+++ b/tests/Unit/data/migrations_using_nullable_timestamps_tz/2020_01_30_000000_create_users_table.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MigrationsUsingNullableTimestampsTz;
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateUsersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('users', static function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('name')->nullable();
+            $table->string('email')->unique();
+            $table->nullableTimestampsTz();
+        });
+    }
+}


### PR DESCRIPTION
The `if` guarding this switch only lets through the non-drop timestamp and `rememberToken` methods, so the `dropTimestamps`, `dropTimestampsTz` and `dropRememberToken` cases can never match, which is why PHPStan reports them as `switch.alwaysFalse`. This removes those unreachable cases and adds the missing `nullableTimestampsTz` case, which the guard already allowed but was never handled. Added a test covering the `nullableTimestampsTz` mapping.

Fixes #2504
