### PR TITLE
fix: respect model class attributes when resolving properties

### DIFF
--- a/src/Properties/ModelPropertyHelper.php
+++ b/src/Properties/ModelPropertyHelper.php
@@ -76,6 +76,8 @@ class ModelPropertyHelper
             return false;
         }
 
+        $this->initializeModel($modelInstance);
+
         if ($propertyName === $modelInstance->getKeyName()) {
             return true;
         }
@@ -97,6 +99,8 @@ class ModelPropertyHelper
         } catch (ReflectionException) {
             throw new ShouldNotHappenException();
         }
+
+        $this->initializeModel($modelInstance);
 
         $tableName = $modelInstance->getTable();
 
@@ -218,6 +222,22 @@ class ModelPropertyHelper
             $method->getVariants()[0]->getReturnType(),
             $method->getVariants()[0]->getReturnType(),
         );
+    }
+
+    /**
+     * Resolve the class attributes, like `#[Table]`, that the constructor would
+     * normally apply. The model is built without it, so `getTable()` would
+     * otherwise fall back to the name derived from the class.
+     */
+    private function initializeModel(Model $modelInstance): void
+    {
+        // @phpstan-ignore-next-line
+        if (! method_exists($modelInstance, 'initializeModelAttributes')) {
+            return;
+        }
+
+        // @phpstan-ignore-next-line
+        $modelInstance->initializeModelAttributes();
     }
 
     private function migrationsLoaded(): bool

--- a/tests/Integration/IntegrationTest.php
+++ b/tests/Integration/IntegrationTest.php
@@ -13,6 +13,7 @@ use Throwable;
 
 use function count;
 use function implode;
+use function Orchestra\Testbench\laravel_version_compare;
 use function sprintf;
 
 class IntegrationTest extends PHPStanTestCase
@@ -109,6 +110,16 @@ class IntegrationTest extends PHPStanTestCase
                 69 => ['Parameter #1 $collection of method CollectionOfType\GenericTest::acceptsAccountCollection() expects App\AccountCollection<(int|string), App\Account>, Illuminate\Database\Eloquent\Collection<int, App\User> given.'],
             ],
         ];
+
+        if (laravel_version_compare('13.0.0', '>=')) {
+            yield [
+                __DIR__ . '/data/model-property-table-attribute-l13.php',
+                [
+                    25 => ['Access to an undefined property ModelPropertyTableAttribute\TableAttributeModel::$not_a_column.'],
+                    30 => ['Function ModelPropertyTableAttribute\keyType() should return int but returns string.'],
+                ],
+            ];
+        }
 
         yield [
             __DIR__ . '/data/model-property-mutator-and-casting.php',

--- a/tests/Integration/data/model-property-table-attribute-l13.php
+++ b/tests/Integration/data/model-property-table-attribute-l13.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace ModelPropertyTableAttribute;
+
+use Illuminate\Database\Eloquent\Attributes\Table;
+use Illuminate\Database\Eloquent\Model;
+
+#[Table('users')]
+class TableAttributeModel extends Model
+{
+}
+
+#[Table(keyType: 'string', incrementing: false)]
+class StringKeyModel extends Model
+{
+}
+
+function existingColumn(TableAttributeModel $model): string
+{
+    return $model->email;
+}
+
+function unknownColumn(TableAttributeModel $model): string
+{
+    return $model->not_a_column;
+}
+
+function keyType(StringKeyModel $model): int
+{
+    return $model->id;
+}


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes

Resolves #2463

**Changes**

`ModelPropertyHelper` builds the model with `newInstanceWithoutConstructor()`, so `initializeModelAttributes()` never runs and the class attributes it applies are never resolved. `getTable()` then falls back to the name derived from the class name, which has no columns, and every property access on a model that sets its table with `#[Table]` reports `property.notFound`. The `key`, `keyType` and `incrementing` arguments, and `#[Connection]`, are lost the same way.

Calling `initializeModelAttributes()` on the instance restores them. The call is guarded, as the method only exists on Laravel 13 and above.

**Breaking changes**

None.