### PR TITLE
fix: conditionable calls on relations

### DIFF
--- a/src/Methods/RelationForwardsCallsExtension.php
+++ b/src/Methods/RelationForwardsCallsExtension.php
@@ -18,6 +18,7 @@ use PHPStan\ShouldNotHappenException;
 use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\ThisType;
+use PHPStan\Type\Type;
 
 use function array_key_exists;
 
@@ -92,7 +93,7 @@ final class RelationForwardsCallsExtension implements MethodsClassReflectionExte
         $parametersAcceptor = $reflection->getVariants()[0];
         $returnType         = $parametersAcceptor->getReturnType();
 
-        if ((new ObjectType(Builder::class))->isSuperTypeOf($returnType)->yes()) {
+        if ($this->returnTypeReferencesBuilder($returnType)) {
             $returnType = new ThisType($classReflection);
         }
 
@@ -103,5 +104,29 @@ final class RelationForwardsCallsExtension implements MethodsClassReflectionExte
             $returnType,
             $parametersAcceptor->isVariadic(),
         );
+    }
+
+    /**
+     * Checks whether the return type references an Eloquent Builder class.
+     *
+     * This handles conditional return types (e.g. from Conditionable::when())
+     * where isSuperTypeOf() returns maybe() instead of yes() because the
+     * type contains unresolved template parameters alongside a Builder branch.
+     */
+    private function returnTypeReferencesBuilder(Type $returnType): bool
+    {
+        $builderObjectType = new ObjectType(Builder::class);
+
+        if ($builderObjectType->isSuperTypeOf($returnType)->yes()) {
+            return true;
+        }
+
+        foreach ($returnType->getReferencedClasses() as $class) {
+            if ($builderObjectType->isSuperTypeOf(new ObjectType($class))->yes()) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/tests/Type/data/conditionable.php
+++ b/tests/Type/data/conditionable.php
@@ -14,34 +14,34 @@ class Foo
 }
 
 /** @param Builder<User> $query */
-function test(Builder $query): void
+function test(Foo $foo, User $user, Builder $query): void
 {
-    assertType('ConditionableStubs\Foo', (new Foo())->when(true, function (Foo $foo) {
+    assertType('ConditionableStubs\Foo', $foo->when(true, function (Foo $foo) {
         // do nothing
     }));
 
-    assertType('ConditionableStubs\Foo', (new Foo())->when(true, function (Foo $foo) {
+    assertType('ConditionableStubs\Foo', $foo->when(true, function (Foo $foo) {
         return null;
     }));
 
-    assertType('int<0, max>', (new Foo())->when(true, function (Foo $foo): int {
+    assertType('int<0, max>', $foo->when(true, function (Foo $foo): int {
         return rand();
     }));
 
     // Test to make sure the callback has a non-null value.
-    (new Foo())->when(User::first(), function (Foo $foo, $user): void {
+    $foo->when(User::first(), function (Foo $foo, $user): void {
         assertType(User::class, $user);
     });
 
-    assertType('ConditionableStubs\Foo', (new Foo())->unless(true, function (Foo $foo) {
+    assertType('ConditionableStubs\Foo', $foo->unless(true, function (Foo $foo) {
         // do nothing
     }));
 
-    assertType('ConditionableStubs\Foo', (new Foo())->unless(true, function (Foo $foo) {
+    assertType('ConditionableStubs\Foo', $foo->unless(true, function (Foo $foo) {
         return null;
     }));
 
-    assertType('int<0, max>', (new Foo())->unless(true, function (Foo $foo): int {
+    assertType('int<0, max>', $foo->unless(true, function (Foo $foo): int {
         return rand();
     }));
 
@@ -49,4 +49,12 @@ function test(Builder $query): void
         /** @phpstan-var Builder<User> $query */
         return $query->whereNull('name');
     }));
+
+    // when()/unless() on relations should return the relation type, not the builder type
+    assertType('Illuminate\Database\Eloquent\Relations\HasMany<App\Account, App\User>', $user->accounts()->when(true, fn ($q) => $q));
+    assertType('Illuminate\Database\Eloquent\Relations\HasMany<App\Account, App\User>', $user->accounts()->unless(false, fn ($q) => $q));
+    assertType("Illuminate\Database\Eloquent\Relations\BelongsToMany<App\Role, App\User, Illuminate\Database\Eloquent\Relations\Pivot, 'pivot'>", $user->roles()->when(true, fn ($q) => $q));
+
+    // when() on a relation with a custom builder model should still return the relation type
+    assertType("Illuminate\Database\Eloquent\Relations\BelongsToMany<App\Post, App\User, Illuminate\Database\Eloquent\Relations\Pivot, 'pivot'>", $user->posts()->when(true, fn ($q) => $q));
 }

--- a/tests/Type/data/model-relations.php
+++ b/tests/Type/data/model-relations.php
@@ -255,6 +255,10 @@ function test(
             ['name' => 'bar'],
         ]),
     );
+
+    // value() on a relation should return mixed, not the relation type
+    assertType('mixed', $user->accounts()->value('id'));
+    assertType('mixed', $user->roles()->value('name'));
 }
 
 /**


### PR DESCRIPTION
Hello!

This fixes `->when()`/`->unless()` calls on relationships to properly return the relationship instead of the forwarded builder

Thanks!