### PR TITLE
feat: detect anonymous Blade component views in checkUnusedViews

### DIFF
--- a/src/Collectors/UsedViewInAnotherViewCollector.php
+++ b/src/Collectors/UsedViewInAnotherViewCollector.php
@@ -8,10 +8,7 @@ use Larastan\Larastan\Support\ViewFileHelper;
 use Larastan\Larastan\Support\ViewParser;
 use PhpParser\Node;
 
-use function array_filter;
-use function array_map;
 use function array_merge;
-use function count;
 use function preg_match_all;
 
 use const PREG_SET_ORDER;
@@ -20,6 +17,14 @@ final class UsedViewInAnotherViewCollector
 {
     /** @see https://regex101.com/r/OyHHCY/1 */
     private const VIEW_NAME_REGEX = '/@(extends|include(If|Unless|When|First)?)(\(.*?([\'"])(.*?)([\'"])([),]))/m';
+
+    /**
+     * Anonymous Blade component tags — `<x-alert>`, `<x-forms.input />`, `</x-card>` — which resolve to the
+     * `components.<name>` view (or its `.index` variant). `<x-slot …>` is a slot, not a component.
+     *
+     * @see https://laravel.com/docs/blade#anonymous-components
+     */
+    private const COMPONENT_TAG_REGEX = '/<\/?x-([a-zA-Z0-9][a-zA-Z0-9._-]*)/';
 
     public function __construct(private ViewParser $viewParser, private ViewFileHelper $viewFileHelper)
     {
@@ -46,22 +51,51 @@ final class UsedViewInAnotherViewCollector
      */
     private function processNodes(array $nodes): array
     {
-        $nodes = array_filter($nodes, static function (Node $node) {
-            return $node instanceof Node\Stmt\InlineHTML;
-        });
-
-        if (count($nodes) === 0) {
-            return [];
-        }
-
         $usedViews = [];
 
         foreach ($nodes as $node) {
+            if (! $node instanceof Node\Stmt\InlineHTML) {
+                continue;
+            }
+
             preg_match_all(self::VIEW_NAME_REGEX, $node->value, $matches, PREG_SET_ORDER, 0);
 
-            $usedViews = array_merge($usedViews, array_map(static function ($match) {
-                return $match[5];
-            }, $matches));
+            foreach ($matches as $match) {
+                $usedViews[] = $match[5];
+            }
+
+            $usedViews = array_merge($usedViews, $this->componentViews($node->value));
+        }
+
+        return $usedViews;
+    }
+
+    /**
+     * Views referenced through anonymous Blade component tags in the given HTML.
+     *
+     * @return list<string>
+     */
+    private function componentViews(string $html): array
+    {
+        preg_match_all(self::COMPONENT_TAG_REGEX, $html, $matches, PREG_SET_ORDER, 0);
+
+        $usedViews = [];
+
+        foreach ($matches as $match) {
+            $name = $match[1];
+
+            if ($name === 'slot') {
+                continue;
+            }
+
+            // The `resources/views/components` directory is commonly registered as its own view path, where
+            // an anonymous component is named by its short path (`alert`); the same file is also reachable
+            // as `components.alert` under `resources/views`. A component can additionally be an index file
+            // (`alert/index.blade.php`). Emit every form so whichever naming the project uses is matched.
+            foreach ([$name, 'components.' . $name] as $view) {
+                $usedViews[] = $view;
+                $usedViews[] = $view . '.index';
+            }
         }
 
         return $usedViews;

--- a/tests/Rules/UnusedViewsRuleTest.php
+++ b/tests/Rules/UnusedViewsRuleTest.php
@@ -46,7 +46,14 @@ class UnusedViewsRuleTest extends RuleTestCase
 
     public function testRule(): void
     {
+        // `unused.blade.php` and `components/orphan.blade.php` are referenced nowhere. The
+        // `components/alert.blade.php` view IS used, but only through the `<x-alert>` Blade component tag
+        // in `index.blade.php` — so it must not be reported (regression guard for component-tag detection).
         $this->analyse([__DIR__ . '/data/FooController.php'], [
+            [
+                'This view is not used in the project.',
+                00,
+            ],
             [
                 'This view is not used in the project.',
                 00,

--- a/tests/application/resources/views/components/alert.blade.php
+++ b/tests/application/resources/views/components/alert.blade.php
@@ -1,0 +1,1 @@
+<div class="alert">{{ $slot }}</div>

--- a/tests/application/resources/views/components/orphan.blade.php
+++ b/tests/application/resources/views/components/orphan.blade.php
@@ -1,0 +1,1 @@
+<div class="orphan"></div>

--- a/tests/application/resources/views/index.blade.php
+++ b/tests/application/resources/views/index.blade.php
@@ -7,3 +7,5 @@
 Lorem ipsum
 
 @include("home")
+
+<x-alert>Heads up</x-alert>


### PR DESCRIPTION
`UnusedViewsRule` (`checkUnusedViews`) only traced `view()` / `@include` / `@extends`, so anonymous Blade components rendered via `<x-...>` tags were always reported as unused — a false positive for any component-driven app.

`UsedViewInAnotherViewCollector` now also scans view HTML for `<x-name>` / `<x-a.b />` / `</x-name>` tags and marks the corresponding view used, under both the short (`name`, when `resources/views/components` is a registered view path) and prefixed (`components.name`) namings, plus their `.index` variants. `<x-slot>` is skipped (it is a slot, not a component).

Adds a regression test: a component used only through `<x-alert>` is no longer flagged, while an unreferenced component still is.