### PR TITLE
feat: add `createQuietly()` to `EloquentBuilder.stub` for model-property checking

### DIFF
--- a/stubs/common/EloquentBuilder.stub
+++ b/stubs/common/EloquentBuilder.stub
@@ -45,6 +45,14 @@ class Builder
     public function create(array $attributes = []);
 
     /**
+     * Save a new model and return the instance without raising model events.
+     *
+     * @phpstan-param array<model-property<TModel>, mixed> $attributes
+     * @phpstan-return TModel
+     */
+    public function createQuietly(array $attributes = []);
+
+    /**
      * Create a collection of models from plain arrays.
      *
      * @param  array<mixed>  $items

--- a/tests/Integration/IntegrationTest.php
+++ b/tests/Integration/IntegrationTest.php
@@ -55,6 +55,7 @@ class IntegrationTest extends PHPStanTestCase
                 35 => ['Parameter #1 $columns of method Illuminate\Database\Eloquent\Builder<App\User>::first() expects \'*\'|array<int, \'*\'|Illuminate\Contracts\Database\Query\Expression|model property of App\User>|Illuminate\Contracts\Database\Query\Expression|model property of App\User, array{\'foo\', \'bar\'} given.'],
                 36 => ['Parameter #1 $columns of method Illuminate\Database\Eloquent\Builder<App\User>::first() expects \'*\'|array<int, \'*\'|Illuminate\Contracts\Database\Query\Expression|model property of App\User>|Illuminate\Contracts\Database\Query\Expression|model property of App\User, \'foo\' given.'],
                 39 => ['Parameter #1 $column of method Illuminate\Database\Eloquent\Builder<App\User>::where() expects array<int|model property of App\User, mixed>|(Closure(Illuminate\Database\Eloquent\Builder<App\User>): Illuminate\Database\Eloquent\Builder<App\User>)|(Closure(Illuminate\Database\Eloquent\Builder<App\User>): void)|Illuminate\Contracts\Database\Query\Expression|model property of App\User, \'roles.foo\' given.'],
+                44 => ['Parameter #1 $attributes of method Illuminate\Database\Eloquent\Builder<App\User>::createQuietly() expects array<model property of App\User, mixed>, array<string, string> given.'],
             ],
         ];
 

--- a/tests/Integration/data/model-property-builder.php
+++ b/tests/Integration/data/model-property-builder.php
@@ -40,6 +40,9 @@ function test(Builder $builder, User $user, string $union): void
 
     User::query()->get(DB::raw('name'));
     User::query()->get([DB::raw('name')]);
+
+    User::query()->createQuietly(['foo' => 'bar']);
+    User::query()->createQuietly(['id' => 1]);
 }
 
 //// Currently, there is no way to change the type of `$query` inside the callback.


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes

Resolves part of #676

**Changes**

Adds a stub declaration for `Illuminate\Database\Eloquent\Builder::createQuietly()` so Larastan validates the `$attributes` array keys against the model's real properties, the same way it already does for `create()`.

`createQuietly()` was missing from `stubs/common/EloquentBuilder.stub`, even though it's functionally identical to `create()` (it just wraps the call in `Model::withoutEvents(...)`). Without a stub entry, PHPStan fell back to Laravel's native `array $attributes = []` signature, which accepts any string key and provides no typo protection.

Before this change:
`
User::query()->createQuietly([
    'emali' => 'test@example.com', // typo — not caught before this PR
]);
`
After this change, Larastan reports an error for invalid keys, while valid ones still pass:
`
User::query()->createQuietly(['foo' => 'bar']); // reported: `foo` is not a property on App\User
User::query()->createQuietly(['id' => 1]);       // passes
`

Specifically:
- `stubs/common/EloquentBuilder.stub` — added a `createQuietly()` method declaration with `@phpstan-param array<model-property<TModel>, mixed> $attributes`, following the same pattern as the existing `create()` method.
- `tests/Integration/data/model-property-builder.php` — added two integration test calls: one with an invalid attribute key (`foo`) and one with a valid one (`id`).
- `tests/Integration/IntegrationTest.php` — added the expected PHPStan error for the invalid `createQuietly()` call.

**Breaking changes**

None. This only adds stricter checking for a method that previously had no dedicated stub, so no existing passing code becomes invalid unless it was already passing genuinely incorrect attribute keys to `createQuietly()`.