### PR TITLE
fix: resolve getCountForPagination passthru at call time

### DIFF
--- a/src/Methods/BuilderHelper.php
+++ b/src/Methods/BuilderHelper.php
@@ -76,13 +76,21 @@ class BuilderHelper
         private bool $checkProperties,
         private MacroMethodsClassReflectionExtension $macroMethodsClassReflectionExtension,
     ) {
+    }
+
+    /** @return string[] */
+    public function getPassthru(): array
+    {
         // @phpstan-ignore-next-line
         if (! defined('LARAVEL_VERSION') || version_compare(LARAVEL_VERSION, '12.15.0', '<')) {
-            return;
+            return $this->passthru;
         }
 
         // @phpstan-ignore-next-line
-        $this->passthru[] = 'getCountForPagination';
+        $passthru   = $this->passthru;
+        $passthru[] = 'getCountForPagination';
+
+        return $passthru;
     }
 
     public function dynamicWhere(
@@ -236,7 +244,7 @@ class BuilderHelper
 
         $queryBuilderReflection = $this->reflectionProvider->getClass(QueryBuilder::class);
 
-        if (in_array($methodName, $this->passthru, true)) {
+        if (in_array($methodName, $this->getPassthru(), true)) {
             return $queryBuilderReflection->getNativeMethod($methodName);
         }
 

--- a/src/Methods/EloquentBuilderForwardsCallsExtension.php
+++ b/src/Methods/EloquentBuilderForwardsCallsExtension.php
@@ -139,7 +139,7 @@ final class EloquentBuilderForwardsCallsExtension implements MethodsClassReflect
 
         $parametersAcceptor = $ref->getVariants()[0];
 
-        if (in_array($methodName, $this->builderHelper->passthru, true)) {
+        if (in_array($methodName, $this->builderHelper->getPassthru(), true)) {
             $returnType = $parametersAcceptor->getReturnType();
         } elseif ($classReflection->isGeneric()) {
             $returnType = new GenericObjectType($classReflection->getName(), array_values($classReflection->getTemplateTypeMap()->getTypes()));


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes

Resolves #2534

**Changes**

`BuilderHelper::__construct()` appended `getCountForPagination` to `$passthru` behind a `defined('LARAVEL_VERSION')` check, but PHPStan builds its container before `bootstrap.php` defines that constant, so the check was always false and the method never made it into the list. In a real `phpstan analyse` run `User::query()->getCountForPagination()` was therefore typed as `Illuminate\Database\Eloquent\Builder<App\User>` instead of `int<0, max>`.

The version check now runs in a new `getPassthru()` method, at the point where the list is actually consulted, so the constant is already there. Both call sites read through it.

The existing `tests/Type/data/passthru-l12-15.php` assertion only passed because earlier test classes in the same process had already booted their own bootstrap files. Running `vendor/bin/phpunit tests/Type/GeneralTypeTest.php` on its own fails on `3.x` and passes with this change.

**Breaking changes**

None. The `$passthru` property keeps its current contents; anything reading it directly behaves as before.
