### PR TITLE
ci: bump GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/coding-standard.yml
+++ b/.github/workflows/coding-standard.yml
@@ -29,10 +29,10 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v4"
+        uses: actions/checkout@v7
 
       - name: "Setup PHP"
-        uses: "shivammathur/setup-php@v2"
+        uses: shivammathur/setup-php@v2
         with:
           php-version: "${{ matrix.php }}"
           extensions: "dom, curl, libxml, mbstring, zip, fileinfo"
@@ -40,21 +40,21 @@ jobs:
           coverage: "none"
 
       - name: "Check Composer configuration"
-        run: "composer validate"
+        run: "composer validate --ansi"
 
       - name: "Determine composer cache directory"
         id: "determine-composer-cache-directory"
         run: "echo \"COMPOSER_CACHE_DIR=$(composer config cache-dir)\" >> $GITHUB_ENV"
 
       - name: "Cache dependencies installed with composer"
-        uses: "actions/cache@v4"
+        uses: actions/cache@v6
         with:
           path: "${{ env.COMPOSER_CACHE_DIR }}"
           key: "php-${{ matrix.php }}-composer-${{ matrix.dependencies }}-${{ hashFiles('composer.lock') }}"
           restore-keys: "php-${{ matrix.php }}-composer-${{ matrix.dependencies }}-"
 
       - name: "Install dependencies from composer.json"
-        run: "composer update --no-interaction --no-progress"
+        run: "composer update --no-interaction --no-progress --ansi"
 
       - name: "Run phpcs"
         run: "composer test:cs"

--- a/.github/workflows/coding-standard.yml
+++ b/.github/workflows/coding-standard.yml
@@ -29,10 +29,10 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v7
+        uses: "actions/checkout@v7"
 
       - name: "Setup PHP"
-        uses: shivammathur/setup-php@v2
+        uses: "shivammathur/setup-php@v2"
         with:
           php-version: "${{ matrix.php }}"
           extensions: "dom, curl, libxml, mbstring, zip, fileinfo"
@@ -40,21 +40,21 @@ jobs:
           coverage: "none"
 
       - name: "Check Composer configuration"
-        run: "composer validate --ansi"
+        run: "composer validate"
 
       - name: "Determine composer cache directory"
         id: "determine-composer-cache-directory"
         run: "echo \"COMPOSER_CACHE_DIR=$(composer config cache-dir)\" >> $GITHUB_ENV"
 
       - name: "Cache dependencies installed with composer"
-        uses: actions/cache@v6
+        uses: "actions/cache@v6"
         with:
           path: "${{ env.COMPOSER_CACHE_DIR }}"
           key: "php-${{ matrix.php }}-composer-${{ matrix.dependencies }}-${{ hashFiles('composer.lock') }}"
           restore-keys: "php-${{ matrix.php }}-composer-${{ matrix.dependencies }}-"
 
       - name: "Install dependencies from composer.json"
-        run: "composer update --no-interaction --no-progress --ansi"
+        run: "composer update --no-interaction --no-progress"
 
       - name: "Run phpcs"
         run: "composer test:cs"

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,3 +1,4 @@
+---
 name: "E2E"
 
 on:
@@ -45,18 +46,18 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v7
+        uses: "actions/checkout@v7"
         with:
           path: "larastan"
 
       - name: "Install PHP"
-        uses: shivammathur/setup-php@v2
+        uses: "shivammathur/setup-php@v2"
         with:
           coverage: "none"
           php-version: "${{ matrix.php-version }}"
 
       - name: "Checkout dependent repo"
-        uses: actions/checkout@v7
+        uses: "actions/checkout@v7"
         with:
           repository: "${{ matrix.repository }}"
           ref: "${{ matrix.ref }}"
@@ -65,26 +66,26 @@ jobs:
       - name: "Install dependencies"
         run: |
           cd e2e/
-          composer install --no-scripts --no-interaction --ansi
+          composer install --no-scripts --no-interaction
           composer config repositories.0 '{ "type": "path", "url": "../larastan", "options": { "symlink": true } }'
           composer config minimum-stability dev
           if [ "${{ matrix.repository }}" = "monicahq/monica" ]; then
             composer remove --dev -n tomasvotruba/bladestan
           fi
           if [ "${{ matrix.force-phpstan-version }}" = "true" ]; then
-            composer require --dev --update-with-all-dependencies "larastan/larastan:*" "phpstan/phpstan:*" --ansi
+            composer require --dev --update-with-all-dependencies "larastan/larastan:*" "phpstan/phpstan:*"
           else
-            composer require --dev --update-with-all-dependencies "larastan/larastan:*" --ansi
+            composer require --dev --update-with-all-dependencies "larastan/larastan:*"
           fi
 
       - name: "Perform static analysis"
         working-directory: e2e
-        run: composer exec phpstan analyse -- -c "../larastan/e2e/${{ matrix.config }}" --no-progress --ansi
+        run: composer exec phpstan analyse -- -c "../larastan/e2e/${{ matrix.config }}"
 
       - name: "Generate baseline"
         if: ${{ failure() }}
         working-directory: e2e
-        run: composer exec phpstan analyse -- -c ../larastan/e2e/${{ matrix.config }} -b ../larastan/e2e/${{ matrix.baseline }}.baseline.neon --no-progress --ansi
+        run: composer exec phpstan analyse -- -c ../larastan/e2e/${{ matrix.config }} -b ../larastan/e2e/${{ matrix.baseline }}.baseline.neon
 
       - uses: actions/upload-artifact@v7
         if: ${{ failure() }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,4 +1,3 @@
----
 name: "E2E"
 
 on:
@@ -46,18 +45,18 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v4"
+        uses: actions/checkout@v7
         with:
           path: "larastan"
 
       - name: "Install PHP"
-        uses: "shivammathur/setup-php@v2"
+        uses: shivammathur/setup-php@v2
         with:
           coverage: "none"
           php-version: "${{ matrix.php-version }}"
 
       - name: "Checkout dependent repo"
-        uses: "actions/checkout@v4"
+        uses: actions/checkout@v7
         with:
           repository: "${{ matrix.repository }}"
           ref: "${{ matrix.ref }}"
@@ -66,28 +65,28 @@ jobs:
       - name: "Install dependencies"
         run: |
           cd e2e/
-          composer install --no-scripts --no-interaction
+          composer install --no-scripts --no-interaction --ansi
           composer config repositories.0 '{ "type": "path", "url": "../larastan", "options": { "symlink": true } }'
           composer config minimum-stability dev
           if [ "${{ matrix.repository }}" = "monicahq/monica" ]; then
             composer remove --dev -n tomasvotruba/bladestan
           fi
           if [ "${{ matrix.force-phpstan-version }}" = "true" ]; then
-            composer require --dev --update-with-all-dependencies "larastan/larastan:*" "phpstan/phpstan:*"
+            composer require --dev --update-with-all-dependencies "larastan/larastan:*" "phpstan/phpstan:*" --ansi
           else
-            composer require --dev --update-with-all-dependencies "larastan/larastan:*"
+            composer require --dev --update-with-all-dependencies "larastan/larastan:*" --ansi
           fi
 
       - name: "Perform static analysis"
         working-directory: e2e
-        run: composer exec phpstan analyse -- -c "../larastan/e2e/${{ matrix.config }}"
+        run: composer exec phpstan analyse -- -c "../larastan/e2e/${{ matrix.config }}" --no-progress --ansi
 
       - name: "Generate baseline"
         if: ${{ failure() }}
         working-directory: e2e
-        run: composer exec phpstan analyse -- -c ../larastan/e2e/${{ matrix.config }} -b ../larastan/e2e/${{ matrix.baseline }}.baseline.neon
+        run: composer exec phpstan analyse -- -c ../larastan/e2e/${{ matrix.config }} -b ../larastan/e2e/${{ matrix.baseline }}.baseline.neon --no-progress --ansi
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: ${{ failure() }}
         with:
           name: "baseline-${{ matrix.baseline }}"
@@ -99,7 +98,7 @@ jobs:
     if: ${{ always() && needs.integration-tests.result == 'failure' }}
     steps:
       - name: Merge Artifacts
-        uses: actions/upload-artifact/merge@v4
+        uses: actions/upload-artifact/merge@v7
         with:
           name: baselines
           pattern: baseline-*

--- a/.github/workflows/phpstan-dev.yml
+++ b/.github/workflows/phpstan-dev.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: "actions/checkout@v4"
+        uses: actions/checkout@v7
 
       - name: "Setup PHP"
-        uses: "shivammathur/setup-php@v2"
+        uses: shivammathur/setup-php@v2
         with:
           php-version: "${{ matrix.php }}"
           extensions: "dom, curl, libxml, mbstring, zip, fileinfo"
@@ -35,10 +35,10 @@ jobs:
         run: "composer config prefer-stable false"
 
       - name: "Require PHPStan dev version"
-        run: "composer require phpstan/phpstan:@dev --no-update --no-interaction --no-progress"
+        run: "composer require phpstan/phpstan:@dev --no-update --no-interaction --no-progress --ansi"
 
       - name: "Install highest dependencies from composer.json"
-        run: "composer update --with='laravel/framework:${{ matrix.laravel }}' --no-interaction --no-progress"
+        run: "composer update --with='laravel/framework:${{ matrix.laravel }}' --no-interaction --no-progress --ansi"
 
       - name: "Execute static analysis"
-        run: "composer run-script test:types"
+        run: "composer run-script test:types -- --no-progress"

--- a/.github/workflows/phpstan-dev.yml
+++ b/.github/workflows/phpstan-dev.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v7
+        uses: "actions/checkout@v7"
 
       - name: "Setup PHP"
-        uses: shivammathur/setup-php@v2
+        uses: "shivammathur/setup-php@v2"
         with:
           php-version: "${{ matrix.php }}"
           extensions: "dom, curl, libxml, mbstring, zip, fileinfo"
@@ -35,10 +35,10 @@ jobs:
         run: "composer config prefer-stable false"
 
       - name: "Require PHPStan dev version"
-        run: "composer require phpstan/phpstan:@dev --no-update --no-interaction --no-progress --ansi"
+        run: "composer require phpstan/phpstan:@dev --no-update --no-interaction --no-progress"
 
       - name: "Install highest dependencies from composer.json"
-        run: "composer update --with='laravel/framework:${{ matrix.laravel }}' --no-interaction --no-progress --ansi"
+        run: "composer update --with='laravel/framework:${{ matrix.laravel }}' --no-interaction --no-progress"
 
       - name: "Execute static analysis"
-        run: "composer run-script test:types -- --no-progress"
+        run: "composer run-script test:types"

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,4 +1,3 @@
----
 name: "Static Analysis"
 
 on:
@@ -40,10 +39,10 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: "actions/checkout@v4"
+        uses: actions/checkout@v7
 
       - name: "Setup PHP"
-        uses: "shivammathur/setup-php@v2"
+        uses: shivammathur/setup-php@v2
         with:
           php-version: "${{ matrix.php }}"
           extensions: "dom, curl, libxml, mbstring, zip, fileinfo"
@@ -52,11 +51,11 @@ jobs:
 
       - name: "Install dependencies from composer.json"
         if: "matrix.dependencies != 'lowest'"
-        run: "composer update --with='laravel/framework:${{ matrix.laravel }}' --no-interaction --no-progress"
+        run: "composer update --with='laravel/framework:${{ matrix.laravel }}' --no-interaction --no-progress --ansi"
 
       - name: "Install lowest dependencies from composer.json"
         if: "matrix.dependencies == 'lowest'"
-        run: "composer update --with='laravel/framework:${{ matrix.laravel }}' --no-interaction --no-progress --prefer-lowest"
+        run: "composer update --with='laravel/framework:${{ matrix.laravel }}' --no-interaction --no-progress --prefer-lowest --ansi"
 
       - name: "Execute static analysis"
-        run: "composer run-script test:types"
+        run: "composer run-script test:types -- --no-progress"

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,3 +1,4 @@
+---
 name: "Static Analysis"
 
 on:
@@ -39,10 +40,10 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v7
+        uses: "actions/checkout@v7"
 
       - name: "Setup PHP"
-        uses: shivammathur/setup-php@v2
+        uses: "shivammathur/setup-php@v2"
         with:
           php-version: "${{ matrix.php }}"
           extensions: "dom, curl, libxml, mbstring, zip, fileinfo"
@@ -51,11 +52,11 @@ jobs:
 
       - name: "Install dependencies from composer.json"
         if: "matrix.dependencies != 'lowest'"
-        run: "composer update --with='laravel/framework:${{ matrix.laravel }}' --no-interaction --no-progress --ansi"
+        run: "composer update --with='laravel/framework:${{ matrix.laravel }}' --no-interaction --no-progress"
 
       - name: "Install lowest dependencies from composer.json"
         if: "matrix.dependencies == 'lowest'"
-        run: "composer update --with='laravel/framework:${{ matrix.laravel }}' --no-interaction --no-progress --prefer-lowest --ansi"
+        run: "composer update --with='laravel/framework:${{ matrix.laravel }}' --no-interaction --no-progress --prefer-lowest"
 
       - name: "Execute static analysis"
-        run: "composer run-script test:types -- --no-progress"
+        run: "composer run-script test:types"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,3 @@
----
 name: "Tests"
 
 on:
@@ -40,10 +39,10 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: "actions/checkout@v4"
+        uses: actions/checkout@v7
 
       - name: "Setup PHP"
-        uses: "shivammathur/setup-php@v2"
+        uses: shivammathur/setup-php@v2
         with:
           php-version: "${{ matrix.php }}"
           extensions: "dom, curl, libxml, mbstring, zip, fileinfo"
@@ -51,24 +50,24 @@ jobs:
           coverage: "none"
 
       - name: "Check Composer configuration"
-        run: "composer validate"
+        run: "composer validate --ansi"
 
       - name: "Check file permissions"
         run: "test \"$(find . -type f -not -path './.git/*' -executable)\" == ./tests/laravel-test.sh"
 
       - name: "Install lowest dependencies from composer.json"
         if: "matrix.dependencies == 'lowest'"
-        run: "composer update --with='laravel/framework:${{ matrix.laravel }}' --no-interaction --no-progress --prefer-lowest"
+        run: "composer update --with='laravel/framework:${{ matrix.laravel }}' --no-interaction --no-progress --prefer-lowest --ansi"
 
       - name: "Install highest dependencies from composer.json"
         if: "matrix.dependencies == 'highest'"
-        run: "composer update --with='laravel/framework:${{ matrix.laravel }}' --no-interaction --no-progress"
+        run: "composer update --with='laravel/framework:${{ matrix.laravel }}' --no-interaction --no-progress --ansi"
 
       - name: "Check PSR-4 mapping"
-        run: "composer dump-autoload --optimize --strict-psr"
+        run: "composer dump-autoload --optimize --strict-psr --ansi"
 
       - name: "Execute unit tests"
-        run: "composer run-script test:unit"
+        run: "composer run-script test:unit --ansi -- --no-progress"
 
       - name: "Run Larastan on a sample Laravel application"
         run: |
@@ -82,10 +81,10 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: "actions/checkout@v4"
+        uses: actions/checkout@v7
 
       - name: "Setup PHP"
-        uses: "shivammathur/setup-php@v2"
+        uses: shivammathur/setup-php@v2
         with:
           php-version: "8.3"
           extensions: "dom, curl, libxml, mbstring, zip, fileinfo"
@@ -93,14 +92,14 @@ jobs:
           coverage: "none"
 
       - name: "Check Composer configuration"
-        run: "composer validate"
+        run: "composer validate --ansi"
 
       - name: "Install dependencies"
         run: |
-          composer require --dev phpmyadmin/sql-parser:^5.9 --no-interaction --no-progress
+          composer require --dev phpmyadmin/sql-parser:^5.9 --no-interaction --no-progress --ansi
 
       - name: "Check PSR-4 mapping"
-        run: "composer dump-autoload --optimize --strict-psr"
+        run: "composer dump-autoload --optimize --strict-psr --ansi"
 
       - name: "Execute SQL parser tests"
-        run: "./vendor/bin/phpunit tests/Unit/SQL/ --colors=always -d memory_limit=1408M"
+        run: "./vendor/bin/phpunit tests/Unit/SQL/ --colors=always -d memory_limit=1408M --no-progress"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,3 +1,4 @@
+---
 name: "Tests"
 
 on:
@@ -39,10 +40,10 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v7
+        uses: "actions/checkout@v7"
 
       - name: "Setup PHP"
-        uses: shivammathur/setup-php@v2
+        uses: "shivammathur/setup-php@v2"
         with:
           php-version: "${{ matrix.php }}"
           extensions: "dom, curl, libxml, mbstring, zip, fileinfo"
@@ -50,24 +51,24 @@ jobs:
           coverage: "none"
 
       - name: "Check Composer configuration"
-        run: "composer validate --ansi"
+        run: "composer validate"
 
       - name: "Check file permissions"
         run: "test \"$(find . -type f -not -path './.git/*' -executable)\" == ./tests/laravel-test.sh"
 
       - name: "Install lowest dependencies from composer.json"
         if: "matrix.dependencies == 'lowest'"
-        run: "composer update --with='laravel/framework:${{ matrix.laravel }}' --no-interaction --no-progress --prefer-lowest --ansi"
+        run: "composer update --with='laravel/framework:${{ matrix.laravel }}' --no-interaction --no-progress --prefer-lowest"
 
       - name: "Install highest dependencies from composer.json"
         if: "matrix.dependencies == 'highest'"
-        run: "composer update --with='laravel/framework:${{ matrix.laravel }}' --no-interaction --no-progress --ansi"
+        run: "composer update --with='laravel/framework:${{ matrix.laravel }}' --no-interaction --no-progress"
 
       - name: "Check PSR-4 mapping"
-        run: "composer dump-autoload --optimize --strict-psr --ansi"
+        run: "composer dump-autoload --optimize --strict-psr"
 
       - name: "Execute unit tests"
-        run: "composer run-script test:unit --ansi -- --no-progress"
+        run: "composer run-script test:unit"
 
       - name: "Run Larastan on a sample Laravel application"
         run: |
@@ -81,10 +82,10 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v7
+        uses: "actions/checkout@v7"
 
       - name: "Setup PHP"
-        uses: shivammathur/setup-php@v2
+        uses: "shivammathur/setup-php@v2"
         with:
           php-version: "8.3"
           extensions: "dom, curl, libxml, mbstring, zip, fileinfo"
@@ -92,14 +93,14 @@ jobs:
           coverage: "none"
 
       - name: "Check Composer configuration"
-        run: "composer validate --ansi"
+        run: "composer validate"
 
       - name: "Install dependencies"
         run: |
-          composer require --dev phpmyadmin/sql-parser:^5.9 --no-interaction --no-progress --ansi
+          composer require --dev phpmyadmin/sql-parser:^5.9 --no-interaction --no-progress
 
       - name: "Check PSR-4 mapping"
-        run: "composer dump-autoload --optimize --strict-psr --ansi"
+        run: "composer dump-autoload --optimize --strict-psr"
 
       - name: "Execute SQL parser tests"
-        run: "./vendor/bin/phpunit tests/Unit/SQL/ --colors=always -d memory_limit=1408M --no-progress"
+        run: "./vendor/bin/phpunit tests/Unit/SQL/ --colors=always -d memory_limit=1408M"

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "orchestra/canvas": "^v9.2.2 || ^10.0.1 || ^11",
         "orchestra/testbench-core": "^9.12.0 || ^10.1 || ^11",
         "phpstan/phpstan-deprecation-rules": "^2.0.1",
-        "phpunit/phpunit": "^10.5.35 || ^11.5.15 || ^12.5.8 || ^13.2.5"
+        "phpunit/phpunit": "^10.5.35 || ^11.5.15 || ^12.5.8 || ^13.3.0"
     },
     "suggest": {
         "orchestra/testbench": "Using Larastan for analysing a package needs Testbench",

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "orchestra/canvas": "^v9.2.2 || ^10.0.1 || ^11",
         "orchestra/testbench-core": "^9.12.0 || ^10.1 || ^11",
         "phpstan/phpstan-deprecation-rules": "^2.0.1",
-        "phpunit/phpunit": "^10.5.35 || ^11.5.15 || ^12.5.8 || ^13.1.8"
+        "phpunit/phpunit": "^10.5.35 || ^11.5.15 || ^12.5.8 || ^13.2.5"
     },
     "suggest": {
         "orchestra/testbench": "Using Larastan for analysing a package needs Testbench",

--- a/tests/Unit/MigrationHelperTest.php
+++ b/tests/Unit/MigrationHelperTest.php
@@ -8,6 +8,7 @@ use Larastan\Larastan\Properties\MigrationHelper;
 use Larastan\Larastan\Properties\SchemaTable;
 use PHPStan\File\FileHelper;
 use PHPStan\Parser\Parser;
+use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Testing\PHPStanTestCase;
 use PHPUnit\Framework\Attributes\Test;
 
@@ -18,6 +19,8 @@ class MigrationHelperTest extends PHPStanTestCase
     private Parser $parser;
 
     private FileHelper $fileHelper;
+
+    private ReflectionProvider $reflectionProvider;
 
     public function setUp(): void
     {

--- a/tests/Unit/ModelFactoryDynamicStaticMethodReturnTypeExtensionTest.php
+++ b/tests/Unit/ModelFactoryDynamicStaticMethodReturnTypeExtensionTest.php
@@ -49,7 +49,7 @@ class ModelFactoryDynamicStaticMethodReturnTypeExtensionTest extends PHPStanTest
         $class = new Name(User::class);
 
         $scope = $this->createMock(Scope::class);
-        $scope->method('resolveName')->with($class)->willReturn(User::class);
+        $scope->expects($this->once())->method('resolveName')->with($class)->willReturn(User::class);
 
         $extension = new ModelFactoryDynamicStaticMethodReturnTypeExtension(
             $this->createReflectionProvider(),
@@ -72,7 +72,7 @@ class ModelFactoryDynamicStaticMethodReturnTypeExtensionTest extends PHPStanTest
         $class = new Name(User::class);
 
         $scope = $this->createMock(Scope::class);
-        $scope->method('resolveName')->with($class)->willReturn(User::class);
+        $scope->expects($this->once())->method('resolveName')->with($class)->willReturn(User::class);
         $scope->method('getType')->willReturn($phpstanType);
 
         $extension = new ModelFactoryDynamicStaticMethodReturnTypeExtension(

--- a/tests/Unit/Support/BootstrapErrorHandlerTest.php
+++ b/tests/Unit/Support/BootstrapErrorHandlerTest.php
@@ -24,7 +24,6 @@ class BootstrapErrorHandlerTest extends TestCase
         // Mock getFile to return a path that looks like user code (not in vendor)
         $reflection   = new ReflectionClass($exception);
         $fileProperty = $reflection->getProperty('file');
-        $fileProperty->setAccessible(true);
         $fileProperty->setValue($exception, getcwd() . '/app/Providers/AppServiceProvider.php');
 
         $handler->handle($exception);
@@ -47,7 +46,6 @@ class BootstrapErrorHandlerTest extends TestCase
         // Mock getFile to return a path that looks like framework code (in vendor)
         $reflection   = new ReflectionClass($exception);
         $fileProperty = $reflection->getProperty('file');
-        $fileProperty->setAccessible(true);
         $fileProperty->setValue($exception, getcwd() . '/vendor/laravel/framework/src/Illuminate/Foundation/Application.php');
 
         $handler->handle($exception);
@@ -87,7 +85,6 @@ class BootstrapErrorHandlerTest extends TestCase
         // Mock getFile to return a path that looks like user code
         $reflection   = new ReflectionClass($exception);
         $fileProperty = $reflection->getProperty('file');
-        $fileProperty->setAccessible(true);
         $fileProperty->setValue($exception, getcwd() . '/app/Providers/AppServiceProvider.php');
 
         $handler->handle($exception);
@@ -110,7 +107,6 @@ class BootstrapErrorHandlerTest extends TestCase
         // Mock getFile to return a path that looks like user code
         $reflection   = new ReflectionClass($exception);
         $fileProperty = $reflection->getProperty('file');
-        $fileProperty->setAccessible(true);
         $fileProperty->setValue($exception, getcwd() . '/app/Providers/AppServiceProvider.php');
 
         $handler->handle($exception);

--- a/tests/laravel-test.sh
+++ b/tests/laravel-test.sh
@@ -9,7 +9,7 @@ export COMPOSER_NO_SECURITY_BLOCKING=1
 LARAVEL_VERSION_CONSTRAINT="${1:-^11.0}"
 
 echo "Install Laravel ${LARAVEL_VERSION_CONSTRAINT}"
-composer create-project --quiet --prefer-dist "laravel/laravel:${LARAVEL_VERSION_CONSTRAINT}" ../laravel
+composer create-project --quiet --prefer-dist --ansi "laravel/laravel:${LARAVEL_VERSION_CONSTRAINT}" ../laravel
 cd ../laravel/
 SAMPLE_APP_DIR="$(pwd)"
 composer show --direct
@@ -19,7 +19,7 @@ composer config minimum-stability dev
 composer config repositories.0 '{ "type": "path", "url": "../larastan", "options": { "symlink": false } }'
 
 # No version information with "type":"path"
-composer require --dev --optimize-autoloader "larastan/larastan:*"
+composer require --dev --optimize-autoloader "larastan/larastan:*" --ansi
 
 cat >phpstan.neon <<"EOF"
 includes:
@@ -31,8 +31,8 @@ parameters:
 EOF
 
 echo "Test Laravel"
-vendor/bin/phpstan analyse
+vendor/bin/phpstan analyse --no-progress --ansi
 
 echo "Test Laravel from another working directory"
 cd /tmp/
-${SAMPLE_APP_DIR}/vendor/bin/phpstan analyse --configuration=${SAMPLE_APP_DIR}/phpstan.neon
+${SAMPLE_APP_DIR}/vendor/bin/phpstan analyse --configuration=${SAMPLE_APP_DIR}/phpstan.neon --no-progress --ansi

--- a/tests/laravel-test.sh
+++ b/tests/laravel-test.sh
@@ -9,7 +9,7 @@ export COMPOSER_NO_SECURITY_BLOCKING=1
 LARAVEL_VERSION_CONSTRAINT="${1:-^11.0}"
 
 echo "Install Laravel ${LARAVEL_VERSION_CONSTRAINT}"
-composer create-project --quiet --prefer-dist --ansi "laravel/laravel:${LARAVEL_VERSION_CONSTRAINT}" ../laravel
+composer create-project --quiet --prefer-dist "laravel/laravel:${LARAVEL_VERSION_CONSTRAINT}" ../laravel
 cd ../laravel/
 SAMPLE_APP_DIR="$(pwd)"
 composer show --direct
@@ -19,7 +19,7 @@ composer config minimum-stability dev
 composer config repositories.0 '{ "type": "path", "url": "../larastan", "options": { "symlink": false } }'
 
 # No version information with "type":"path"
-composer require --dev --optimize-autoloader "larastan/larastan:*" --ansi
+composer require --dev --optimize-autoloader "larastan/larastan:*"
 
 cat >phpstan.neon <<"EOF"
 includes:
@@ -31,8 +31,8 @@ parameters:
 EOF
 
 echo "Test Laravel"
-vendor/bin/phpstan analyse --no-progress --ansi
+vendor/bin/phpstan analyse
 
 echo "Test Laravel from another working directory"
 cd /tmp/
-${SAMPLE_APP_DIR}/vendor/bin/phpstan analyse --configuration=${SAMPLE_APP_DIR}/phpstan.neon --no-progress --ansi
+${SAMPLE_APP_DIR}/vendor/bin/phpstan analyse --configuration=${SAMPLE_APP_DIR}/phpstan.neon


### PR DESCRIPTION
- `actions/checkout@v4`→`v7`, `actions/cache@v4`→`v6`, `actions/upload-artifact@v4`→`v7` (+ `upload-artifact/merge`) — clears the Node 20 deprecation warnings
- `phpunit/phpunit` floor bumped to `^13.3.0`
- test deprecation fixes: declared property instead of dynamic, drop redundant `ReflectionProperty::setAccessible(true)`, `expects($this->once())`

Rebased onto latest `3.x`; the earlier schema-aggregator and e2e-baseline churn is now covered upstream (#2506, #2528).