### PR TITLE
fix: allow closures in trans replacements

### DIFF
--- a/stubs/common/Helpers.stub
+++ b/stubs/common/Helpers.stub
@@ -128,7 +128,7 @@ function view($view = null, $data = [], $mergeData = []) {}
  * Translate the given message.
  *
  * @param  string|null  $key
- * @param  array<string, scalar|null>  $replace
+ * @param  array<string, (\Closure(string): string)|scalar|null>  $replace
  * @param  string|null  $locale
  * @return ($key is null ? \Illuminate\Contracts\Translation\Translator : mixed)
  */
@@ -138,7 +138,7 @@ function trans($key = null, $replace = [], $locale = null) {}
  * Translate the given message.
  *
  * @param  string|null  $key
- * @param  array<string, scalar|null>  $replace
+ * @param  array<string, (\Closure(string): string)|scalar|null>  $replace
  * @param  string|null  $locale
  * @return ($key is null ? null : mixed)
  */

--- a/tests/Integration/data/helpers.php
+++ b/tests/Integration/data/helpers.php
@@ -17,3 +17,9 @@ function retryAcceptsCallableAsSleepMilliseconds(): void
         return true;
     });
 }
+
+function translationsAcceptClosureReplacements(): void
+{
+    trans('<wrap>Hello</wrap>', ['wrap' => fn (string $chunk): string => '<b>' . $chunk . '</b>']);
+    __('<wrap>Hello</wrap>', ['wrap' => fn (string $chunk): string => '<b>' . $chunk . '</b>']);
+}


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes

Resolves #2525

**Changes**

<!-- Detail the changes in behaviour this PR introduces. -->

`trans()` and `__()` type `$replace` as `array<string, scalar|null>`, but `Translator::makeReplacements()` has accepted closure values since laravel/framework#51190, so passing one is reported as an argument type error. The stubs now allow `\Closure(string): string` values too.

**Breaking changes**

<!-- Are existing use cases affected and require changes when upgrading? 
If so, describe the necessary changes in UPGRADE.md. -->
