### PR TITLE
Implement strict Contract mode

### DIFF
--- a/docs/custom-config-parameters.md
+++ b/docs/custom-config-parameters.md
@@ -193,3 +193,25 @@ $foo = env('FOO', fn() => 'bar');
 will also dump `string` when the parameter is enabled.
 
 The reasoning behind it is that the default value is always used when the environment variable is not set. And for almost all the cases the default value should be the same type as the actual env variable. So it makes sense to generalize the return type to the type of the default value.
+
+## `checkStrictContracts`
+**default**: `false`
+
+By default, when Larastan sees a class or interface FQCN passed to `resolve()`, `app()`, `App::make()`/`App::makeWith()`, or `Container::make()`/`makeWith()`/`resolve()`, it resolves the argument through the container bindings and infers the return type as the concrete class that would be bound at runtime. This can lead to incorrect assumptions when the binding varies between environments (e.g. production vs. testing), since code may end up relying on methods that only exist on the concrete implementation and not on the interface it type-hinted.
+
+When this option is enabled, Larastan will not resolve container bindings for arguments that are already a class or interface FQCN, and will instead infer the type as the FQCN itself. Aliases (e.g. `resolve('cache')`) are unaffected and continue to resolve to their concrete implementation.
+
+### Example
+```php
+use Illuminate\Contracts\Config\Repository;
+
+$repository = resolve(Repository::class);
+\PHPStan\dumpType($repository);
+```
+
+With `checkStrictContracts` disabled (default), this dumps `Illuminate\Config\Repository` (the concrete implementation bound in the container). With it enabled, this dumps `Illuminate\Contracts\Config\Repository` (the interface that was type-hinted).
+
+```neon
+parameters:
+    checkStrictContracts: true
+```

--- a/extension.neon
+++ b/extension.neon
@@ -33,6 +33,7 @@ parameters:
     checkAuthCallsWhenInRequestScope: false
     parseModelCastsMethod: false
     enableMigrationCache: false
+    checkStrictContracts: false
 
 parametersSchema:
     checkOctaneCompatibility: bool()
@@ -59,6 +60,7 @@ parametersSchema:
     checkAuthCallsWhenInRequestScope: bool()
     parseModelCastsMethod: bool()
     enableMigrationCache: bool()
+    checkStrictContracts: bool()
 
 conditionalTags:
     Larastan\Larastan\Rules\NoEnvCallsOutsideOfConfigRule:
@@ -654,6 +656,8 @@ services:
 
     -
         class: Larastan\Larastan\ReturnTypes\AppMakeHelper
+        arguments:
+            checkStrictContracts: %checkStrictContracts%
 
     -
         class: Larastan\Larastan\Internal\ConsoleApplicationResolver

--- a/src/ReturnTypes/AppMakeHelper.php
+++ b/src/ReturnTypes/AppMakeHelper.php
@@ -22,6 +22,11 @@ final class AppMakeHelper
 {
     use HasContainer;
 
+    public function __construct(
+        private readonly bool $checkStrictContracts = false,
+    ) {
+    }
+
     public function resolveTypeFromCall(FuncCall|MethodCall|StaticCall $call, Scope $scope): Type
     {
         $args = $call->getArgs();
@@ -36,6 +41,11 @@ final class AppMakeHelper
         if (count($constantStrings) > 0) {
             $types = [];
             foreach ($constantStrings as $constantString) {
+                if ($this->checkStrictContracts && $constantString->isClassString()->yes()) {
+                    $types[] = $constantString->getClassStringObjectType();
+                    continue;
+                }
+
                 try {
                     /** @var object|null $resolved */
                     $resolved = $this->resolve($constantString->getValue());

--- a/tests/Type/StrictContractModeTest.php
+++ b/tests/Type/StrictContractModeTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Type;
+
+use PHPStan\Testing\TypeInferenceTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+class StrictContractModeTest extends TypeInferenceTestCase
+{
+    /** @return iterable<mixed> */
+    public static function dataFileAsserts(): iterable
+    {
+        yield from self::gatherAssertTypes(__DIR__ . '/data/strict-contracts.php');
+    }
+
+    #[DataProvider('dataFileAsserts')]
+    public function testFileAsserts(
+        string $assertType,
+        string $file,
+        mixed ...$args,
+    ): void {
+        $this->assertFileAsserts($assertType, $file, ...$args);
+    }
+
+    /** @return string[] */
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/data/config-strict-contracts.neon'];
+    }
+}

--- a/tests/Type/data/config-strict-contracts.neon
+++ b/tests/Type/data/config-strict-contracts.neon
@@ -1,0 +1,4 @@
+includes:
+    - ../../phpstan-tests.neon
+parameters:
+    checkStrictContracts: true

--- a/tests/Type/data/strict-contracts.php
+++ b/tests/Type/data/strict-contracts.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace StrictContracts;
+
+use FailsAtRuntime;
+use Illuminate\Contracts\Config\Repository;
+use Illuminate\Contracts\Container\Container as ContainerContract;
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Foundation\Application as ApplicationContract;
+use Illuminate\Foundation\Application;
+use Illuminate\Support\Facades\App;
+
+use function PHPStan\Testing\assertType;
+
+function test(
+    Application $app,
+    ApplicationContract $app2,
+    Container $container,
+    ContainerContract $container2,
+): void {
+    assertType('Illuminate\Contracts\Config\Repository', app(Repository::class));
+    assertType('Illuminate\Contracts\Config\Repository', resolve(Repository::class));
+    assertType('Illuminate\Auth\AuthManager', app('auth'));
+    assertType('Illuminate\Auth\AuthManager', resolve('auth'));
+
+    assertType('Illuminate\Contracts\Config\Repository', App::make(Repository::class));
+    assertType('Illuminate\Contracts\Config\Repository', App::makeWith(Repository::class));
+
+    assertType('Illuminate\Contracts\Config\Repository', $app->make(Repository::class));
+    assertType('Illuminate\Contracts\Config\Repository', $app->makeWith(Repository::class));
+    assertType('Illuminate\Contracts\Config\Repository', $app->resolve(Repository::class));
+    assertType('FailsAtRuntime', $app->resolve(FailsAtRuntime::class));
+
+    assertType('Illuminate\Contracts\Config\Repository', $app2->make(Repository::class));
+    assertType('Illuminate\Contracts\Config\Repository', $app2->makeWith(Repository::class));
+    assertType('Illuminate\Contracts\Config\Repository', $app2->resolve(Repository::class));
+    assertType('FailsAtRuntime', $app2->resolve(FailsAtRuntime::class));
+
+    assertType('Illuminate\Contracts\Config\Repository', $container->make(Repository::class));
+    assertType('Illuminate\Contracts\Config\Repository', $container->makeWith(Repository::class));
+    assertType('Illuminate\Contracts\Config\Repository', $container->resolve(Repository::class));
+
+    assertType('Illuminate\Contracts\Config\Repository', $container2->make(Repository::class));
+    assertType('Illuminate\Contracts\Config\Repository', $container2->makeWith(Repository::class));
+    assertType('Illuminate\Contracts\Config\Repository', $container2->resolve(Repository::class));
+}


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes

Resolves #2216

**Changes**

Adds an opt-in `checkStrictContracts` config parameter (default `false`). When enabled, Larastan no longer resolves container bindings for arguments to `resolve()`, `app()`, `App::make()`/`App::makeWith()`, and `Container::make()`/`makeWith()`/`resolve()` when the argument is already a class or interface FQCN it infers the return type as that FQCN itself instead of digging into the container to find the concrete implementation currently bound to it. String aliases (e.g. `resolve('cache')`) are unaffected and continue to resolve to their concrete implementation as before.

This is implemented in a single shared helper (`AppMakeHelper::resolveTypeFromCall()`), which backs all of the call sites above, so enabling the flag consistently affects every resolution path in one place.

**Breaking changes**

None, the option is off by default.