### PR TITLE
PHPStan addresses the RAMpocalypse!

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -73,7 +73,7 @@
     },
     "scripts": {
         "test:cs": "phpcs",
-        "test:types": "phpstan analyse --ansi --memory-limit 300M",
+        "test:types": "phpstan analyse -v --ansi --memory-limit 300M",
         "test:unit": "phpunit --colors=always -d memory_limit=1408M",
         "test": [
             "@test:types",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "illuminate/http": "^11.44.2 || ^12.4.1 || ^13",
         "illuminate/pipeline": "^11.44.2 || ^12.4.1 || ^13",
         "illuminate/support": "^11.44.2 || ^12.4.1 || ^13",
-        "phpstan/phpstan": "^2.2.2"
+        "phpstan/phpstan": "2.2.2"
     },
     "require-dev": {
         "doctrine/coding-standard": "^14",


### PR DESCRIPTION
PHP 8.5 - L^13.0 ↑

v2.2.2

Elapsed time: 10.28 seconds
Used memory: 1.01 GB

v2.2.4

Elapsed time: 11.73 seconds
Used memory: 798.88 MB
