### PR TITLE
fix: allow null and object as Http request body data

### DIFF
--- a/stubs/12.41.0/Http/PendingRequest.stub
+++ b/stubs/12.41.0/Http/PendingRequest.stub
@@ -46,7 +46,7 @@ namespace Illuminate\Http\Client
          * Issue a POST request to the given URL.
          *
          * @param  string  $url
-         * @param  array<string, mixed>|list<array{name: scalar, contents: scalar}>|\JsonSerializable|\Illuminate\Contracts\Support\Arrayable<string, mixed>  $data
+         * @param  array<string, mixed>|list<array{name: scalar, contents: scalar}>|\JsonSerializable|\Illuminate\Contracts\Support\Arrayable<string, mixed>|object|null  $data
          * @return (TAsync is true ? \Illuminate\Http\Client\Promises\LazyPromise : \Illuminate\Http\Client\Response)
          */
         public function post(string $url, $data = []);
@@ -55,7 +55,7 @@ namespace Illuminate\Http\Client
          * Issue a PATCH request to the given URL.
          *
          * @param  string  $url
-         * @param  array<string, mixed>|list<array{name: scalar, contents: scalar}>|\JsonSerializable|\Illuminate\Contracts\Support\Arrayable<string, mixed>  $data
+         * @param  array<string, mixed>|list<array{name: scalar, contents: scalar}>|\JsonSerializable|\Illuminate\Contracts\Support\Arrayable<string, mixed>|object|null  $data
          * @return (TAsync is true ? \Illuminate\Http\Client\Promises\LazyPromise : \Illuminate\Http\Client\Response)
          */
         public function patch(string $url, $data = []);
@@ -64,7 +64,7 @@ namespace Illuminate\Http\Client
          * Issue a PUT request to the given URL.
          *
          * @param  string  $url
-         * @param  array<string, mixed>|list<array{name: scalar, contents: scalar}>|\JsonSerializable|\Illuminate\Contracts\Support\Arrayable<string, mixed>  $data
+         * @param  array<string, mixed>|list<array{name: scalar, contents: scalar}>|\JsonSerializable|\Illuminate\Contracts\Support\Arrayable<string, mixed>|object|null  $data
          * @return (TAsync is true ? \Illuminate\Http\Client\Promises\LazyPromise : \Illuminate\Http\Client\Response)
          */
         public function put(string $url, $data = []);
@@ -73,7 +73,7 @@ namespace Illuminate\Http\Client
          * Issue a DELETE request to the given URL.
          *
          * @param  string  $url
-         * @param  array<string, mixed>|list<array{name: scalar, contents: scalar}>|\JsonSerializable|\Illuminate\Contracts\Support\Arrayable<string, mixed>  $data
+         * @param  array<string, mixed>|list<array{name: scalar, contents: scalar}>|\JsonSerializable|\Illuminate\Contracts\Support\Arrayable<string, mixed>|object|null  $data
          * @return (TAsync is true ? \Illuminate\Http\Client\Promises\LazyPromise : \Illuminate\Http\Client\Response)
          */
         public function delete(string $url, $data = []);

--- a/stubs/common/Http/PendingRequest.stub
+++ b/stubs/common/Http/PendingRequest.stub
@@ -46,7 +46,7 @@ namespace Illuminate\Http\Client
          * Issue a POST request to the given URL.
          *
          * @param  string  $url
-         * @param  array<string, mixed>|list<array{name: scalar, contents: scalar}>|\JsonSerializable|\Illuminate\Contracts\Support\Arrayable<string, mixed>  $data
+         * @param  array<string, mixed>|list<array{name: scalar, contents: scalar}>|\JsonSerializable|\Illuminate\Contracts\Support\Arrayable<string, mixed>|object|null  $data
          * @return (TAsync is true ? \GuzzleHttp\Promise\PromiseInterface : \Illuminate\Http\Client\Response)
          */
         public function post(string $url, $data = []);
@@ -55,7 +55,7 @@ namespace Illuminate\Http\Client
          * Issue a PATCH request to the given URL.
          *
          * @param  string  $url
-         * @param  array<string, mixed>|list<array{name: scalar, contents: scalar}>|\JsonSerializable|\Illuminate\Contracts\Support\Arrayable<string, mixed>  $data
+         * @param  array<string, mixed>|list<array{name: scalar, contents: scalar}>|\JsonSerializable|\Illuminate\Contracts\Support\Arrayable<string, mixed>|object|null  $data
          * @return (TAsync is true ? \GuzzleHttp\Promise\PromiseInterface : \Illuminate\Http\Client\Response)
          */
         public function patch(string $url, $data = []);
@@ -64,7 +64,7 @@ namespace Illuminate\Http\Client
          * Issue a PUT request to the given URL.
          *
          * @param  string  $url
-         * @param  array<string, mixed>|list<array{name: scalar, contents: scalar}>|\JsonSerializable|\Illuminate\Contracts\Support\Arrayable<string, mixed>  $data
+         * @param  array<string, mixed>|list<array{name: scalar, contents: scalar}>|\JsonSerializable|\Illuminate\Contracts\Support\Arrayable<string, mixed>|object|null  $data
          * @return (TAsync is true ? \GuzzleHttp\Promise\PromiseInterface : \Illuminate\Http\Client\Response)
          */
         public function put(string $url, $data = []);
@@ -73,7 +73,7 @@ namespace Illuminate\Http\Client
          * Issue a DELETE request to the given URL.
          *
          * @param  string  $url
-         * @param  array<string, mixed>|list<array{name: scalar, contents: scalar}>|\JsonSerializable|\Illuminate\Contracts\Support\Arrayable<string, mixed>  $data
+         * @param  array<string, mixed>|list<array{name: scalar, contents: scalar}>|\JsonSerializable|\Illuminate\Contracts\Support\Arrayable<string, mixed>|object|null  $data
          * @return (TAsync is true ? \GuzzleHttp\Promise\PromiseInterface : \Illuminate\Http\Client\Response)
          */
         public function delete(string $url, $data = []);

--- a/tests/Integration/IntegrationTest.php
+++ b/tests/Integration/IntegrationTest.php
@@ -23,6 +23,7 @@ class IntegrationTest extends PHPStanTestCase
         self::getContainer();
 
         yield [__DIR__ . '/data/bug-2074.php'];
+        yield [__DIR__ . '/data/bug-2426.php'];
         yield [__DIR__ . '/data/bug-2431.php'];
         yield [__DIR__ . '/data/bug-final_model_query.php'];
         yield [__DIR__ . '/data/test-case-extension.php', [34 => ['Call to function method_exists() with $this(TestTestCase) and \'partialMock\' will always evaluate to true.']]];

--- a/tests/Integration/data/bug-2426.php
+++ b/tests/Integration/data/bug-2426.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Bug2426;
+
+use Illuminate\Support\Facades\Http;
+
+function test(): void
+{
+    Http::post('localhost', null);
+    Http::post('localhost', (object) []);
+    Http::patch('localhost', null);
+    Http::put('localhost', null);
+    Http::delete('localhost', null);
+}


### PR DESCRIPTION
`Http::post()`, `patch()`, `put()`, and `delete()` all accept null and plain objects as $data at runtime — `parseHttpOptions()` only special-cases `Arrayable` and `JsonSerializable`, everything else (including null) passes through untouched to the request body. 

The stub's `@param` type didn't include null|object, so valid calls like `Http::post($url, null)` or `Http::post($url, (object) [])` were flagged as errors.

Fixes #2426