### PR TITLE
feat: extend `view-string` type coverage to more view-name signatures

### DIFF
--- a/stubs/common/Contracts/View.stub
+++ b/stubs/common/Contracts/View.stub
@@ -13,6 +13,16 @@ interface Factory
      * @phpstan-assert-if-true view-string $view
      */
     public function exists($view);
+
+    /**
+     * Get the evaluated view contents for the given view.
+     *
+     * @param  view-string  $view
+     * @param  array<string, mixed>  $data
+     * @param  array<string, mixed>  $mergeData
+     * @return \Illuminate\Contracts\View\View
+     */
+    public function make($view, $data = [], $mergeData = []);
 }
 
 interface View

--- a/stubs/common/Contracts/View.stub
+++ b/stubs/common/Contracts/View.stub
@@ -18,7 +18,7 @@ interface Factory
      * Get the evaluated view contents for the given view.
      *
      * @param  view-string  $view
-     * @param  array<string, mixed>  $data
+     * @param  \Illuminate\Contracts\Support\Arrayable<array-key, mixed>|array<string, mixed>  $data
      * @param  array<string, mixed>  $mergeData
      * @return \Illuminate\Contracts\View\View
      */

--- a/stubs/common/Facades.stub
+++ b/stubs/common/Facades.stub
@@ -63,14 +63,25 @@ class Cookie extends Facade {
 /**
  * @mixin \Illuminate\Config\Repository
  */
- class Config extends Facade {}
+class Config extends Facade {}
 
 /**
  * @mixin \Illuminate\Http\Client\Factory
  */
- class Http extends Facade {}
+class Http extends Facade {}
 
- /**
-  * @mixin \Illuminate\View\Factory
-  */
- class View extends Facade {}
+/**
+ * @mixin \Illuminate\View\Factory
+ */
+class View extends Facade {}
+
+class Route extends Facade {
+    /**
+     * @param  string  $uri
+     * @param  view-string  $view
+     * @param  array<string, mixed>  $data
+     * @param  array<string, string>  $headers
+     * @return \Illuminate\Routing\Route
+     */
+    public static function view($uri, $view, $data = [], int $status = 200, array $headers = []);
+}

--- a/stubs/common/Facades.stub
+++ b/stubs/common/Facades.stub
@@ -75,6 +75,9 @@ class Http extends Facade {}
  */
 class View extends Facade {}
 
+/**
+ * @mixin \Illuminate\Routing\Router
+ */
 class Route extends Facade {
     /**
      * @param  string  $uri

--- a/stubs/common/InteractsWithViews.stub
+++ b/stubs/common/InteractsWithViews.stub
@@ -1,0 +1,15 @@
+<?php
+
+namespace Illuminate\Foundation\Testing\Concerns;
+
+trait InteractsWithViews
+{
+    /**
+     * Create a new TestView from the given view.
+     *
+     * @param  view-string  $view
+     * @param  \Illuminate\Contracts\Support\Arrayable|array<string, mixed>  $data
+     * @return \Illuminate\Testing\TestView
+     */
+    protected function view(string $view, $data = []);
+}

--- a/stubs/common/MailMessage.stub
+++ b/stubs/common/MailMessage.stub
@@ -12,7 +12,7 @@ class MailMessage
     public function markdown($view, array $data = []);
 
     /**
-     * @param  view-string  $view
+     * @param  view-string[]|view-string  $view
      * @param  array<string, mixed>  $data
      * @return $this
      */

--- a/stubs/common/MailMessage.stub
+++ b/stubs/common/MailMessage.stub
@@ -1,0 +1,20 @@
+<?php
+
+namespace Illuminate\Notifications\Messages;
+
+class MailMessage
+{
+    /**
+     * @param  view-string  $view
+     * @param  array<string, mixed>  $data
+     * @return $this
+     */
+    public function markdown($view, array $data = []);
+
+    /**
+     * @param  view-string  $view
+     * @param  array<string, mixed>  $data
+     * @return $this
+     */
+    public function view($view, array $data = []);
+}

--- a/stubs/common/MailMessage.stub
+++ b/stubs/common/MailMessage.stub
@@ -17,4 +17,11 @@ class MailMessage
      * @return $this
      */
     public function view($view, array $data = []);
+
+    /**
+     * @param  view-string  $textView
+     * @param  array<string, mixed>  $data
+     * @return $this
+     */
+    public function text($textView, array $data = []);
 }

--- a/stubs/common/Mailable.stub
+++ b/stubs/common/Mailable.stub
@@ -17,4 +17,11 @@ class Mailable
      * @return $this
      */
     public function view($view, array $data = []);
+
+    /**
+     * @param  view-string  $textView
+     * @param  array<string, mixed>  $data
+     * @return $this
+     */
+    public function text($textView, array $data = []);
 }

--- a/stubs/common/Router.stub
+++ b/stubs/common/Router.stub
@@ -1,0 +1,17 @@
+<?php
+
+namespace Illuminate\Routing;
+
+class Router
+{
+    /**
+     * Register a new route that returns a view.
+     *
+     * @param  string  $uri
+     * @param  view-string  $view
+     * @param  array<string, mixed>  $data
+     * @param  array<string, string>  $headers
+     * @return \Illuminate\Routing\Route
+     */
+    public function view($uri, $view, $data = [], int $status = 200, array $headers = []);
+}

--- a/stubs/common/TestResponse.stub
+++ b/stubs/common/TestResponse.stub
@@ -1,0 +1,14 @@
+<?php
+
+namespace Illuminate\Testing;
+
+class TestResponse
+{
+    /**
+     * Assert that the response view equals the given value.
+     *
+     * @param  view-string  $value
+     * @return $this
+     */
+    public function assertViewIs($value);
+}

--- a/tests/Integration/IntegrationTest.php
+++ b/tests/Integration/IntegrationTest.php
@@ -41,14 +41,16 @@ class IntegrationTest extends PHPStanTestCase
         yield [
             __DIR__ . '/data/view-string-signatures.php',
             [
-                16 => ['Parameter #1 $view of method Illuminate\Contracts\View\Factory::make() expects view-string, string given.'],
-                22 => ['Parameter #2 $view of method Illuminate\Routing\Router::view() expects view-string, string given.'],
-                28 => ['Parameter #1 $view of method Illuminate\Notifications\Messages\MailMessage::view() expects array<view-string>|view-string, string given.'],
-                30 => ['Parameter #1 $view of method Illuminate\Notifications\Messages\MailMessage::markdown() expects view-string, string given.'],
-                37 => ['Parameter #1 $value of method Illuminate\Testing\TestResponse<Illuminate\Http\Response>::assertViewIs() expects view-string, string given.'],
-                51 => ['Parameter #1 $view of method ViewStringSignatures\UsesInteractsWithViews::view() expects view-string, string given.'],
-                58 => ['Parameter #1 $view of static method Illuminate\View\Factory::make() expects view-string, string given.'],
-                64 => ['Parameter #2 $view of static method Illuminate\Support\Facades\Route::view() expects view-string, string given.'],
+                17 => ['Parameter #1 $view of method Illuminate\Contracts\View\Factory::make() expects view-string, string given.'],
+                23 => ['Parameter #2 $view of method Illuminate\Routing\Router::view() expects view-string, string given.'],
+                29 => ['Parameter #1 $view of method Illuminate\Notifications\Messages\MailMessage::view() expects array<view-string>|view-string, string given.'],
+                31 => ['Parameter #1 $view of method Illuminate\Notifications\Messages\MailMessage::markdown() expects view-string, string given.'],
+                38 => ['Parameter #1 $value of method Illuminate\Testing\TestResponse<Illuminate\Http\Response>::assertViewIs() expects view-string, string given.'],
+                52 => ['Parameter #1 $view of method ViewStringSignatures\UsesInteractsWithViews::view() expects view-string, string given.'],
+                59 => ['Parameter #1 $view of static method Illuminate\View\Factory::make() expects view-string, string given.'],
+                65 => ['Parameter #2 $view of static method Illuminate\Support\Facades\Route::view() expects view-string, string given.'],
+                71 => ['Parameter #1 $textView of method Illuminate\Notifications\Messages\MailMessage::text() expects view-string, string given.'],
+                77 => ['Parameter #1 $textView of method Illuminate\Mail\Mailable::text() expects view-string, string given.'],
             ],
         ];
 

--- a/tests/Integration/IntegrationTest.php
+++ b/tests/Integration/IntegrationTest.php
@@ -43,7 +43,7 @@ class IntegrationTest extends PHPStanTestCase
             [
                 16 => ['Parameter #1 $view of method Illuminate\Contracts\View\Factory::make() expects view-string, string given.'],
                 22 => ['Parameter #2 $view of method Illuminate\Routing\Router::view() expects view-string, string given.'],
-                28 => ['Parameter #1 $view of method Illuminate\Notifications\Messages\MailMessage::view() expects view-string, string given.'],
+                28 => ['Parameter #1 $view of method Illuminate\Notifications\Messages\MailMessage::view() expects array<view-string>|view-string, string given.'],
                 30 => ['Parameter #1 $view of method Illuminate\Notifications\Messages\MailMessage::markdown() expects view-string, string given.'],
                 37 => ['Parameter #1 $value of method Illuminate\Testing\TestResponse<Illuminate\Http\Response>::assertViewIs() expects view-string, string given.'],
                 51 => ['Parameter #1 $view of method ViewStringSignatures\UsesInteractsWithViews::view() expects view-string, string given.'],

--- a/tests/Integration/IntegrationTest.php
+++ b/tests/Integration/IntegrationTest.php
@@ -37,6 +37,21 @@ class IntegrationTest extends PHPStanTestCase
 
         yield [__DIR__ . '/data/model-factories.php'];
         yield [__DIR__ . '/data/blade-view.php'];
+
+        yield [
+            __DIR__ . '/data/view-string-signatures.php',
+            [
+                16 => ['Parameter #1 $view of method Illuminate\Contracts\View\Factory::make() expects view-string, string given.'],
+                22 => ['Parameter #2 $view of method Illuminate\Routing\Router::view() expects view-string, string given.'],
+                28 => ['Parameter #1 $view of method Illuminate\Notifications\Messages\MailMessage::view() expects view-string, string given.'],
+                30 => ['Parameter #1 $view of method Illuminate\Notifications\Messages\MailMessage::markdown() expects view-string, string given.'],
+                37 => ['Parameter #1 $value of method Illuminate\Testing\TestResponse<Illuminate\Http\Response>::assertViewIs() expects view-string, string given.'],
+                51 => ['Parameter #1 $view of method ViewStringSignatures\UsesInteractsWithViews::view() expects view-string, string given.'],
+                58 => ['Parameter #1 $view of static method Illuminate\View\Factory::make() expects view-string, string given.'],
+                64 => ['Parameter #2 $view of static method Illuminate\Support\Facades\Route::view() expects view-string, string given.'],
+            ],
+        ];
+
         yield [__DIR__ . '/data/helpers.php'];
         yield [__DIR__ . '/data/facades.php'];
 

--- a/tests/Integration/IntegrationTest.php
+++ b/tests/Integration/IntegrationTest.php
@@ -48,7 +48,7 @@ class IntegrationTest extends PHPStanTestCase
                 38 => ['Parameter #1 $value of method Illuminate\Testing\TestResponse<Illuminate\Http\Response>::assertViewIs() expects view-string, string given.'],
                 52 => ['Parameter #1 $view of method ViewStringSignatures\UsesInteractsWithViews::view() expects view-string, string given.'],
                 59 => ['Parameter #1 $view of static method Illuminate\View\Factory::make() expects view-string, string given.'],
-                65 => ['Parameter #2 $view of static method Illuminate\Support\Facades\Route::view() expects view-string, string given.'],
+                65 => ['Parameter #2 $view of static method Illuminate\Routing\Router::view() expects view-string, string given.'],
                 71 => ['Parameter #1 $textView of method Illuminate\Notifications\Messages\MailMessage::text() expects view-string, string given.'],
                 77 => ['Parameter #1 $textView of method Illuminate\Mail\Mailable::text() expects view-string, string given.'],
             ],

--- a/tests/Integration/data/view-string-signatures.php
+++ b/tests/Integration/data/view-string-signatures.php
@@ -4,6 +4,7 @@ namespace ViewStringSignatures;
 
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithViews;
+use Illuminate\Mail\Mailable;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\Route;
@@ -62,4 +63,16 @@ function routeFacadeView(): void
 {
     Route::view('/uri', 'route-view');
     Route::view('/uri', 'route-view-does-not-exist');
+}
+
+function mailMessageText(MailMessage $message): void
+{
+    $message->text('emails.mail-message.view');
+    $message->text('emails.mail-message.text-does-not-exist');
+}
+
+function mailableText(Mailable $mailable): void
+{
+    $mailable->text('emails.mailable.view');
+    $mailable->text('emails.mailable.text-does-not-exist');
 }

--- a/tests/Integration/data/view-string-signatures.php
+++ b/tests/Integration/data/view-string-signatures.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace ViewStringSignatures;
+
+use Illuminate\Contracts\View\Factory;
+use Illuminate\Foundation\Testing\Concerns\InteractsWithViews;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Routing\Router;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\View;
+use Illuminate\Testing\TestResponse;
+
+function factoryMake(Factory $factory): void
+{
+    $factory->make('view-factory-make');
+    $factory->make('view-factory-make-does-not-exist');
+}
+
+function routerView(Router $router): void
+{
+    $router->view('/uri', 'route-view');
+    $router->view('/uri', 'route-view-does-not-exist');
+}
+
+function mailMessage(MailMessage $message): void
+{
+    $message->view('emails.mail-message.view');
+    $message->view('emails.mail-message.view-does-not-exist');
+    $message->markdown('emails.mail-message.markdown');
+    $message->markdown('emails.mail-message.markdown-does-not-exist');
+}
+
+/** @param TestResponse<\Illuminate\Http\Response> $response */
+function testResponseAssertion(TestResponse $response): void
+{
+    $response->assertViewIs('home');
+    $response->assertViewIs('home-does-not-exist');
+}
+
+class UsesInteractsWithViews
+{
+    use InteractsWithViews;
+
+    public function good(): void
+    {
+        $this->view('home');
+    }
+
+    public function bad(): void
+    {
+        $this->view('home-does-not-exist');
+    }
+}
+
+function viewFacadeMake(): void
+{
+    View::make('view-factory-make');
+    View::make('view-factory-make-does-not-exist');
+}
+
+function routeFacadeView(): void
+{
+    Route::view('/uri', 'route-view');
+    Route::view('/uri', 'route-view-does-not-exist');
+}


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes

**Changes**

Extends `view-string` type coverage to signatures Larastan didn't stub yet:

- `Illuminate\Contracts\View\Factory::make()`
- `Illuminate\Routing\Router::view()`
- `Illuminate\Notifications\Messages\MailMessage::view()` / `markdown()`
- `Illuminate\Testing\TestResponse::assertViewIs()`
- `Illuminate\Foundation\Testing\Concerns\InteractsWithViews::view()`
- `Illuminate\Support\Facades\View::make()` and `Illuminate\Support\Facades\Route::view()` facade static calls

**Breaking changes**

None expected. These are additive type refinements on existing method signatures (plain `string` → `view-string`, a subtype of `string`); code passing dynamic (non-literal) view names is unaffected, since `view-string` only narrows/validates constant string literals.

While updating one of my projects, I deleted a view that was being used, and my CI checks didn't catch it.
I figured this would be helpful 