### PR TITLE
feat: add throw types for facade calls

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -134,6 +134,10 @@ services:
         tags:
             - phpstan.broker.methodsClassReflectionExtension
     -
+        class: Larastan\Larastan\Methods\FacadeThrowTypeExtension
+        tags:
+            - phpstan.dynamicStaticMethodThrowTypeExtension
+    -
         class: Larastan\Larastan\Methods\ManagersMethodsExtension
         tags:
             - phpstan.broker.methodsClassReflectionExtension

--- a/src/Methods/FacadeThrowTypeExtension.php
+++ b/src/Methods/FacadeThrowTypeExtension.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Larastan\Larastan\Methods;
+
+use Illuminate\Support\Facades\Facade;
+use PhpParser\Node\Expr\StaticCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Type\DynamicStaticMethodThrowTypeExtension;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+use Throwable;
+
+/**
+ * Gives a facade static call the throw type of the real method behind it.
+ *
+ * A call like `View::first()` forwards to its facade root
+ * (`Illuminate\View\Factory::first()`), which declares `@throws InvalidArgumentException`.
+ * PHPStan does not follow that forward for throw types: it sees only
+ * `Facade::__callStatic()`, whose `@throws \RuntimeException` covers the "facade root has
+ * not been set" case. So the call looks like it throws only RuntimeException, and catching
+ * the real exception is wrongly reported as a dead catch (`catch.neverThrown`).
+ *
+ * This resolves the facade root method and returns its real throw type, unioned with the
+ * __callStatic throw type so that failure mode is not lost.
+ */
+final class FacadeThrowTypeExtension implements DynamicStaticMethodThrowTypeExtension
+{
+    public function __construct(private ReflectionProvider $reflectionProvider)
+    {
+    }
+
+    public function isStaticMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return $methodReflection->getDeclaringClass()->is(Facade::class);
+    }
+
+    public function getThrowTypeFromStaticMethodCall(MethodReflection $methodReflection, StaticCall $methodCall, Scope $scope): Type|null
+    {
+        $facadeClass = $methodReflection->getDeclaringClass()->getName();
+
+        try {
+            $root = $facadeClass::getFacadeRoot();
+        } catch (Throwable) {
+            return null;
+        }
+
+        if ($root === null) {
+            return null;
+        }
+
+        $rootClass = $root::class;
+
+        if (! $this->reflectionProvider->hasClass($rootClass)) {
+            return null;
+        }
+
+        $rootReflection = $this->reflectionProvider->getClass($rootClass);
+        $methodName     = $methodReflection->getName();
+
+        if (! $rootReflection->hasNativeMethod($methodName)) {
+            return null;
+        }
+
+        // What the real method behind the facade declares it throws.
+        $rootThrowType = $rootReflection->getNativeMethod($methodName)->getThrowType();
+
+        if ($rootThrowType === null) {
+            return null;
+        }
+
+        // What every facade call can still throw via the magic Facade::__callStatic().
+        $callStaticThrowType = $this->callStaticThrowType();
+
+        if ($callStaticThrowType === null) {
+            return $rootThrowType;
+        }
+
+        return TypeCombinator::union($rootThrowType, $callStaticThrowType);
+    }
+
+    private function callStaticThrowType(): Type|null
+    {
+        if (! $this->reflectionProvider->hasClass(Facade::class)) {
+            return null;
+        }
+
+        $facadeReflection = $this->reflectionProvider->getClass(Facade::class);
+
+        if (! $facadeReflection->hasNativeMethod('__callStatic')) {
+            return null;
+        }
+
+        return $facadeReflection->getNativeMethod('__callStatic')->getThrowType();
+    }
+}

--- a/tests/Integration/IntegrationTest.php
+++ b/tests/Integration/IntegrationTest.php
@@ -38,6 +38,12 @@ class IntegrationTest extends PHPStanTestCase
         yield [__DIR__ . '/data/model-factories.php'];
         yield [__DIR__ . '/data/blade-view.php'];
         yield [__DIR__ . '/data/helpers.php'];
+        yield [
+            __DIR__ . '/data/facade-throw-type.php',
+            [
+                37 => ['Dead catch - JsonException is never thrown in the try block.'],
+            ],
+        ];
 
         yield [
             __DIR__ . '/data/model-property-builder.php',

--- a/tests/Integration/data/facade-throw-type.php
+++ b/tests/Integration/data/facade-throw-type.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FacadeThrowType;
+
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Facades\View as ViewFacade;
+use InvalidArgumentException;
+use JsonException;
+use RuntimeException;
+
+class FacadeThrowType
+{
+    public function catchesRealException(): View|null
+    {
+        try {
+            return ViewFacade::first(['a', 'b']);
+        } catch (InvalidArgumentException $e) {
+            return null;
+        }
+    }
+
+    public function catchesFacadeRootNotSet(): View|null
+    {
+        try {
+            return ViewFacade::first(['a', 'b']);
+        } catch (RuntimeException $e) {
+            return null;
+        }
+    }
+
+    public function deadCatchIsStillReported(): View|null
+    {
+        try {
+            return ViewFacade::first(['a', 'b']);
+        } catch (JsonException $e) {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
Facade calls now report the throws of the underlying method, not just the `RuntimeException` from `Facade::__callStatic()`. Both get unioned.

PHPStan previously only knew about the `__callStatic()` throw, so a catch for the method's real exception got flagged as dead:

```php
use Illuminate\Support\Facades\View;

try {
    return View::first(['home', 'welcome']);
} catch (InvalidArgumentException $e) {
    // Illuminate\View\Factory::first() has @throws InvalidArgumentException,
    // but PHPStan reported: Dead catch - InvalidArgumentException is never
    // thrown in the try block. (catch.neverThrown)
    return null;
}
```

Adds `FacadeThrowTypeExtension` and an integration test.

- [x] Added or updated tests
- [ ] Documented user facing changes

**Changes**

- Facade calls expose the underlying method's real throws, so a valid catch is no
  longer flagged as a dead catch.

**Breaking changes**

Nothing API-wise. Facade calls now carry real throw types, so PHPStan may flag things it missed before: a catch for an exception that's no longer thrown, or a `@throws` that's now too wide.
