### PR TITLE
feat: add seven opt-in rules for queued jobs

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -663,3 +663,427 @@ This rule is disabled by default. To enable, add the following to your `phpstan.
 parameters:
     checkConfigTypes: true
 ```
+
+## UniqueJobDeclaresUniqueForRule
+
+Every job implementing `Illuminate\Contracts\Queue\ShouldBeUnique` (including
+`ShouldBeUniqueUntilProcessing`, which extends it) must declare `uniqueFor`, either as a
+property (`public int $uniqueFor = 3600;`) or a method (`public function uniqueFor(): int`).
+
+Without `uniqueFor` the uniqueness lock is held until the job finishes processing. If a
+worker dies mid job (OOM, deploy, fatal) the lock is never released and the job can never be
+dispatched again until the cache key is cleared by hand. `uniqueFor` bounds the lock so a
+stuck job self heals after the timeout.
+
+Abstract classes are skipped. They aren't dispatched directly, and a concrete subclass
+supplies (or inherits) `uniqueFor`.
+
+### Examples
+
+```php
+class FetchSocialAvatar implements ShouldQueue, ShouldBeUnique
+{
+    public function uniqueId(): string
+    {
+        return (string) $this->userId;
+    }
+}
+```
+
+Will result in the following error:
+
+```
+Job 'App\Jobs\FetchSocialAvatar' implements ShouldBeUnique but does not declare uniqueFor, so a worker that dies mid job leaks the lock and the job can never be dispatched again. Add a 'public int $uniqueFor' property or a 'uniqueFor()' method.
+```
+
+To fix the error, declare how long the lock may live:
+
+```php
+class FetchSocialAvatar implements ShouldQueue, ShouldBeUnique
+{
+    public int $uniqueFor = 3600;
+
+    public function uniqueId(): string
+    {
+        return (string) $this->userId;
+    }
+}
+```
+
+### Configuration
+
+This rule is disabled by default.
+To enable, add the following to your `phpstan.neon` file:
+
+```neon
+parameters:
+    checkUniqueJobUniqueFor: true
+```
+
+## UniqueJobDeclaresUniqueIdRule
+
+A **parameterized** `ShouldBeUnique` job, meaning one whose constructor takes arguments,
+must declare `uniqueId`: a method (`public function uniqueId(): string`) or a property
+(`public $uniqueId`).
+
+Laravel builds the lock key as `laravel_unique_job:<class>:<uniqueId>` and falls back to an
+empty `uniqueId` when neither is declared (`Illuminate\Bus\UniqueLock::getKey`). For a
+parameterized job the empty key collapses *every* dispatch into one unique job regardless of
+its arguments, so legitimately distinct jobs (per company, per product, ...) are silently
+dropped at dispatch with no error. That lost work failure is harder to spot than a leaked
+lock.
+
+The rule fires only when the constructor has at least one parameter: a parameterless job is
+a legitimate singleton whose class name only key is correct. A job that is intentionally
+class wide satisfies the rule by declaring `uniqueId()` returning a constant, which makes
+that intent explicit. Abstract classes are skipped.
+
+### Examples
+
+```php
+class SyncCompany implements ShouldQueue, ShouldBeUnique
+{
+    public int $uniqueFor = 3600;
+
+    public function __construct(public int $companyId)
+    {
+    }
+}
+```
+
+Will result in the following error:
+
+```
+Job 'App\Jobs\SyncCompany' implements ShouldBeUnique and is parameterized but does not declare uniqueId, so every dispatch shares one lock key whatever the constructor arguments and distinct jobs are silently dropped. Add a 'uniqueId()' method derived from the distinguishing arguments, or return a constant from it for an intentionally class wide job.
+```
+
+To fix the error, scope the lock to the arguments that make the job distinct:
+
+```php
+class SyncCompany implements ShouldQueue, ShouldBeUnique
+{
+    public int $uniqueFor = 3600;
+
+    public function __construct(public int $companyId)
+    {
+    }
+
+    public function uniqueId(): string
+    {
+        return (string) $this->companyId;
+    }
+}
+```
+
+### Configuration
+
+This rule is disabled by default.
+To enable, add the following to your `phpstan.neon` file:
+
+```neon
+parameters:
+    checkUniqueJobUniqueId: true
+```
+
+## NoBatchedUniqueJobRule
+
+A `ShouldBeUnique` job must not be dispatched through the bulk or batch entry points:
+`Bus::batch([...])`, `Bus::bulk([...])` or the equivalent `Queue::bulk([...])`. Both bypass
+the per job uniqueness guarantee:
+
+- `Queue::bulk()` and `Bus::bulk()` push raw payloads straight onto the queue, skipping the
+  dispatcher path that acquires the unique lock, so duplicates are queued and
+  `ShouldBeUnique` silently does nothing.
+- Batching a unique job means a duplicate is dropped at dispatch, but the batch's job count
+  is computed up front, so the batch's progress and `then`/`finally` callbacks never
+  reconcile and the batch can hang as pending.
+
+Dispatch unique jobs individually (`Foo::dispatch(...)`). The rule recurses into nested
+arrays (chains within a batch) and reports each offending job.
+
+### Examples
+
+```php
+Bus::batch([
+    new SyncCompany(1),
+    new RegularJob(),
+]);
+```
+
+Will result in the following error:
+
+```
+Job 'App\Jobs\SyncCompany' implements ShouldBeUnique and must not be dispatched via 'batch()'. Bulk and batch dispatch bypass the uniqueness lock, dispatch the job individually instead.
+```
+
+### Configuration
+
+This rule is disabled by default.
+To enable, add the following to your `phpstan.neon` file:
+
+```neon
+parameters:
+    noBatchedUniqueJob: true
+```
+
+## JobWithModelPropertyDeclaresSerializesModelsRule
+
+A queued job (one implementing `Illuminate\Contracts\Queue\ShouldQueue`) that holds an
+Eloquent model in a **public** property must use the `Illuminate\Queue\SerializesModels`
+trait.
+
+A queued job is serialized to the queue store at dispatch and unserialized in the worker.
+Without `SerializesModels` an Eloquent model property is serialized whole: the full attribute
+set, loaded relations and casts go onto the wire, bloating the payload, and the job runs
+against a frozen snapshot taken at dispatch time, so any change made between dispatch and
+execution is silently lost. `SerializesModels` instead stores just the class name and primary
+key (plus the loaded relation names) and re-resolves the model fresh from the database when
+the job runs, keeping the payload small and the data current. A model that was deleted in the
+meantime then surfaces as a `ModelNotFoundException` instead of the job operating on stale
+data.
+
+The rule fires only for public properties, because the queue serialization boundary makes
+public state the concern; private and protected model state is the class's own business.
+Properties typed against a model (including nullable unions) count, and an inherited
+`SerializesModels` (used by the class, a parent, or another trait) satisfies the rule.
+Abstract classes are skipped.
+
+### Examples
+
+```php
+class SendInvoice implements ShouldQueue
+{
+    public function __construct(public Invoice $invoice)
+    {
+    }
+
+    public function handle(): void
+    {
+    }
+}
+```
+
+Will result in the following error:
+
+```
+Job 'App\Jobs\SendInvoice' holds Eloquent model in public property ($invoice) but does not use the SerializesModels trait, so each model is serialized whole onto the queue and rehydrated from a stale dispatch time snapshot. Add 'use Illuminate\Queue\SerializesModels;' to the job.
+```
+
+To fix the error, let the queue store the model as a class and id reference:
+
+```php
+class SendInvoice implements ShouldQueue
+{
+    use SerializesModels;
+
+    public function __construct(public Invoice $invoice)
+    {
+    }
+
+    public function handle(): void
+    {
+    }
+}
+```
+
+### Configuration
+
+This rule is disabled by default.
+To enable, add the following to your `phpstan.neon` file:
+
+```neon
+parameters:
+    checkJobSerializesModels: true
+```
+
+## BatchedJobIsBatchableRule
+
+Every job dispatched through `Bus::batch([...])` must use the `Illuminate\Bus\Batchable`
+trait. The batch wires each job back to its parent batch so the job can read progress and
+short circuit (`$this->batch()->cancelled()`), and so the batch can reconcile its job count
+and fire `then`/`catch`/`finally`. All of that lives in `Batchable`. A job added to a batch
+without it has no `batch()` method, so `$this->batch()` is a fatal call to an undefined method
+the moment the job touches it. The framework does not validate this at dispatch, so the
+breakage only surfaces in the worker.
+
+The rule inspects the array literal passed to `Bus::batch()` and flags every element that is
+a queued job but does not use `Batchable`, recursing into nested arrays (chains within a
+batch).
+
+### Examples
+
+```php
+Bus::batch([
+    new BatchableJob(),
+    new RegularJob(),
+]);
+```
+
+Will result in the following error:
+
+```
+Job 'App\Jobs\RegularJob' is dispatched in 'Bus::batch()' but does not use the Batchable trait, so it has no '$this->batch()' accessor and the batch cannot track it. Add 'use Illuminate\Bus\Batchable;' to the job.
+```
+
+### Configuration
+
+This rule is disabled by default.
+To enable, add the following to your `phpstan.neon` file:
+
+```neon
+parameters:
+    checkBatchedJobIsBatchable: true
+```
+
+## BatchableJobChecksCancellationRule
+
+A queued job that uses the `Illuminate\Bus\Batchable` trait must respect early batch
+cancellation, either by checking `$this->batch()?->cancelled()` at the start of `handle()`, or
+by registering the `Illuminate\Queue\Middleware\SkipIfBatchCancelled` middleware from
+`middleware()`.
+
+Cancelling a batch (`$batch->cancel()`, or the automatic cancel on first failure when the
+batch is not `allowFailures`) only stops *future* dispatches from running their body. Laravel
+does not forcibly kill jobs already on the queue: each queued job still wakes up and, unless
+it checks `cancelled()`, runs its full body. That is wasted work at best, and at worst it
+keeps mutating state (writing files, calling external APIs, charging cards) for a batch the
+caller has already abandoned.
+
+To report the requirement once per hierarchy at its source, the rule fires on the first
+concrete class in the chain that carries `Batchable`; a concrete subclass whose parent already
+has the trait is skipped, because the guard belongs on, or is inherited from, that ancestor.
+Abstract classes are skipped. The guard is detected by inspecting the class under analysis for
+a `cancelled()` call or a `SkipIfBatchCancelled` reference, so centralising the skip middleware
+on a concrete base class satisfies the whole hierarchy.
+
+### Examples
+
+```php
+class GenerateReport implements ShouldQueue
+{
+    use Batchable;
+
+    public function handle(): void
+    {
+        // ... heavy work ...
+    }
+}
+```
+
+Will result in the following error:
+
+```
+Job 'App\Jobs\GenerateReport' uses the Batchable trait but never checks whether its batch has been cancelled, so it still runs its full body for an abandoned batch. Guard the work with 'if ($this->batch()?->cancelled()) { return; }' at the start of handle(), or register the 'SkipIfBatchCancelled' middleware.
+```
+
+To fix the error, guard the work at the start of `handle()`:
+
+```php
+class GenerateReport implements ShouldQueue
+{
+    use Batchable;
+
+    public function handle(): void
+    {
+        if ($this->batch()?->cancelled()) {
+            return;
+        }
+
+        // ... heavy work ...
+    }
+}
+```
+
+Or let the skip middleware short circuit cancelled batches:
+
+```php
+class GenerateReport implements ShouldQueue
+{
+    use Batchable;
+
+    public function middleware(): array
+    {
+        return [new SkipIfBatchCancelled()];
+    }
+
+    public function handle(): void
+    {
+        // ... heavy work ...
+    }
+}
+```
+
+### Configuration
+
+This rule is disabled by default.
+To enable, add the following to your `phpstan.neon` file:
+
+```neon
+parameters:
+    checkBatchableJobChecksCancellation: true
+```
+
+## JobDispatchedInTransactionUsesAfterCommitRule
+
+A queued job dispatched inside a `DB::transaction(...)` closure must defer its dispatch until
+the transaction commits, either by chaining `->afterCommit()` on the dispatch, or by declaring
+`public bool $afterCommit = true;` on the job.
+
+A queued job pushed during an open transaction can be picked up by a worker before the
+transaction commits (a fast worker racing the still open connection): it then loads rows that
+aren't visible yet and fails, or operates on half written state. If the transaction rolls back,
+the job still runs against data that never existed. `afterCommit` holds the dispatch until the
+outermost transaction commits and drops it entirely on rollback.
+
+Only the `DB::transaction(Closure)` and arrow function form is inspected, since the manual
+`beginTransaction()` ... `commit()` form has no closure to bound the analysis. Only the
+chainable dispatch forms are flagged: `Job::dispatch(...)` and the `dispatch(new Job)` helper.
+Synchronous dispatch (`dispatchSync`, `dispatch_sync`) and the `Bus` and `Queue` facade entry
+points are left alone, as are non queued dispatchables, which run synchronously. The rule
+assumes the default queue config: a project that enables `after_commit` globally does not need
+it.
+
+### Examples
+
+```php
+DB::transaction(function () use ($product) {
+    $product->save();
+
+    NotifyOwner::dispatch($product->id);
+});
+```
+
+Will result in the following error:
+
+```
+Job 'App\Jobs\NotifyOwner' is dispatched inside 'DB::transaction()' without '->afterCommit()', so a worker can pick it up before the transaction commits, or run it against rows a rollback threw away. Chain '->afterCommit()' on the dispatch, or declare 'public bool $afterCommit = true;' on the job.
+```
+
+To fix the error, defer the dispatch explicitly:
+
+```php
+DB::transaction(function () use ($product) {
+    $product->save();
+
+    NotifyOwner::dispatch($product->id)->afterCommit();
+});
+```
+
+Or opt the job in for every dispatch:
+
+```php
+class NotifyOwner implements ShouldQueue
+{
+    public bool $afterCommit = true;
+}
+```
+
+### Configuration
+
+This rule is disabled by default.
+To enable, add the following to your `phpstan.neon` file:
+
+```neon
+parameters:
+    checkDispatchInTransactionAfterCommit: true
+```

--- a/extension.neon
+++ b/extension.neon
@@ -33,6 +33,13 @@ parameters:
     checkAuthCallsWhenInRequestScope: false
     parseModelCastsMethod: false
     enableMigrationCache: true
+    checkUniqueJobUniqueFor: false
+    checkUniqueJobUniqueId: false
+    noBatchedUniqueJob: false
+    checkJobSerializesModels: false
+    checkBatchedJobIsBatchable: false
+    checkBatchableJobChecksCancellation: false
+    checkDispatchInTransactionAfterCommit: false
 
 parametersSchema:
     checkOctaneCompatibility: bool()
@@ -59,6 +66,13 @@ parametersSchema:
     checkAuthCallsWhenInRequestScope: bool()
     parseModelCastsMethod: bool()
     enableMigrationCache: bool()
+    checkUniqueJobUniqueFor: bool()
+    checkUniqueJobUniqueId: bool()
+    noBatchedUniqueJob: bool()
+    checkJobSerializesModels: bool()
+    checkBatchedJobIsBatchable: bool()
+    checkBatchableJobChecksCancellation: bool()
+    checkDispatchInTransactionAfterCommit: bool()
 
 conditionalTags:
     Larastan\Larastan\Rules\NoEnvCallsOutsideOfConfigRule:
@@ -93,6 +107,20 @@ conditionalTags:
         phpstan.broker.dynamicStaticMethodReturnTypeExtension: %checkConfigTypes%
     Larastan\Larastan\Rules\ConfigCollectionRule:
         phpstan.rules.rule: %checkConfigTypes%
+    Larastan\Larastan\Rules\Queue\UniqueJobDeclaresUniqueForRule:
+        phpstan.rules.rule: %checkUniqueJobUniqueFor%
+    Larastan\Larastan\Rules\Queue\UniqueJobDeclaresUniqueIdRule:
+        phpstan.rules.rule: %checkUniqueJobUniqueId%
+    Larastan\Larastan\Rules\Queue\NoBatchedUniqueJobRule:
+        phpstan.rules.rule: %noBatchedUniqueJob%
+    Larastan\Larastan\Rules\Queue\JobWithModelPropertyDeclaresSerializesModelsRule:
+        phpstan.rules.rule: %checkJobSerializesModels%
+    Larastan\Larastan\Rules\Queue\BatchedJobIsBatchableRule:
+        phpstan.rules.rule: %checkBatchedJobIsBatchable%
+    Larastan\Larastan\Rules\Queue\BatchableJobChecksCancellationRule:
+        phpstan.rules.rule: %checkBatchableJobChecksCancellation%
+    Larastan\Larastan\Rules\Queue\JobDispatchedInTransactionUsesAfterCommitRule:
+        phpstan.rules.rule: %checkDispatchInTransactionAfterCommit%
 
 services:
     -
@@ -704,6 +732,27 @@ services:
 
     -
         class: Larastan\Larastan\Rules\ConfigCollectionRule
+
+    -
+        class: Larastan\Larastan\Rules\Queue\UniqueJobDeclaresUniqueForRule
+
+    -
+        class: Larastan\Larastan\Rules\Queue\UniqueJobDeclaresUniqueIdRule
+
+    -
+        class: Larastan\Larastan\Rules\Queue\NoBatchedUniqueJobRule
+
+    -
+        class: Larastan\Larastan\Rules\Queue\JobWithModelPropertyDeclaresSerializesModelsRule
+
+    -
+        class: Larastan\Larastan\Rules\Queue\BatchedJobIsBatchableRule
+
+    -
+        class: Larastan\Larastan\Rules\Queue\BatchableJobChecksCancellationRule
+
+    -
+        class: Larastan\Larastan\Rules\Queue\JobDispatchedInTransactionUsesAfterCommitRule
 
     -
         class: Illuminate\Filesystem\Filesystem

--- a/src/Concerns/InspectsQueuedJobs.php
+++ b/src/Concerns/InspectsQueuedJobs.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Larastan\Larastan\Concerns;
+
+use PhpParser\Node\Name;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Type\ObjectType;
+
+trait InspectsQueuedJobs
+{
+    /**
+     * Whether the class uses the given trait, directly or through a parent class
+     * or another trait.
+     *
+     * `getTraits(true)` resolves traits used by the class, by its parent classes,
+     * and by those traits, so an inherited trait counts.
+     */
+    private function usesTrait(ClassReflection $classReflection, string $traitName): bool
+    {
+        foreach ($classReflection->getTraits(true) as $trait) {
+            if ($trait->getName() === $traitName) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Whether the class can be dispatched as it stands. Interfaces and traits are
+     * not classes, and an abstract class is never dispatched directly: a concrete
+     * subclass supplies (or inherits) whatever the rule asks for, and is checked
+     * on its own.
+     */
+    private function isDispatchableClass(ClassReflection $classReflection): bool
+    {
+        return ! $classReflection->isInterface()
+            && ! $classReflection->isTrait()
+            && ! $classReflection->isAbstract();
+    }
+
+    /**
+     * Whether the static call target names the given facade. Matches the facade
+     * itself, a subclass of it, and the root namespace alias Laravel registers
+     * for it (`\Bus`, `\DB`, ...).
+     */
+    private function isFacade(Name $class, string $facade, string $alias): bool
+    {
+        $className = $class->toString();
+
+        if ($className === $facade || $className === $alias) {
+            return true;
+        }
+
+        return (new ObjectType($facade))->isSuperTypeOf(new ObjectType($className))->yes();
+    }
+}

--- a/src/Rules/Queue/BatchableJobChecksCancellationRule.php
+++ b/src/Rules/Queue/BatchableJobChecksCancellationRule.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Larastan\Larastan\Rules\Queue;
+
+use Illuminate\Bus\Batchable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\Middleware\SkipIfBatchCancelled;
+use Larastan\Larastan\Concerns\InspectsQueuedJobs;
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\NullsafeMethodCall;
+use PhpParser\Node\Name;
+use PhpParser\NodeFinder;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\InClassNode;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+use function sprintf;
+
+/**
+ * A queued job that uses the `Batchable` trait must respect early batch
+ * cancellation, either by checking `$this->batch()?->cancelled()` at the start of
+ * `handle()`, or by registering the `SkipIfBatchCancelled` middleware from
+ * `middleware()`.
+ *
+ * Cancelling a batch (`$batch->cancel()`, or the automatic cancel on first
+ * failure when the batch is not `allowFailures`) only stops *future* dispatches
+ * from running their body. Laravel does not forcibly kill jobs already on the
+ * queue: each still wakes up and, unless it checks `cancelled()`, runs its full
+ * body. That is wasted work at best, and at worst it keeps mutating state
+ * (writing files, calling external APIs, charging cards) for a batch the caller
+ * has already abandoned.
+ *
+ * To report the requirement once per hierarchy at its source, the rule fires on
+ * the first concrete class in the chain that carries `Batchable`: a concrete
+ * subclass whose parent already has the trait is skipped, because the guard
+ * belongs on, or is inherited from, that ancestor. The guard is detected by
+ * inspecting the class under analysis, so centralising the skip middleware on a
+ * concrete base class satisfies the whole hierarchy.
+ *
+ * @implements Rule<InClassNode>
+ */
+class BatchableJobChecksCancellationRule implements Rule
+{
+    use InspectsQueuedJobs;
+
+    private const SKIP_MIDDLEWARE_SHORT_NAME = 'SkipIfBatchCancelled';
+
+    public function getNodeType(): string
+    {
+        return InClassNode::class;
+    }
+
+    /**
+     * @param InClassNode $node
+     *
+     * @return list<IdentifierRuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $classReflection = $node->getClassReflection();
+
+        if (! $this->isDispatchableClass($classReflection)) {
+            return [];
+        }
+
+        if (! $classReflection->is(ShouldQueue::class)) {
+            return [];
+        }
+
+        if (! $this->usesTrait($classReflection, Batchable::class)) {
+            return [];
+        }
+
+        if ($this->concreteAncestorUsesBatchable($classReflection)) {
+            // A concrete ancestor already carries Batchable and owns the guard,
+            // so it is reported there and not again on every subclass.
+            return [];
+        }
+
+        if ($this->guardsCancellation($node)) {
+            return [];
+        }
+
+        return [
+            RuleErrorBuilder::message(sprintf(
+                "Job '%s' uses the Batchable trait but never checks whether its batch has been cancelled, so it still runs its full body for an abandoned batch. Guard the work with 'if (\$this->batch()?->cancelled()) { return; }' at the start of handle(), or register the 'SkipIfBatchCancelled' middleware.",
+                $classReflection->getDisplayName(),
+            ))
+                ->identifier('larastan.batchableJobChecksCancellation')
+                ->line($node->getStartLine())
+                ->build(),
+        ];
+    }
+
+    private function concreteAncestorUsesBatchable(ClassReflection $classReflection): bool
+    {
+        foreach ($classReflection->getParents() as $parent) {
+            if (! $parent->isAbstract() && $this->usesTrait($parent, Batchable::class)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * The class satisfies the requirement when its own body either calls
+     * `cancelled()` (the `$this->batch()?->cancelled()` guard in `handle()`) or
+     * references the `SkipIfBatchCancelled` middleware. Inspecting the AST of the
+     * class under analysis keeps the check local and deterministic.
+     */
+    private function guardsCancellation(InClassNode $node): bool
+    {
+        $finder     = new NodeFinder();
+        $statements = $node->getOriginalNode()->stmts;
+
+        $cancelledCall = $finder->findFirst(
+            $statements,
+            static fn (Node $node): bool => ($node instanceof MethodCall || $node instanceof NullsafeMethodCall)
+                && $node->name instanceof Node\Identifier
+                && $node->name->toString() === 'cancelled',
+        );
+
+        if ($cancelledCall !== null) {
+            return true;
+        }
+
+        // Matched on the short name too, so the root namespace alias is
+        // recognised alongside the imported class.
+        return $finder->findFirst(
+            $statements,
+            static fn (Node $node): bool => $node instanceof Name
+                && ($node->toString() === SkipIfBatchCancelled::class || $node->getLast() === self::SKIP_MIDDLEWARE_SHORT_NAME),
+        ) !== null;
+    }
+}

--- a/src/Rules/Queue/BatchedJobIsBatchableRule.php
+++ b/src/Rules/Queue/BatchedJobIsBatchableRule.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Larastan\Larastan\Rules\Queue;
+
+use Illuminate\Bus\Batchable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Support\Facades\Bus;
+use Larastan\Larastan\Concerns\InspectsQueuedJobs;
+use PhpParser\Node;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Name;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\Type;
+
+use function implode;
+use function sprintf;
+
+/**
+ * Every job dispatched through `Bus::batch([...])` must use the `Batchable` trait.
+ *
+ * The batch wires each job back to its parent batch so the job can read progress
+ * and short circuit (`$this->batch()->cancelled()`), and so the batch can
+ * reconcile its job count and fire its then/catch/finally callbacks. All of that
+ * lives in `Batchable`. A job added to a batch without it has no `batch()`
+ * method, so `$this->batch()` is a fatal call to an undefined method the moment
+ * the job touches it, and the batch cannot account for the job either. The
+ * framework does not validate this at dispatch, so the breakage only surfaces in
+ * the worker.
+ *
+ * The rule inspects the array literal passed to `Bus::batch()` and flags every
+ * element that is a queued job but does not use `Batchable`. It recurses into
+ * nested arrays, which represent chains within a batch, because chained jobs need
+ * the trait too.
+ *
+ * @implements Rule<StaticCall>
+ */
+class BatchedJobIsBatchableRule implements Rule
+{
+    use InspectsQueuedJobs;
+
+    public function getNodeType(): string
+    {
+        return StaticCall::class;
+    }
+
+    /**
+     * @param StaticCall $node
+     *
+     * @return list<IdentifierRuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (! $this->isBusBatchCall($node)) {
+            return [];
+        }
+
+        $jobsArg = $node->getArgs()[0] ?? null;
+
+        if ($jobsArg === null || ! $jobsArg->value instanceof Array_) {
+            // Only array literals can be inspected element by element. A variable
+            // or a collection is left alone.
+            return [];
+        }
+
+        return $this->checkJobExpressions($jobsArg->value, $scope);
+    }
+
+    private function isBusBatchCall(StaticCall $node): bool
+    {
+        if (! $node->class instanceof Name) {
+            return false;
+        }
+
+        if (! $node->name instanceof Node\Identifier || $node->name->toString() !== 'batch') {
+            return false;
+        }
+
+        return $this->isFacade($node->class, Bus::class, 'Bus');
+    }
+
+    /**
+     * Walk an array of jobs, recursing into nested arrays (which represent chains
+     * within a batch), and flag every queued job that lacks `Batchable`.
+     *
+     * @return list<IdentifierRuleError>
+     */
+    private function checkJobExpressions(Array_ $array, Scope $scope): array
+    {
+        $errors = [];
+
+        foreach ($array->items as $item) {
+            if ($item->value instanceof Array_) {
+                foreach ($this->checkJobExpressions($item->value, $scope) as $error) {
+                    $errors[] = $error;
+                }
+
+                continue;
+            }
+
+            $type = $scope->getType($item->value);
+
+            if (! $this->isNonBatchableQueuedJob($type)) {
+                continue;
+            }
+
+            $classNames = $type->getObjectClassNames();
+
+            $errors[] = RuleErrorBuilder::message(sprintf(
+                "Job '%s' is dispatched in 'Bus::batch()' but does not use the Batchable trait, so it has no '\$this->batch()' accessor and the batch cannot track it. Add 'use Illuminate\Bus\Batchable;' to the job.",
+                $classNames === [] ? 'dispatched here' : implode('|', $classNames),
+            ))
+                ->identifier('larastan.batchedJobIsBatchable')
+                ->line($item->value->getStartLine())
+                ->build();
+        }
+
+        return $errors;
+    }
+
+    private function isNonBatchableQueuedJob(Type $type): bool
+    {
+        $reflections = $type->getObjectClassReflections();
+
+        if ($reflections === []) {
+            return false;
+        }
+
+        foreach ($reflections as $classReflection) {
+            // Only constrain queued jobs. A non job object in the array is not
+            // this rule's concern.
+            if (! $classReflection->is(ShouldQueue::class)) {
+                return false;
+            }
+
+            if ($this->usesTrait($classReflection, Batchable::class)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Rules/Queue/JobDispatchedInTransactionUsesAfterCommitRule.php
+++ b/src/Rules/Queue/JobDispatchedInTransactionUsesAfterCommitRule.php
@@ -1,0 +1,337 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Larastan\Larastan\Rules\Queue;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Queue;
+use Larastan\Larastan\Concerns\InspectsQueuedJobs;
+use PhpParser\Node;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\ArrowFunction;
+use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\NullsafeMethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Name;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+use function array_values;
+use function in_array;
+use function is_array;
+use function spl_object_id;
+use function sprintf;
+use function strtolower;
+
+/**
+ * A queued job dispatched inside a `DB::transaction(...)` closure must defer its
+ * dispatch until the transaction commits, either by chaining `->afterCommit()` on
+ * the dispatch, or by declaring `public bool $afterCommit = true;` on the job.
+ *
+ * A queued job pushed during an open transaction can be picked up by a worker
+ * before the transaction commits (a fast worker racing the still open connection):
+ * the job then loads rows that are not visible yet and fails, or silently operates
+ * on half written state. Worse, if the transaction rolls back the job still runs
+ * against data that never existed. `afterCommit` holds the dispatch until the
+ * outermost transaction commits, and drops it entirely on rollback.
+ *
+ * Scope and limits:
+ *
+ *   - Only the `DB::transaction(Closure)` and arrow function form is inspected.
+ *     The manual `DB::beginTransaction()` ... `DB::commit()` form has no closure
+ *     to bound the analysis and is not covered.
+ *   - Only the chainable dispatch forms are flagged: `Job::dispatch(...)` and the
+ *     `dispatch(new Job)` helper. Synchronous dispatch (`dispatchSync`,
+ *     `dispatch_sync`) runs inline within the transaction by design, and the
+ *     `Bus` and `Queue` facade entry points are a different mechanism, so both
+ *     are left alone.
+ *   - Non queued dispatchables are ignored: they run synchronously, so the commit
+ *     race does not apply.
+ *   - `->afterCommit()` only counts as protection when it is syntactically
+ *     chained on the dispatch. Splitting it across statements
+ *     (`$p = Job::dispatch(); $p->afterCommit();`) is not recognised.
+ *   - The walk descends into nested closures, so a dispatch inside a callback
+ *     that is merely *registered* within the transaction rather than run
+ *     synchronously (`DB::afterCommit(fn () => Job::dispatch())`) is reported even
+ *     though it does not race the commit. Chain `->afterCommit()` or move the
+ *     dispatch to silence it.
+ *   - The rule assumes the default queue config: a project that enables
+ *     `after_commit` globally does not need it.
+ *
+ * @implements Rule<StaticCall>
+ */
+class JobDispatchedInTransactionUsesAfterCommitRule implements Rule
+{
+    use InspectsQueuedJobs;
+
+    private const DISPATCH_METHOD = 'dispatch';
+
+    private const AFTER_COMMIT_METHOD = 'afterCommit';
+
+    private const AFTER_COMMIT_PROPERTY = 'afterCommit';
+
+    /** Static call class names that do not name a concrete, resolvable job class. */
+    private const NON_RESOLVABLE_CLASS_NAMES = ['self', 'static', 'parent'];
+
+    public function __construct(private ReflectionProvider $reflectionProvider)
+    {
+    }
+
+    public function getNodeType(): string
+    {
+        return StaticCall::class;
+    }
+
+    /**
+     * @param StaticCall $node
+     *
+     * @return list<IdentifierRuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (! $this->isTransactionCall($node)) {
+            return [];
+        }
+
+        $callback = $node->getArgs()[0] ?? null;
+
+        if ($callback === null) {
+            return [];
+        }
+
+        $bodyNodes = $this->closureBody($callback->value);
+
+        if ($bodyNodes === []) {
+            return [];
+        }
+
+        $dispatches = [];
+        $protected  = [];
+
+        foreach ($bodyNodes as $bodyNode) {
+            $this->visit($bodyNode, $dispatches, $protected);
+        }
+
+        $errors = [];
+
+        foreach ($dispatches as $dispatch) {
+            if (isset($protected[spl_object_id($dispatch)])) {
+                continue;
+            }
+
+            $job = $this->dispatchedJobNeedingAfterCommit($dispatch, $scope);
+
+            if ($job === null) {
+                continue;
+            }
+
+            $errors[] = RuleErrorBuilder::message(sprintf(
+                "Job '%s' is dispatched inside 'DB::transaction()' without '->afterCommit()', so a worker can pick it up before the transaction commits, or run it against rows a rollback threw away. Chain '->afterCommit()' on the dispatch, or declare 'public bool \$afterCommit = true;' on the job.",
+                $job->getDisplayName(),
+            ))
+                ->identifier('larastan.dispatchInTransactionAfterCommit')
+                ->line($dispatch->getStartLine())
+                ->build();
+        }
+
+        return $errors;
+    }
+
+    private function isTransactionCall(StaticCall $node): bool
+    {
+        if (! $node->class instanceof Name) {
+            return false;
+        }
+
+        if (! $node->name instanceof Node\Identifier || $node->name->toString() !== 'transaction') {
+            return false;
+        }
+
+        return $this->isFacade($node->class, DB::class, 'DB');
+    }
+
+    /**
+     * The statements or expression that make up the transaction callback's body,
+     * or an empty list when the callback is not an inspectable closure literal.
+     *
+     * @return list<Node>
+     */
+    private function closureBody(Expr $callback): array
+    {
+        if ($callback instanceof Closure) {
+            return array_values($callback->stmts);
+        }
+
+        if ($callback instanceof ArrowFunction) {
+            return [$callback->expr];
+        }
+
+        return [];
+    }
+
+    /**
+     * Walk the callback body, recording every dispatch call and the object ids of
+     * those already guarded by an `->afterCommit()` in their method chain. Nested
+     * `DB::transaction()` calls are pruned: their own dispatches are reported when
+     * that inner call is analysed, so descending here would report them twice.
+     *
+     * @param list<Node>      $dispatches
+     * @param array<int,true> $protected
+     */
+    private function visit(Node $node, array &$dispatches, array &$protected): void
+    {
+        if ($node instanceof StaticCall && $this->isTransactionCall($node)) {
+            return;
+        }
+
+        if ($this->isAfterCommitCall($node)) {
+            $guarded = $this->dispatchInReceiverChain($node);
+
+            if ($guarded !== null) {
+                $protected[spl_object_id($guarded)] = true;
+            }
+        }
+
+        if ($this->isDispatchCall($node)) {
+            $dispatches[] = $node;
+        }
+
+        foreach ($node->getSubNodeNames() as $subNodeName) {
+            $sub      = $node->{$subNodeName};
+            $children = is_array($sub) ? $sub : [$sub];
+
+            foreach ($children as $child) {
+                if (! $child instanceof Node) {
+                    continue;
+                }
+
+                $this->visit($child, $dispatches, $protected);
+            }
+        }
+    }
+
+    private function isAfterCommitCall(Node $node): bool
+    {
+        return ($node instanceof MethodCall || $node instanceof NullsafeMethodCall)
+            && $node->name instanceof Node\Identifier
+            && $node->name->toString() === self::AFTER_COMMIT_METHOD;
+    }
+
+    private function isDispatchCall(Node $node): bool
+    {
+        if ($node instanceof FuncCall) {
+            return $node->name instanceof Name && $node->name->getLast() === self::DISPATCH_METHOD;
+        }
+
+        if ($node instanceof StaticCall) {
+            if (! $node->name instanceof Node\Identifier || $node->name->toString() !== self::DISPATCH_METHOD) {
+                return false;
+            }
+
+            if (! $node->class instanceof Name) {
+                return false;
+            }
+
+            return ! $this->isFacade($node->class, Bus::class, 'Bus')
+                && ! $this->isFacade($node->class, Queue::class, 'Queue');
+        }
+
+        return false;
+    }
+
+    /**
+     * Descend a method chain ending in `->afterCommit()` and return the dispatch
+     * call it is applied to, for example the `Job::dispatch()` in
+     * `Job::dispatch()->onQueue('x')->afterCommit()`.
+     */
+    private function dispatchInReceiverChain(Node $afterCommitCall): Node|null
+    {
+        $current = $afterCommitCall;
+
+        while ($current instanceof MethodCall || $current instanceof NullsafeMethodCall) {
+            $receiver = $current->var;
+
+            if ($this->isDispatchCall($receiver)) {
+                return $receiver;
+            }
+
+            $current = $receiver;
+        }
+
+        return null;
+    }
+
+    /**
+     * Resolve the dispatched job and return its reflection when it is a queued job
+     * that does not already opt into afterCommit, that is, when the dispatch needs
+     * an explicit `->afterCommit()`. Returns null when the job cannot be resolved,
+     * is not queued, or already declares `$afterCommit = true`.
+     */
+    private function dispatchedJobNeedingAfterCommit(Node $dispatch, Scope $scope): ClassReflection|null
+    {
+        foreach ($this->dispatchedJobReflections($dispatch, $scope) as $reflection) {
+            if ($reflection->is(ShouldQueue::class) && ! $this->declaresAfterCommit($reflection)) {
+                return $reflection;
+            }
+        }
+
+        return null;
+    }
+
+    /** @return list<ClassReflection> */
+    private function dispatchedJobReflections(Node $dispatch, Scope $scope): array
+    {
+        if ($dispatch instanceof StaticCall && $dispatch->class instanceof Name) {
+            $className = $dispatch->class->toString();
+
+            if (in_array(strtolower($className), self::NON_RESOLVABLE_CLASS_NAMES, true)) {
+                return [];
+            }
+
+            if (! $this->reflectionProvider->hasClass($className)) {
+                return [];
+            }
+
+            return [$this->reflectionProvider->getClass($className)];
+        }
+
+        if ($dispatch instanceof FuncCall) {
+            $jobArg = $dispatch->getArgs()[0] ?? null;
+
+            if ($jobArg === null) {
+                return [];
+            }
+
+            return $scope->getType($jobArg->value)->getObjectClassReflections();
+        }
+
+        return [];
+    }
+
+    /**
+     * True when the job, or an ancestor, declares `$afterCommit = true`, so every
+     * dispatch of it is already deferred until after the surrounding transaction
+     * commits and no per call `->afterCommit()` is needed.
+     */
+    private function declaresAfterCommit(ClassReflection $classReflection): bool
+    {
+        $native = $classReflection->getNativeReflection();
+
+        if (! $native->hasProperty(self::AFTER_COMMIT_PROPERTY)) {
+            return false;
+        }
+
+        // getProperty() resolves an inherited property too, so a base job that
+        // sets the flag covers its subclasses.
+        return $native->getProperty(self::AFTER_COMMIT_PROPERTY)->getDefaultValue() === true;
+    }
+}

--- a/src/Rules/Queue/JobWithModelPropertyDeclaresSerializesModelsRule.php
+++ b/src/Rules/Queue/JobWithModelPropertyDeclaresSerializesModelsRule.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Larastan\Larastan\Rules\Queue;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Queue\SerializesModels;
+use Larastan\Larastan\Concerns\InspectsQueuedJobs;
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\InClassNode;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+use ReflectionProperty;
+
+use function array_map;
+use function count;
+use function implode;
+use function sprintf;
+
+/**
+ * A queued job (one implementing `ShouldQueue`) that holds an Eloquent model in a
+ * public property must use the `SerializesModels` trait.
+ *
+ * A queued job is serialized to the queue store at dispatch and unserialized in
+ * the worker. Without `SerializesModels` an Eloquent model property is serialized
+ * whole: the full attribute set, loaded relations and casts go onto the wire,
+ * bloating the payload, and the job runs against a frozen snapshot taken at
+ * dispatch time, so any change made between dispatch and execution is silently
+ * lost. `SerializesModels` instead stores just the class name and primary key
+ * (plus the loaded relation names) and re-resolves the model fresh from the
+ * database when the job runs, keeping the payload small and the data current. A
+ * model deleted in the meantime then surfaces as a `ModelNotFoundException`
+ * instead of the job operating on stale data.
+ *
+ * The rule fires only for public properties, because the queue serialization
+ * boundary makes public state the concern. Properties typed against a model
+ * (including nullable unions) count, and an inherited `SerializesModels` (used by
+ * the class, a parent, or another trait) satisfies the rule.
+ *
+ * @implements Rule<InClassNode>
+ */
+class JobWithModelPropertyDeclaresSerializesModelsRule implements Rule
+{
+    use InspectsQueuedJobs;
+
+    public function getNodeType(): string
+    {
+        return InClassNode::class;
+    }
+
+    /**
+     * @param InClassNode $node
+     *
+     * @return list<IdentifierRuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $classReflection = $node->getClassReflection();
+
+        if (! $this->isDispatchableClass($classReflection)) {
+            return [];
+        }
+
+        if (! $classReflection->is(ShouldQueue::class)) {
+            return [];
+        }
+
+        if ($this->usesTrait($classReflection, SerializesModels::class)) {
+            return [];
+        }
+
+        $modelProperties = $this->modelTypedPublicProperties($classReflection);
+
+        if ($modelProperties === []) {
+            return [];
+        }
+
+        return [
+            RuleErrorBuilder::message(sprintf(
+                "Job '%s' holds Eloquent model%s in public propert%s (%s) but does not use the SerializesModels trait, so each model is serialized whole onto the queue and rehydrated from a stale dispatch time snapshot. Add 'use Illuminate\Queue\SerializesModels;' to the job.",
+                $classReflection->getDisplayName(),
+                count($modelProperties) === 1 ? '' : 's',
+                count($modelProperties) === 1 ? 'y' : 'ies',
+                implode(', ', array_map(static fn (string $name): string => '$' . $name, $modelProperties)),
+            ))
+                ->identifier('larastan.jobSerializesModels')
+                ->line($node->getStartLine())
+                ->build(),
+        ];
+    }
+
+    /**
+     * Public, non static properties declared on this class whose type references
+     * an Eloquent model. Only properties declared here are considered: an
+     * inherited property is the declaring class's responsibility, so a missing
+     * trait is reported once at its source rather than again on every subclass.
+     *
+     * @return list<string>
+     */
+    private function modelTypedPublicProperties(ClassReflection $classReflection): array
+    {
+        $names = [];
+
+        foreach ($classReflection->getNativeReflection()->getProperties(ReflectionProperty::IS_PUBLIC) as $property) {
+            if ($property->isStatic()) {
+                continue;
+            }
+
+            if ($property->getDeclaringClass()->getName() !== $classReflection->getName()) {
+                continue;
+            }
+
+            $type = $classReflection->getNativeProperty($property->getName())->getReadableType();
+
+            if (! $this->typeReferencesModel($type)) {
+                continue;
+            }
+
+            $names[] = $property->getName();
+        }
+
+        return $names;
+    }
+
+    private function typeReferencesModel(Type $type): bool
+    {
+        // A union carrying null reports no object class reflections, so strip it
+        // first. The result then flattens `Model` and `Foo|Bar` member by member.
+        foreach (TypeCombinator::removeNull($type)->getObjectClassReflections() as $classReflection) {
+            if ($classReflection->is(Model::class)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Rules/Queue/NoBatchedUniqueJobRule.php
+++ b/src/Rules/Queue/NoBatchedUniqueJobRule.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Larastan\Larastan\Rules\Queue;
+
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Queue;
+use Larastan\Larastan\Concerns\InspectsQueuedJobs;
+use PhpParser\Node;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Name;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+
+use function implode;
+use function in_array;
+use function sprintf;
+
+/**
+ * A job implementing `ShouldBeUnique` must not be dispatched through the bulk or
+ * batch entry points: `Bus::batch([...])`, `Bus::bulk([...])` or the equivalent
+ * `Queue::bulk([...])`.
+ *
+ * Both bypass the per job uniqueness guarantee:
+ *
+ *   - `Queue::bulk()` and `Bus::bulk()` push raw payloads straight onto the
+ *     queue, skipping the dispatcher path that acquires the unique lock, so
+ *     duplicates are queued and `ShouldBeUnique` silently does nothing.
+ *   - Batching a unique job means a duplicate is dropped at dispatch, but the
+ *     batch's job count is computed up front, so the batch's progress and
+ *     then/finally callbacks never reconcile and the batch can hang as pending.
+ *
+ * Dispatch unique jobs individually instead.
+ *
+ * @implements Rule<StaticCall>
+ */
+class NoBatchedUniqueJobRule implements Rule
+{
+    use InspectsQueuedJobs;
+
+    private const BULK_METHODS = ['batch', 'bulk'];
+
+    public function getNodeType(): string
+    {
+        return StaticCall::class;
+    }
+
+    /**
+     * @param StaticCall $node
+     *
+     * @return list<IdentifierRuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (! $this->isBulkOrBatchCall($node)) {
+            return [];
+        }
+
+        $jobsArg = $node->getArgs()[0] ?? null;
+
+        if ($jobsArg === null) {
+            return [];
+        }
+
+        $method = $node->name instanceof Node\Identifier ? $node->name->toString() : 'batch';
+
+        // Array literal: inspect each element so the error points at the exact
+        // offending job and names it.
+        if ($jobsArg->value instanceof Array_) {
+            return $this->checkJobExpressions($jobsArg->value, $scope, $method);
+        }
+
+        // Anything else (a variable, a collection): fall back to the iterable
+        // value type and report once at the call site.
+        return $this->checkIterableType($scope->getType($jobsArg->value), $node, $method);
+    }
+
+    private function isBulkOrBatchCall(StaticCall $node): bool
+    {
+        if (! $node->class instanceof Name) {
+            return false;
+        }
+
+        if (! $node->name instanceof Node\Identifier || ! in_array($node->name->toString(), self::BULK_METHODS, true)) {
+            return false;
+        }
+
+        return $this->isFacade($node->class, Bus::class, 'Bus')
+            || $this->isFacade($node->class, Queue::class, 'Queue');
+    }
+
+    /**
+     * Walk an array of jobs, recursing into nested arrays (which represent chains
+     * within a batch), and flag every ShouldBeUnique element.
+     *
+     * @return list<IdentifierRuleError>
+     */
+    private function checkJobExpressions(Array_ $array, Scope $scope, string $method): array
+    {
+        $errors = [];
+
+        foreach ($array->items as $item) {
+            if ($item->value instanceof Array_) {
+                foreach ($this->checkJobExpressions($item->value, $scope, $method) as $error) {
+                    $errors[] = $error;
+                }
+
+                continue;
+            }
+
+            $type = $scope->getType($item->value);
+
+            if (! $this->isUniqueJobType($type)) {
+                continue;
+            }
+
+            $errors[] = RuleErrorBuilder::message($this->buildMessage($type, $method))
+                ->identifier('larastan.noBatchedUniqueJob')
+                ->line($item->value->getStartLine())
+                ->build();
+        }
+
+        return $errors;
+    }
+
+    /** @return list<IdentifierRuleError> */
+    private function checkIterableType(Type $jobsType, StaticCall $node, string $method): array
+    {
+        if (! $jobsType->isIterable()->yes()) {
+            return [];
+        }
+
+        $valueType = $jobsType->getIterableValueType();
+
+        if (! $this->isUniqueJobType($valueType)) {
+            return [];
+        }
+
+        return [
+            RuleErrorBuilder::message($this->buildMessage($valueType, $method))
+                ->identifier('larastan.noBatchedUniqueJob')
+                ->line($node->getStartLine())
+                ->build(),
+        ];
+    }
+
+    private function isUniqueJobType(Type $type): bool
+    {
+        foreach ($type->getObjectClassReflections() as $classReflection) {
+            if ($this->isDispatchableClass($classReflection) && $classReflection->is(ShouldBeUnique::class)) {
+                return true;
+            }
+        }
+
+        // Fallback for types that carry the interface without a resolvable class
+        // reflection, such as an interface typed variable.
+        return (new ObjectType(ShouldBeUnique::class))->isSuperTypeOf($type)->yes();
+    }
+
+    private function buildMessage(Type $type, string $method): string
+    {
+        $classNames = $type->getObjectClassNames();
+
+        return sprintf(
+            "Job '%s' implements ShouldBeUnique and must not be dispatched via '%s()'. Bulk and batch dispatch bypass the uniqueness lock, dispatch the job individually instead.",
+            $classNames === [] ? 'dispatched here' : implode('|', $classNames),
+            $method,
+        );
+    }
+}

--- a/src/Rules/Queue/UniqueJobDeclaresUniqueForRule.php
+++ b/src/Rules/Queue/UniqueJobDeclaresUniqueForRule.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Larastan\Larastan\Rules\Queue;
+
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Larastan\Larastan\Concerns\InspectsQueuedJobs;
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\InClassNode;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+use function sprintf;
+
+/**
+ * Every job implementing `ShouldBeUnique` must declare `uniqueFor`, either as a
+ * property (`public int $uniqueFor`) or a method (`public function uniqueFor(): int`).
+ *
+ * Without `uniqueFor`, Laravel holds the uniqueness lock until the job finishes
+ * processing. If the worker dies mid job (OOM, deploy, fatal) the lock is never
+ * released and the job can never be dispatched again until the cache key is
+ * cleared by hand. Declaring `uniqueFor` bounds the lock so a stuck job self
+ * heals after the timeout.
+ *
+ * @implements Rule<InClassNode>
+ */
+class UniqueJobDeclaresUniqueForRule implements Rule
+{
+    use InspectsQueuedJobs;
+
+    public function getNodeType(): string
+    {
+        return InClassNode::class;
+    }
+
+    /**
+     * @param InClassNode $node
+     *
+     * @return list<IdentifierRuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $classReflection = $node->getClassReflection();
+
+        if (! $this->isDispatchableClass($classReflection)) {
+            return [];
+        }
+
+        if (! $classReflection->is(ShouldBeUnique::class)) {
+            return [];
+        }
+
+        if ($classReflection->hasNativeProperty('uniqueFor') || $classReflection->hasNativeMethod('uniqueFor')) {
+            return [];
+        }
+
+        return [
+            RuleErrorBuilder::message(sprintf(
+                "Job '%s' implements ShouldBeUnique but does not declare uniqueFor, so a worker that dies mid job leaks the lock and the job can never be dispatched again. Add a 'public int \$uniqueFor' property or a 'uniqueFor()' method.",
+                $classReflection->getDisplayName(),
+            ))
+                ->identifier('larastan.uniqueJobUniqueFor')
+                ->line($node->getStartLine())
+                ->build(),
+        ];
+    }
+}

--- a/src/Rules/Queue/UniqueJobDeclaresUniqueIdRule.php
+++ b/src/Rules/Queue/UniqueJobDeclaresUniqueIdRule.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Larastan\Larastan\Rules\Queue;
+
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Larastan\Larastan\Concerns\InspectsQueuedJobs;
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\InClassNode;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+use function sprintf;
+
+/**
+ * A *parameterized* job implementing `ShouldBeUnique` must declare `uniqueId`,
+ * either as a method (`public function uniqueId(): string`) or a property
+ * (`public $uniqueId`).
+ *
+ * Laravel builds the uniqueness lock key as `laravel_unique_job:<class>:<uniqueId>`
+ * and falls back to an empty `uniqueId` when neither is declared (see
+ * `Illuminate\Bus\UniqueLock::getKey()`). For a job that carries no distinguishing
+ * state that empty key is correct: the class is a singleton, only one may run at
+ * a time. But for a job whose constructor takes arguments (per company, per
+ * product, ...) the empty key collapses *every* dispatch into one unique job
+ * regardless of those arguments, so legitimately distinct jobs are silently
+ * dropped at dispatch with no error.
+ *
+ * The rule therefore fires only when the job has a constructor with at least one
+ * parameter. A genuinely class wide unique job satisfies it by declaring
+ * `uniqueId()` returning a constant, which makes that intent explicit.
+ *
+ * @implements Rule<InClassNode>
+ */
+class UniqueJobDeclaresUniqueIdRule implements Rule
+{
+    use InspectsQueuedJobs;
+
+    public function getNodeType(): string
+    {
+        return InClassNode::class;
+    }
+
+    /**
+     * @param InClassNode $node
+     *
+     * @return list<IdentifierRuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $classReflection = $node->getClassReflection();
+
+        if (! $this->isDispatchableClass($classReflection)) {
+            return [];
+        }
+
+        if (! $classReflection->is(ShouldBeUnique::class)) {
+            return [];
+        }
+
+        if (! $this->hasConstructorParameters($classReflection)) {
+            // Parameterless job: the class name only lock key is correct.
+            return [];
+        }
+
+        if ($classReflection->hasNativeMethod('uniqueId') || $classReflection->hasNativeProperty('uniqueId')) {
+            return [];
+        }
+
+        return [
+            RuleErrorBuilder::message(sprintf(
+                "Job '%s' implements ShouldBeUnique and is parameterized but does not declare uniqueId, so every dispatch shares one lock key whatever the constructor arguments and distinct jobs are silently dropped. Add a 'uniqueId()' method derived from the distinguishing arguments, or return a constant from it for an intentionally class wide job.",
+                $classReflection->getDisplayName(),
+            ))
+                ->identifier('larastan.uniqueJobUniqueId')
+                ->line($node->getStartLine())
+                ->build(),
+        ];
+    }
+
+    private function hasConstructorParameters(ClassReflection $classReflection): bool
+    {
+        if (! $classReflection->hasConstructor()) {
+            return false;
+        }
+
+        $variants = $classReflection->getConstructor()->getVariants();
+
+        return $variants !== [] && $variants[0]->getParameters() !== [];
+    }
+}

--- a/tests/Rules/Queue/BatchableJobChecksCancellationRuleTest.php
+++ b/tests/Rules/Queue/BatchableJobChecksCancellationRuleTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Rules\Queue;
+
+use Larastan\Larastan\Rules\Queue\BatchableJobChecksCancellationRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/** @extends RuleTestCase<BatchableJobChecksCancellationRule> */
+class BatchableJobChecksCancellationRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(BatchableJobChecksCancellationRule::class);
+    }
+
+    public function testRule(): void
+    {
+        $this->analyse([__DIR__ . '/data/batchable-jobs.php'], [
+            [
+                "Job 'Tests\Rules\Queue\Data\BatchableJobWithoutCancellationCheck' uses the Batchable trait but never checks whether its batch has been cancelled, so it still runs its full body for an abandoned batch. Guard the work with 'if (\$this->batch()?->cancelled()) { return; }' at the start of handle(), or register the 'SkipIfBatchCancelled' middleware.",
+                74,
+            ],
+            [
+                "Job 'Tests\Rules\Queue\Data\ConcreteBatchableJobFromAbstractBase' uses the Batchable trait but never checks whether its batch has been cancelled, so it still runs its full body for an abandoned batch. Guard the work with 'if (\$this->batch()?->cancelled()) { return; }' at the start of handle(), or register the 'SkipIfBatchCancelled' middleware.",
+                84,
+            ],
+        ]);
+    }
+
+    /** @return string[] */
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/../../phpstan-tests.neon'];
+    }
+}

--- a/tests/Rules/Queue/BatchedJobIsBatchableRuleTest.php
+++ b/tests/Rules/Queue/BatchedJobIsBatchableRuleTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Rules\Queue;
+
+use Larastan\Larastan\Rules\Queue\BatchedJobIsBatchableRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/** @extends RuleTestCase<BatchedJobIsBatchableRule> */
+class BatchedJobIsBatchableRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(BatchedJobIsBatchableRule::class);
+    }
+
+    public function testRule(): void
+    {
+        $this->analyse([__DIR__ . '/data/bus-batch.php'], [
+            [
+                "Job 'Tests\Rules\Queue\Data\RegularJob' is dispatched in 'Bus::batch()' but does not use the Batchable trait, so it has no '\$this->batch()' accessor and the batch cannot track it. Add 'use Illuminate\Bus\Batchable;' to the job.",
+                11,
+            ],
+            [
+                "Job 'Tests\Rules\Queue\Data\RegularJob' is dispatched in 'Bus::batch()' but does not use the Batchable trait, so it has no '\$this->batch()' accessor and the batch cannot track it. Add 'use Illuminate\Bus\Batchable;' to the job.",
+                18,
+            ],
+        ]);
+    }
+
+    /** @return string[] */
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/../../phpstan-tests.neon'];
+    }
+}

--- a/tests/Rules/Queue/JobDispatchedInTransactionUsesAfterCommitRuleTest.php
+++ b/tests/Rules/Queue/JobDispatchedInTransactionUsesAfterCommitRuleTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Rules\Queue;
+
+use Larastan\Larastan\Rules\Queue\JobDispatchedInTransactionUsesAfterCommitRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/** @extends RuleTestCase<JobDispatchedInTransactionUsesAfterCommitRule> */
+class JobDispatchedInTransactionUsesAfterCommitRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(JobDispatchedInTransactionUsesAfterCommitRule::class);
+    }
+
+    public function testRule(): void
+    {
+        $message = "Job 'Tests\Rules\Queue\Data\NotifyOwner' is dispatched inside 'DB::transaction()' without '->afterCommit()', so a worker can pick it up before the transaction commits, or run it against rows a rollback threw away. Chain '->afterCommit()' on the dispatch, or declare 'public bool \$afterCommit = true;' on the job.";
+
+        $this->analyse([__DIR__ . '/data/transaction-dispatch.php'], [
+            [$message, 40],
+            [$message, 44],
+            [$message, 48],
+            [$message, 51],
+        ]);
+    }
+
+    /** @return string[] */
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/../../phpstan-tests.neon'];
+    }
+}

--- a/tests/Rules/Queue/JobWithModelPropertyDeclaresSerializesModelsRuleTest.php
+++ b/tests/Rules/Queue/JobWithModelPropertyDeclaresSerializesModelsRuleTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Rules\Queue;
+
+use Larastan\Larastan\Rules\Queue\JobWithModelPropertyDeclaresSerializesModelsRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/** @extends RuleTestCase<JobWithModelPropertyDeclaresSerializesModelsRule> */
+class JobWithModelPropertyDeclaresSerializesModelsRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(JobWithModelPropertyDeclaresSerializesModelsRule::class);
+    }
+
+    public function testRule(): void
+    {
+        $this->analyse([__DIR__ . '/data/serializes-models.php'], [
+            [
+                "Job 'Tests\Rules\Queue\Data\JobWithModelPropertyWithoutSerializesModels' holds Eloquent model in public property (\$product) but does not use the SerializesModels trait, so each model is serialized whole onto the queue and rehydrated from a stale dispatch time snapshot. Add 'use Illuminate\Queue\SerializesModels;' to the job.",
+                68,
+            ],
+            [
+                "Job 'Tests\Rules\Queue\Data\JobWithNullableModelPropertyWithoutSerializesModels' holds Eloquent model in public property (\$product) but does not use the SerializesModels trait, so each model is serialized whole onto the queue and rehydrated from a stale dispatch time snapshot. Add 'use Illuminate\Queue\SerializesModels;' to the job.",
+                75,
+            ],
+            [
+                "Job 'Tests\Rules\Queue\Data\JobWithMultipleModelPropertiesWithoutSerializesModels' holds Eloquent models in public properties (\$product, \$invoice) but does not use the SerializesModels trait, so each model is serialized whole onto the queue and rehydrated from a stale dispatch time snapshot. Add 'use Illuminate\Queue\SerializesModels;' to the job.",
+                80,
+            ],
+        ]);
+    }
+
+    /** @return string[] */
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/../../phpstan-tests.neon'];
+    }
+}

--- a/tests/Rules/Queue/NoBatchedUniqueJobRuleTest.php
+++ b/tests/Rules/Queue/NoBatchedUniqueJobRuleTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Rules\Queue;
+
+use Larastan\Larastan\Rules\Queue\NoBatchedUniqueJobRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/** @extends RuleTestCase<NoBatchedUniqueJobRule> */
+class NoBatchedUniqueJobRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(NoBatchedUniqueJobRule::class);
+    }
+
+    public function testRule(): void
+    {
+        $this->analyse([__DIR__ . '/data/batched-unique-jobs.php'], [
+            [
+                "Job 'Tests\Rules\Queue\Data\UniqueJobWithUniqueForProperty' implements ShouldBeUnique and must not be dispatched via 'batch()'. Bulk and batch dispatch bypass the uniqueness lock, dispatch the job individually instead.",
+                11,
+            ],
+            [
+                "Job 'Tests\Rules\Queue\Data\UniqueJobWithUniqueForMethod' implements ShouldBeUnique and must not be dispatched via 'bulk()'. Bulk and batch dispatch bypass the uniqueness lock, dispatch the job individually instead.",
+                16,
+            ],
+            [
+                "Job 'Tests\Rules\Queue\Data\UniqueJobWithUniqueForProperty' implements ShouldBeUnique and must not be dispatched via 'bulk()'. Bulk and batch dispatch bypass the uniqueness lock, dispatch the job individually instead.",
+                20,
+            ],
+            [
+                "Job 'Tests\Rules\Queue\Data\UniqueJobWithUniqueForProperty' implements ShouldBeUnique and must not be dispatched via 'batch()'. Bulk and batch dispatch bypass the uniqueness lock, dispatch the job individually instead.",
+                27,
+            ],
+            [
+                "Job 'Tests\Rules\Queue\Data\UniqueJobWithUniqueForProperty' implements ShouldBeUnique and must not be dispatched via 'batch()'. Bulk and batch dispatch bypass the uniqueness lock, dispatch the job individually instead.",
+                43,
+            ],
+        ]);
+    }
+
+    /** @return string[] */
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/../../phpstan-tests.neon'];
+    }
+}

--- a/tests/Rules/Queue/UniqueJobDeclaresUniqueForRuleTest.php
+++ b/tests/Rules/Queue/UniqueJobDeclaresUniqueForRuleTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Rules\Queue;
+
+use Larastan\Larastan\Rules\Queue\UniqueJobDeclaresUniqueForRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/** @extends RuleTestCase<UniqueJobDeclaresUniqueForRule> */
+class UniqueJobDeclaresUniqueForRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(UniqueJobDeclaresUniqueForRule::class);
+    }
+
+    public function testRule(): void
+    {
+        $this->analyse([__DIR__ . '/data/unique-jobs.php'], [
+            [
+                "Job 'Tests\Rules\Queue\Data\UniqueJobWithoutUniqueFor' implements ShouldBeUnique but does not declare uniqueFor, so a worker that dies mid job leaks the lock and the job can never be dispatched again. Add a 'public int \$uniqueFor' property or a 'uniqueFor()' method.",
+                47,
+            ],
+            [
+                "Job 'Tests\Rules\Queue\Data\UniqueUntilProcessingJob' implements ShouldBeUnique but does not declare uniqueFor, so a worker that dies mid job leaks the lock and the job can never be dispatched again. Add a 'public int \$uniqueFor' property or a 'uniqueFor()' method.",
+                108,
+            ],
+        ]);
+    }
+
+    /** @return string[] */
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/../../phpstan-tests.neon'];
+    }
+}

--- a/tests/Rules/Queue/UniqueJobDeclaresUniqueIdRuleTest.php
+++ b/tests/Rules/Queue/UniqueJobDeclaresUniqueIdRuleTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Rules\Queue;
+
+use Larastan\Larastan\Rules\Queue\UniqueJobDeclaresUniqueIdRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/** @extends RuleTestCase<UniqueJobDeclaresUniqueIdRule> */
+class UniqueJobDeclaresUniqueIdRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(UniqueJobDeclaresUniqueIdRule::class);
+    }
+
+    public function testRule(): void
+    {
+        $this->analyse([__DIR__ . '/data/unique-jobs.php'], [
+            [
+                "Job 'Tests\Rules\Queue\Data\ParameterizedUniqueJobWithoutUniqueId' implements ShouldBeUnique and is parameterized but does not declare uniqueId, so every dispatch shares one lock key whatever the constructor arguments and distinct jobs are silently dropped. Add a 'uniqueId()' method derived from the distinguishing arguments, or return a constant from it for an intentionally class wide job.",
+                65,
+            ],
+            [
+                "Job 'Tests\Rules\Queue\Data\UniqueUntilProcessingJob' implements ShouldBeUnique and is parameterized but does not declare uniqueId, so every dispatch shares one lock key whatever the constructor arguments and distinct jobs are silently dropped. Add a 'uniqueId()' method derived from the distinguishing arguments, or return a constant from it for an intentionally class wide job.",
+                108,
+            ],
+        ]);
+    }
+
+    /** @return string[] */
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/../../phpstan-tests.neon'];
+    }
+}

--- a/tests/Rules/Queue/data/batchable-jobs.php
+++ b/tests/Rules/Queue/data/batchable-jobs.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Rules\Queue\Data;
+
+use Illuminate\Bus\Batchable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\Middleware\SkipIfBatchCancelled;
+
+class BatchableNonQueuedClass
+{
+    use Batchable;
+
+    public function handle(): void
+    {
+    }
+}
+
+abstract class AbstractBatchableJob implements ShouldQueue
+{
+    use Batchable;
+
+    public function handle(): void
+    {
+    }
+}
+
+class BatchableJobWithCancellationCheck implements ShouldQueue
+{
+    use Batchable;
+    use Dispatchable;
+
+    public function handle(): void
+    {
+        if ($this->batch()?->cancelled()) {
+            return;
+        }
+    }
+}
+
+class BatchableJobWithSkipMiddleware implements ShouldQueue
+{
+    use Batchable;
+
+    /** @return list<object> */
+    public function middleware(): array
+    {
+        return [new SkipIfBatchCancelled()];
+    }
+
+    public function handle(): void
+    {
+    }
+}
+
+class BatchableJobBase implements ShouldQueue
+{
+    use Batchable;
+
+    public function handle(): void
+    {
+        if ($this->batch()?->cancelled()) {
+            return;
+        }
+    }
+}
+
+class BatchableJobSubclass extends BatchableJobBase
+{
+}
+
+class BatchableJobWithoutCancellationCheck implements ShouldQueue
+{
+    use Batchable;
+    use Dispatchable;
+
+    public function handle(): void
+    {
+    }
+}
+
+class ConcreteBatchableJobFromAbstractBase extends AbstractBatchableJob
+{
+}

--- a/tests/Rules/Queue/data/batched-unique-jobs.php
+++ b/tests/Rules/Queue/data/batched-unique-jobs.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Rules\Queue\Data;
+
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Queue;
+
+Bus::batch([
+    new UniqueJobWithUniqueForProperty(),
+    new RegularJob(1),
+]);
+
+Bus::bulk([
+    new UniqueJobWithUniqueForMethod(),
+]);
+
+Queue::bulk([
+    new UniqueJobWithUniqueForProperty(),
+]);
+
+// Chains within a batch are nested arrays and are inspected too.
+Bus::batch([
+    [
+        new RegularJob(1),
+        new UniqueJobWithUniqueForProperty(),
+    ],
+]);
+
+// Not flagged: none of these are ShouldBeUnique.
+Bus::batch([
+    new RegularJob(1),
+    new RegularJob(2),
+]);
+
+// Not flagged: dispatching a unique job on its own is the supported path.
+UniqueJobWithUniqueForProperty::dispatch();
+
+/** @var list<UniqueJobWithUniqueForProperty> $jobs */
+$jobs = [];
+
+Bus::batch($jobs);

--- a/tests/Rules/Queue/data/bus-batch.php
+++ b/tests/Rules/Queue/data/bus-batch.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Rules\Queue\Data;
+
+use Illuminate\Support\Facades\Bus;
+
+Bus::batch([
+    new BatchableJobWithCancellationCheck(),
+    new RegularJob(1),
+]);
+
+// Chains within a batch are nested arrays and need the trait too.
+Bus::batch([
+    [
+        new BatchableJobWithCancellationCheck(),
+        new RegularJob(2),
+    ],
+]);
+
+// Not flagged: every job uses Batchable.
+Bus::batch([
+    new BatchableJobWithCancellationCheck(),
+    new BatchableJobWithoutCancellationCheck(),
+]);
+
+// Not flagged: not a queued job, so not this rule's concern.
+Bus::batch([
+    new BatchableNonQueuedClass(),
+]);
+
+// Not flagged: only array literals are inspected element by element.
+/** @var list<RegularJob> $jobs */
+$jobs = [];
+
+Bus::batch($jobs);

--- a/tests/Rules/Queue/data/serializes-models.php
+++ b/tests/Rules/Queue/data/serializes-models.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Rules\Queue\Data;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Queue\SerializesModels;
+
+class Product extends Model
+{
+}
+
+class Invoice extends Model
+{
+}
+
+class JobWithoutModelProperty implements ShouldQueue
+{
+    public function __construct(public int $productId)
+    {
+    }
+}
+
+class ModelHolderNotQueued
+{
+    public function __construct(public Product $product)
+    {
+    }
+}
+
+class JobWithModelPropertyWithSerializesModels implements ShouldQueue
+{
+    use SerializesModels;
+
+    public function __construct(public Product $product)
+    {
+    }
+}
+
+abstract class AbstractJobWithModelProperty implements ShouldQueue
+{
+    public function __construct(public Product $product)
+    {
+    }
+}
+
+class BaseJobWithSerializesModels implements ShouldQueue
+{
+    use SerializesModels;
+}
+
+class JobInheritingSerializesModels extends BaseJobWithSerializesModels
+{
+    public function __construct(public Product $product)
+    {
+    }
+}
+
+class JobWithProtectedModelProperty implements ShouldQueue
+{
+    public function __construct(protected Product $product)
+    {
+    }
+}
+
+class JobWithModelPropertyWithoutSerializesModels implements ShouldQueue
+{
+    public function __construct(public Product $product)
+    {
+    }
+}
+
+class JobWithNullableModelPropertyWithoutSerializesModels implements ShouldQueue
+{
+    public Product|null $product = null;
+}
+
+class JobWithMultipleModelPropertiesWithoutSerializesModels implements ShouldQueue
+{
+    public function __construct(public Product $product, public Invoice $invoice)
+    {
+    }
+}

--- a/tests/Rules/Queue/data/transaction-dispatch.php
+++ b/tests/Rules/Queue/data/transaction-dispatch.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Rules\Queue\Data;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\DB;
+
+use function dispatch;
+
+class NotifyOwner implements ShouldQueue
+{
+    use Dispatchable;
+
+    public function __construct(public int $productId)
+    {
+    }
+}
+
+class NotifyOwnerAfterCommit implements ShouldQueue
+{
+    use Dispatchable;
+
+    public bool $afterCommit = true;
+
+    public function __construct(public int $productId)
+    {
+    }
+}
+
+class PlainDispatchable
+{
+    use Dispatchable;
+}
+
+DB::transaction(static function (): void {
+    NotifyOwner::dispatch(1);
+});
+
+DB::transaction(static function (): void {
+    dispatch(new NotifyOwner(1));
+});
+
+DB::transaction(static function (): void {
+    NotifyOwner::dispatch(1)->onQueue('default');
+});
+
+DB::transaction(static fn (): mixed => NotifyOwner::dispatch(1));
+
+// Not flagged: the dispatch is deferred explicitly.
+DB::transaction(static function (): void {
+    NotifyOwner::dispatch(1)->afterCommit();
+});
+
+DB::transaction(static function (): void {
+    NotifyOwner::dispatch(1)->onQueue('default')->afterCommit();
+});
+
+// Not flagged: the job opts in for every dispatch.
+DB::transaction(static function (): void {
+    NotifyOwnerAfterCommit::dispatch(1);
+});
+
+// Not flagged: synchronous dispatch runs inline, inside the transaction.
+DB::transaction(static function (): void {
+    NotifyOwner::dispatchSync(1);
+});
+
+// Not flagged: the Bus facade is a different entry point.
+DB::transaction(static function (): void {
+    Bus::dispatch(new NotifyOwner(1));
+});
+
+// Not flagged: a non queued dispatchable runs synchronously.
+DB::transaction(static function (): void {
+    PlainDispatchable::dispatch();
+});
+
+// Not flagged: outside any transaction.
+NotifyOwner::dispatch(1);

--- a/tests/Rules/Queue/data/unique-jobs.php
+++ b/tests/Rules/Queue/data/unique-jobs.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Rules\Queue\Data;
+
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Contracts\Queue\ShouldBeUniqueUntilProcessing;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+
+class RegularJob implements ShouldQueue
+{
+    use Dispatchable;
+
+    public function __construct(public int $productId)
+    {
+    }
+
+    public function handle(): void
+    {
+    }
+}
+
+abstract class AbstractUniqueJob implements ShouldQueue, ShouldBeUnique
+{
+    public function __construct(public int $companyId)
+    {
+    }
+}
+
+class UniqueJobWithUniqueForProperty implements ShouldQueue, ShouldBeUnique
+{
+    use Dispatchable;
+
+    public int $uniqueFor = 3600;
+}
+
+class UniqueJobWithUniqueForMethod implements ShouldQueue, ShouldBeUnique
+{
+    public function uniqueFor(): int
+    {
+        return 3600;
+    }
+}
+
+class UniqueJobWithoutUniqueFor implements ShouldQueue, ShouldBeUnique
+{
+    public function uniqueId(): string
+    {
+        return 'constant';
+    }
+}
+
+class UniqueJobInheritingUniqueFor extends AbstractUniqueJob
+{
+    public int $uniqueFor = 3600;
+
+    public function uniqueId(): string
+    {
+        return (string) $this->companyId;
+    }
+}
+
+class ParameterizedUniqueJobWithoutUniqueId implements ShouldQueue, ShouldBeUnique
+{
+    public int $uniqueFor = 3600;
+
+    public function __construct(public int $companyId)
+    {
+    }
+}
+
+class ParameterizedUniqueJobWithUniqueIdMethod implements ShouldQueue, ShouldBeUnique
+{
+    public int $uniqueFor = 3600;
+
+    public function __construct(public int $companyId)
+    {
+    }
+
+    public function uniqueId(): string
+    {
+        return (string) $this->companyId;
+    }
+}
+
+class ParameterizedUniqueJobWithUniqueIdProperty implements ShouldQueue, ShouldBeUnique
+{
+    public int $uniqueFor = 3600;
+
+    public string $uniqueId = 'fixed';
+
+    public function __construct(public int $companyId)
+    {
+    }
+}
+
+class UniqueJobWithParameterlessConstructor implements ShouldQueue, ShouldBeUnique
+{
+    public int $uniqueFor = 3600;
+
+    public function __construct()
+    {
+    }
+}
+
+class UniqueUntilProcessingJob implements ShouldQueue, ShouldBeUniqueUntilProcessing
+{
+    public function __construct(public int $companyId)
+    {
+    }
+}


### PR DESCRIPTION
Adds rules for enforcing background jobs best practises:

  larastan.uniqueJobUniqueFor                ShouldBeUnique jobs declare uniqueFor
  larastan.uniqueJobUniqueId                 parameterized ones declare uniqueId
  larastan.noBatchedUniqueJob                unique jobs are not batched or bulked
  larastan.jobSerializesModels               public model props need SerializesModels
  larastan.batchedJobIsBatchable             batched jobs use Batchable
  larastan.batchableJobChecksCancellation    batchable jobs honour cancellation
  larastan.dispatchInTransactionAfterCommit  dispatch in a transaction defers

All seven are disabled by default, each behind its own boolean parameter, so an upgrade cannot break an existing build. Documented in docs/rules.md.

- [x] Added or updated tests
- [x] Documented user facing changes

If you find any of the rules too opinionated, happy to drop it and leave the rest