### PR TITLE
feat: add NoSchemaExistenceChecksInMigrationsRule

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -480,6 +480,79 @@ parameters:
         - tests
 ```
 
+## NoSchemaExistenceChecksInMigrations
+
+Checks for schema existence checks — `Schema::hasTable()`, `Schema::hasColumn()` and `Schema::hasColumns()` —
+inside your migration directories.
+
+A migration always runs against a known schema state: the state left behind by the migrations before it.
+Guarding a migration with an existence check silently turns a broken migration history into a no-op,
+so the failure only surfaces much later, on a different environment.
+
+### Examples
+
+```php
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('users')) {
+            Schema::create('users', function (Blueprint $table) {
+                $table->id();
+            });
+        }
+    }
+};
+```
+
+Will result in the following error:
+
+```
+Called 'Schema::hasTable()' inside a migration. A migration runs against a known schema state, remove the conditional check.
+```
+
+Write the migration unconditionally instead:
+
+```php
+Schema::create('users', function (Blueprint $table) {
+    $table->id();
+});
+```
+
+The rule reports the check whether or not it is negated, and it also catches checks made on a
+specific connection, like `Schema::connection('mysql')->hasTable('users')`.
+
+### Configuration
+
+This rule is disabled by default, since packages legitimately need to guard against the schema of the
+application they are installed into. To enable it, add the following to your `phpstan.neon` file:
+
+```neon
+parameters:
+    noSchemaExistenceChecksInMigrations: true
+```
+
+By default, this rule checks the application migrations directory (`database/migrations`). If your
+migrations are stored elsewhere, use the [`databaseMigrationsPath`](custom-config-parameters.md#databasemigrationspath)
+option to specify them. Globs are supported:
+
+```neon
+parameters:
+    databaseMigrationsPath:
+        - database/migrations
+        - modules/*/database/migrations
+```
+
+If a migration genuinely needs the check, ignore it for that file:
+
+```neon
+parameters:
+    ignoreErrors:
+        -
+            identifier: larastan.noSchemaExistenceChecksInMigrations
+            path: database/migrations/2024_01_01_000000_fix_legacy_table.php
+```
+
 ## ModelAppendsRule
 
 Checks model's `$appends` property for computed properties. The properties added to `$appends` array should both exist in the model and be computed properties.

--- a/extension.neon
+++ b/extension.neon
@@ -16,6 +16,7 @@ parameters:
     noUnnecessaryCollectionCallOnly: []
     noUnnecessaryCollectionCallExcept: []
     noUnnecessaryEnumerableToArrayCalls: false
+    noSchemaExistenceChecksInMigrations: false
     squashedMigrationsPath: []
     databaseMigrationsPath: []
     disableMigrationScan: false
@@ -42,6 +43,7 @@ parametersSchema:
     noUnnecessaryCollectionCallOnly: listOf(string())
     noUnnecessaryCollectionCallExcept: listOf(string())
     noUnnecessaryEnumerableToArrayCalls: bool()
+    noSchemaExistenceChecksInMigrations: bool()
     databaseMigrationsPath: listOf(string())
     disableMigrationScan: bool()
     configDirectories: listOf(string())
@@ -69,6 +71,8 @@ conditionalTags:
         phpstan.rules.rule: %noUnnecessaryCollectionCall%
     Larastan\Larastan\Rules\NoUnnecessaryEnumerableToArrayCallsRule:
         phpstan.rules.rule: %noUnnecessaryEnumerableToArrayCalls%
+    Larastan\Larastan\Rules\NoSchemaExistenceChecksInMigrationsRule:
+        phpstan.rules.rule: %noSchemaExistenceChecksInMigrations%
     Larastan\Larastan\Rules\OctaneCompatibilityRule:
         phpstan.rules.rule: %checkOctaneCompatibility%
     Larastan\Larastan\Rules\UnusedViewsRule:
@@ -420,6 +424,11 @@ services:
 
     -
         class: Larastan\Larastan\Rules\NoUnnecessaryEnumerableToArrayCallsRule
+
+    -
+        class: Larastan\Larastan\Rules\NoSchemaExistenceChecksInMigrationsRule
+        arguments:
+            migrationDirectories: %databaseMigrationsPath%
 
     -
         class: Larastan\Larastan\Rules\ModelAppendsRule

--- a/src/Rules/NoSchemaExistenceChecksInMigrationsRule.php
+++ b/src/Rules/NoSchemaExistenceChecksInMigrationsRule.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Larastan\Larastan\Rules;
+
+use Illuminate\Database\Schema\Builder;
+use Illuminate\Support\Facades\Schema;
+use PhpParser\Node;
+use PhpParser\Node\Expr\CallLike;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PHPStan\Analyser\Scope;
+use PHPStan\File\FileHelper;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+
+use function count;
+use function database_path;
+use function glob;
+use function in_array;
+use function is_dir;
+use function sprintf;
+use function str_starts_with;
+
+/**
+ * Catches schema existence checks, like `Schema::hasTable()` and `Schema::hasColumn()`,
+ * inside the migration directories.
+ *
+ * A migration always runs against a known schema state, so guarding it with an
+ * existence check hides the real problem instead of solving it.
+ *
+ * @implements Rule<CallLike>
+ */
+class NoSchemaExistenceChecksInMigrationsRule implements Rule
+{
+    private const EXISTENCE_CHECKS = ['hasTable', 'hasColumn', 'hasColumns'];
+
+    /** @var list<string>|null */
+    private array|null $absoluteMigrationDirectories = null;
+
+    /** @param list<non-empty-string> $migrationDirectories */
+    public function __construct(private array $migrationDirectories, private FileHelper $fileHelper)
+    {
+    }
+
+    public function getNodeType(): string
+    {
+        return CallLike::class;
+    }
+
+    /**
+     * @param CallLike $node
+     *
+     * @return list<IdentifierRuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $methodName = $this->getExistenceCheckName($node, $scope);
+
+        if ($methodName === null) {
+            return [];
+        }
+
+        if (! $this->isInsideMigrations($scope->getFile())) {
+            return [];
+        }
+
+        return [
+            RuleErrorBuilder::message(sprintf(
+                "Called 'Schema::%s()' inside a migration. A migration runs against a known schema state, remove the conditional check.",
+                $methodName,
+            ))
+                ->identifier('larastan.noSchemaExistenceChecksInMigrations')
+                ->line($node->getStartLine())
+                ->build(),
+        ];
+    }
+
+    /** @return value-of<self::EXISTENCE_CHECKS>|null */
+    private function getExistenceCheckName(CallLike $node, Scope $scope): string|null
+    {
+        if ($node instanceof StaticCall) {
+            if (! $node->class instanceof Name) {
+                return null;
+            }
+
+            $calledOn = new ObjectType($scope->resolveName($node->class));
+            $expected = new ObjectType(Schema::class);
+        } elseif ($node instanceof MethodCall) {
+            $calledOn = $scope->getType($node->var);
+            $expected = new ObjectType(Builder::class);
+        } else {
+            return null;
+        }
+
+        if (! $this->isSchema($expected, $calledOn)) {
+            return null;
+        }
+
+        if (! $node->name instanceof Identifier) {
+            return null;
+        }
+
+        $methodName = $node->name->toString();
+
+        if (! in_array($methodName, self::EXISTENCE_CHECKS, true)) {
+            return null;
+        }
+
+        return $methodName;
+    }
+
+    private function isSchema(ObjectType $expected, Type $calledOn): bool
+    {
+        return $expected->isSuperTypeOf($calledOn)->yes();
+    }
+
+    private function isInsideMigrations(string $file): bool
+    {
+        foreach ($this->getMigrationDirectories() as $migrationDirectory) {
+            if (str_starts_with($file, $migrationDirectory)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /** @return list<string> */
+    private function getMigrationDirectories(): array
+    {
+        if ($this->absoluteMigrationDirectories !== null) {
+            return $this->absoluteMigrationDirectories;
+        }
+
+        $directoryGlobs = $this->migrationDirectories;
+
+        if (count($directoryGlobs) === 0) {
+            $directoryGlobs = [database_path('migrations')]; // @phpstan-ignore-line
+        }
+
+        $this->absoluteMigrationDirectories = [];
+
+        foreach ($directoryGlobs as $directoryGlob) {
+            foreach ((glob($this->fileHelper->normalizePath($directoryGlob)) ?: []) as $directory) {
+                $absolutePath = $this->fileHelper->absolutizePath($directory);
+
+                if (! is_dir($absolutePath)) {
+                    continue;
+                }
+
+                $this->absoluteMigrationDirectories[] = $absolutePath;
+            }
+        }
+
+        return $this->absoluteMigrationDirectories;
+    }
+}

--- a/tests/Rules/NoSchemaExistenceChecksInMigrationsRuleTest.php
+++ b/tests/Rules/NoSchemaExistenceChecksInMigrationsRuleTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Rules;
+
+use Illuminate\Foundation\Application;
+use Larastan\Larastan\Rules\NoSchemaExistenceChecksInMigrationsRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/** @extends RuleTestCase<NoSchemaExistenceChecksInMigrationsRule> */
+class NoSchemaExistenceChecksInMigrationsRuleTest extends RuleTestCase
+{
+    /** @var list<non-empty-string> */
+    private array $migrationDirectories = [];
+
+    private string|null $originalDatabasePath = null;
+
+    protected function tearDown(): void
+    {
+        if ($this->originalDatabasePath !== null) {
+            Application::getInstance()->useDatabasePath($this->originalDatabasePath);
+            $this->originalDatabasePath = null;
+        }
+
+        parent::tearDown();
+    }
+
+    protected function getRule(): Rule
+    {
+        return new NoSchemaExistenceChecksInMigrationsRule($this->migrationDirectories, $this->getFileHelper());
+    }
+
+    #[Test]
+    public function itReportsSchemaExistenceChecksInsideMigrations(): void
+    {
+        $this->migrationDirectories = [__DIR__ . '/data/migrations'];
+
+        $this->analyse([__DIR__ . '/data/migrations/2024_01_01_000000_create_users_table.php'], [
+            ["Called 'Schema::hasTable()' inside a migration. A migration runs against a known schema state, remove the conditional check.", 13],
+            ["Called 'Schema::hasColumn()' inside a migration. A migration runs against a known schema state, remove the conditional check.", 19],
+            ["Called 'Schema::hasColumns()' inside a migration. A migration runs against a known schema state, remove the conditional check.", 23],
+            ["Called 'Schema::hasTable()' inside a migration. A migration runs against a known schema state, remove the conditional check.", 27],
+            ["Called 'Schema::hasColumn()' inside a migration. A migration runs against a known schema state, remove the conditional check.", 33],
+            ["Called 'Schema::hasTable()' inside a migration. A migration runs against a known schema state, remove the conditional check.", 40],
+        ]);
+    }
+
+    #[Test]
+    public function itDoesNotReportMigrationsWithoutExistenceChecks(): void
+    {
+        $this->migrationDirectories = [__DIR__ . '/data/migrations'];
+
+        $this->analyse([__DIR__ . '/data/migrations/2024_01_02_000000_create_posts_table.php'], []);
+    }
+
+    #[Test]
+    public function itDoesNotReportSchemaExistenceChecksOutsideOfMigrations(): void
+    {
+        $this->migrationDirectories = [__DIR__ . '/data/migrations'];
+
+        $this->analyse([__DIR__ . '/data/schema-existence-checks.php'], []);
+    }
+
+    #[Test]
+    public function itReportsSchemaExistenceChecksInsideGlobMigrationDirectories(): void
+    {
+        $this->migrationDirectories = [__DIR__ . '/data/module/*/migrations'];
+
+        $this->analyse([
+            __DIR__ . '/data/module/foo/migrations/2024_01_01_000000_add_flag_to_users_table.php',
+            __DIR__ . '/data/module/bar/migrations/2024_01_01_000000_add_flag_to_posts_table.php',
+        ], [
+            ["Called 'Schema::hasColumn()' inside a migration. A migration runs against a known schema state, remove the conditional check.", 13],
+            ["Called 'Schema::hasTable()' inside a migration. A migration runs against a known schema state, remove the conditional check.", 13],
+        ]);
+    }
+
+    #[Test]
+    public function itFallsBackToTheApplicationMigrationsDirectory(): void
+    {
+        $this->overrideDatabasePath(__DIR__ . '/data/database');
+
+        $this->migrationDirectories = [];
+
+        $this->analyse([__DIR__ . '/data/database/migrations/2024_01_01_000000_create_comments_table.php'], [
+            ["Called 'Schema::hasTable()' inside a migration. A migration runs against a known schema state, remove the conditional check.", 13],
+        ]);
+    }
+
+    protected function overrideDatabasePath(string $path): void
+    {
+        $app = Application::getInstance();
+
+        $this->originalDatabasePath = $app->databasePath();
+
+        $app->useDatabasePath($path);
+    }
+}

--- a/tests/Rules/data/database/migrations/2024_01_01_000000_create_comments_table.php
+++ b/tests/Rules/data/database/migrations/2024_01_01_000000_create_comments_table.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('comments')) {
+            return;
+        }
+
+        Schema::create('comments', function (Blueprint $table) {
+            $table->id();
+        });
+    }
+};

--- a/tests/Rules/data/migrations/2024_01_01_000000_create_users_table.php
+++ b/tests/Rules/data/migrations/2024_01_01_000000_create_users_table.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('users')) {
+            Schema::create('users', function (Blueprint $table) {
+                $table->id();
+            });
+        }
+
+        if (Schema::hasColumn('users', 'name')) {
+            return;
+        }
+
+        if (! Schema::hasColumns('users', ['name', 'email'])) {
+            return;
+        }
+
+        if (! Schema::connection('mysql')->hasTable('users')) {
+            return;
+        }
+
+        $schema = Schema::connection('mysql');
+
+        if ($schema->hasColumn('users', 'email')) {
+            return;
+        }
+    }
+
+    public function down(): void
+    {
+        if (Schema::hasTable('users')) {
+            Schema::drop('users');
+        }
+    }
+};

--- a/tests/Rules/data/migrations/2024_01_02_000000_create_posts_table.php
+++ b/tests/Rules/data/migrations/2024_01_02_000000_create_posts_table.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('posts', function (Blueprint $table) {
+            $table->id();
+            $table->string('title');
+        });
+
+        Schema::table('posts', function (Blueprint $table) {
+            $table->string('subtitle');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('posts');
+    }
+};

--- a/tests/Rules/data/module/bar/migrations/2024_01_01_000000_add_flag_to_posts_table.php
+++ b/tests/Rules/data/module/bar/migrations/2024_01_01_000000_add_flag_to_posts_table.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('posts')) {
+            return;
+        }
+
+        Schema::table('posts', function (Blueprint $table) {
+            $table->boolean('flag');
+        });
+    }
+};

--- a/tests/Rules/data/module/foo/migrations/2024_01_01_000000_add_flag_to_users_table.php
+++ b/tests/Rules/data/module/foo/migrations/2024_01_01_000000_add_flag_to_users_table.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasColumn('users', 'flag')) {
+            return;
+        }
+
+        Schema::table('users', function (Blueprint $table) {
+            $table->boolean('flag');
+        });
+    }
+};

--- a/tests/Rules/data/schema-existence-checks.php
+++ b/tests/Rules/data/schema-existence-checks.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Rules\Data;
+
+use Illuminate\Support\Facades\Schema;
+
+function schemaChecksOutsideOfMigrations(): bool
+{
+    if (! Schema::hasTable('users')) {
+        return false;
+    }
+
+    if (! Schema::hasColumn('users', 'name')) {
+        return false;
+    }
+
+    return ! Schema::connection('mysql')->hasTable('users');
+}


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Documented user facing changes

**Changes**

Adds a new opt-in rule, `NoSchemaExistenceChecksInMigrationsRule`, which reports `Schema::hasTable()`, `Schema::hasColumn()` and `Schema::hasColumns()` calls made inside the migration directories.

A migration always runs against a known schema state — the one left behind by the migrations before it. Guarding a migration with an existence check silently turns a broken migration history into a no-op, so the failure surfaces much later and on a different environment instead of where it happened.

```php
return new class extends Migration
{
    public function up(): void
    {
        if (! Schema::hasTable('users')) {
            Schema::create('users', function (Blueprint $table) {
                $table->id();
            });
        }
    }
};
```

```
Called 'Schema::hasTable()' inside a migration. A migration runs against a known schema state, remove the conditional check.
```

Details:

* The check is reported whether or not it is negated — `if (Schema::hasColumn(...)) { $table->dropColumn(...); }` is the same smell, and matching only the negated form would be trivially sidestepped by inverting the condition.
* Connection-scoped checks such as `Schema::connection('mysql')->hasTable('users')` are caught too. The rule registers on `PhpParser\Node\Expr\CallLike` so a single rule handles both the facade `StaticCall` and `MethodCall`s on an `Illuminate\Database\Schema\Builder`.
* Migration directories are read from the existing `databaseMigrationsPath` parameter (globs supported), falling back to `database_path('migrations')` — no new path parameter to configure.
* The rule is **disabled by default** (`noSchemaExistenceChecksInMigrations: false`), since packages legitimately need to guard against the schema of the application they are installed into. It is aimed at end applications.
* Errors carry the `larastan.noSchemaExistenceChecksInMigrations` identifier, so genuine exceptions can be ignored per file.

Tests cover all reported forms, a clean migration, the same checks outside the migration directories, glob directories, and the `database_path('migrations')` fallback. `docs/rules.md` has a new section with rationale, examples and configuration.

**Breaking changes**

None. The rule is disabled by default, so no existing analysis result changes.
