### PR TITLE
chore: remove `ext-json` dependency from `composer.json`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,6 @@
     ],
     "require": {
         "php": "^8.2",
-        "ext-json": "*",
         "iamcal/sql-parser": "^0.7.0",
         "illuminate/console": "^11.44.2 || ^12.4.1 || ^13",
         "illuminate/container": "^11.44.2 || ^12.4.1 || ^13",


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Documented user facing changes

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

> For composer.json file that had ext-json in the require section, this requirement is no longer necessary if already requires php ^8.0.

https://php.watch/versions/8.0/ext-json

<!-- Detail the changes in behaviour this PR introduces. -->

**Breaking changes**

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
