### PR TITLE
fix: keep static in the newQuery() method family on non-final models

### DIFF
--- a/src/ReturnTypes/NewModelQueryDynamicMethodReturnTypeExtension.php
+++ b/src/ReturnTypes/NewModelQueryDynamicMethodReturnTypeExtension.php
@@ -11,6 +11,7 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Type\DynamicMethodReturnTypeExtension;
 use PHPStan\Type\ObjectType;
+use PHPStan\Type\StaticType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 
@@ -61,7 +62,19 @@ class NewModelQueryDynamicMethodReturnTypeExtension implements DynamicMethodRetu
 
             $builderName = $this->builderHelper->determineBuilderName($classReflection->getName());
 
-            $types[] = $this->builderHelper->getBuilderType($builderName, new ObjectType($classReflection->getName()));
+            // Eloquent declares these methods as `@return Builder<static>`. On a model that is
+            // not final, `static` is strictly narrower than the class it resolves to, and
+            // Builder is invariant in its model parameter, so handing back the class name makes
+            // `Builder<static>` unsatisfiable for anything that declares it. Keep `static` when
+            // the call was made on it; on a final model the two are the same type and the plain
+            // object type reads better in error messages.
+            $modelType = ! $classReflection->isFinal()
+                && $calledOnType instanceof StaticType
+                && $calledOnType->getClassName() === $classReflection->getName()
+                    ? new StaticType($classReflection)
+                    : new ObjectType($classReflection->getName());
+
+            $types[] = $this->builderHelper->getBuilderType($builderName, $modelType);
         }
 
         if ($types === []) {

--- a/tests/Type/data/model-l11-42.php
+++ b/tests/Type/data/model-l11-42.php
@@ -21,9 +21,29 @@ class AbstractModel extends Model
         assertType('static(Model\AbstractModel)', static::query()->create());
         return static::query()->create();
     }
+
+    public function newQueryKeepsStatic(): void
+    {
+        assertType('Illuminate\Database\Eloquent\Builder<static(Model\AbstractModel)>', $this->newQuery());
+        assertType('Illuminate\Database\Eloquent\Builder<static(Model\AbstractModel)>', $this->newModelQuery());
+        assertType('Illuminate\Database\Eloquent\Builder<static(Model\AbstractModel)>', $this->newQueryWithoutRelationships());
+        assertType('Illuminate\Database\Eloquent\Builder<static(Model\AbstractModel)>', $this->newQueryWithoutScopes());
+        assertType('Illuminate\Database\Eloquent\Builder<static(Model\AbstractModel)>', $this->newQueryWithoutScope('foo'));
+        assertType('Illuminate\Database\Eloquent\Builder<static(Model\AbstractModel)>', $this->newQueryForRestoration([1]));
+    }
 }
 
 class Child extends AbstractModel {}
+
+final class FinalModel extends Model
+{
+    public function newQueryOnFinalModel(): void
+    {
+        // `static` and the class name are the same type here, so the plain object type stays.
+        assertType('Illuminate\Database\Eloquent\Builder<Model\FinalModel>', $this->newQuery());
+        assertType('Illuminate\Database\Eloquent\Builder<Model\FinalModel>', $this->newModelQuery());
+    }
+}
 
 class Foo
 {


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes

I couldn't find an existing issue for this. I searched this repo for `newQuery static`, for the extension class name and for `Builder<static>`; the hits are about generic builders in general, and #2474 is the closest in spirit (a template parameter lost through `Builder<T>::get()`) but it's a different path.

**Changes**

`NewModelQueryDynamicMethodReturnTypeExtension` parameterizes the returned builder with the class it was called on rather than with `static`. Laravel annotates all six of these methods as `@return Builder<static>`, and `Builder` is invariant in its model parameter, so on a model that isn't final nothing declaring `Builder<static>` can be satisfied by `$this->newQuery()`:

```php
class Page extends Model
{
    /** @param Builder<static> $query */
    public function gate(Builder $query): void {}

    public function run(): void
    {
        $this->gate($this->newQuery());
    }
}
```

```
Parameter #1 $query of method Page::gate() expects
Illuminate\Database\Eloquent\Builder<static(Page)>,
Illuminate\Database\Eloquent\Builder<Page> given.
```

Adding `final` to the class makes the error go away, and that's what makes the constellation easy to miss: a codebase whose models are all final never meets it, while Laravel's own generators produce models without `final`.

The patch keeps `static` when the call was made on it and the model isn't final. Everything else stays where it was:

| call | before | after |
| --- | --- | --- |
| `$this->newQuery()`, non-final model | `Builder<Page>` | `Builder<static(Page)>` |
| `$this->newQuery()`, final model | `Builder<Page>` | unchanged |
| `$page->newQuery()` | `Builder<Page>` | unchanged |
| `Page::query()` | `Builder<Page>` | unchanged |

The final-model guard is load-bearing rather than decorative: PHPStan doesn't collapse `static(FinalPage)` back to `FinalPage` by itself, so without that condition a final model would start failing `Builder<static>` **and** `Builder<FinalPage>` parameters, which is worse than what it fixes.

**Breaking changes**

One, and it's the flip side of the fix rather than a separate defect. Under invariance the two annotations can't both work, so code that declares the concrete model and returns `$this->newQuery()` from inside a non-final model starts erroring:

```php
class Comment extends Model
{
    /** @return Builder<self> */
    public function ownQuery(): Builder
    {
        // Method Comment::ownQuery() should return Builder<Comment>
        // but returns Builder<static(Comment)>.
        return $this->newQuery();
    }
}
```

The fix in that code is to write `Builder<static>`, which is what Eloquent declares anyway. I left `UPGRADE.md` alone because it's organized per major version and this isn't one — say the word if you'd like an entry and where.

**What I ran**

PHP 8.5.8, `laravel/framework` 13.30.1, on `3.x` at 8f878f2.

- `composer test:cs` on the changed file: clean.
- `composer test:types`: no errors.
- The whole `tests/Type` directory: 1455 tests, 1477 assertions, green. With the source change reverted and the new assertions kept, exactly those two data files fail and nothing else does, so the other 1447 assertions don't move.
- `tests/Rules`, `tests/Unit`, `tests/Reflection` and `tests/Integration`: green, except that `ConfigCollectionRuleTest::testRule` is reported risky here ("did not remove its own error handlers") and `failOnRisky` turns that into a non-zero exit. It does the same at 8f878f2 without the patch, so it isn't this change.
