### PR TITLE
fix: detect documented database columns in collection rule

### DIFF
--- a/src/Properties/ModelPropertyHelper.php
+++ b/src/Properties/ModelPropertyHelper.php
@@ -47,8 +47,11 @@ class ModelPropertyHelper
     /**
      * Determine if the model has a database property.
      */
-    public function hasDatabaseProperty(ClassReflection|string $classReflectionOrTable, string $propertyName): bool
-    {
+    public function hasDatabaseProperty(
+        ClassReflection|string $classReflectionOrTable,
+        string $propertyName,
+        bool $excludePropertyTags = true,
+    ): bool {
         if (! $this->migrationsLoaded()) {
             $this->loadMigrations();
         }
@@ -69,7 +72,7 @@ class ModelPropertyHelper
             return false;
         }
 
-        if (ReflectionHelper::hasPropertyTag($classReflectionOrTable, $propertyName)) {
+        if ($excludePropertyTags && ReflectionHelper::hasPropertyTag($classReflectionOrTable, $propertyName)) {
             return false;
         }
 

--- a/src/Rules/NoUnnecessaryCollectionCallRule.php
+++ b/src/Rules/NoUnnecessaryCollectionCallRule.php
@@ -10,7 +10,7 @@ use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
-use Larastan\Larastan\Properties\ModelPropertyExtension;
+use Larastan\Larastan\Properties\ModelPropertyHelper;
 use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\MethodCall;
@@ -95,7 +95,7 @@ class NoUnnecessaryCollectionCallRule implements Rule
      */
     public function __construct(
         protected ReflectionProvider $reflectionProvider,
-        protected ModelPropertyExtension $propertyExtension,
+        protected ModelPropertyHelper $modelPropertyHelper,
         array $onlyMethods,
         array $excludeMethods,
     ) {
@@ -222,7 +222,11 @@ class NoUnnecessaryCollectionCallRule implements Rule
             /** @var String_ $firstArg */
             $firstArg = $args[0]->value;
 
-            return $this->propertyExtension->hasProperty($modelReflection, $firstArg->value);
+            return $this->modelPropertyHelper->hasDatabaseProperty(
+                $modelReflection,
+                $firstArg->value,
+                excludePropertyTags: false,
+            );
         }
 
         $iterableType = $scope->getType($node->var)->getIterableValueType();
@@ -255,7 +259,11 @@ class NoUnnecessaryCollectionCallRule implements Rule
             /** @var String_ $firstArg */
             $firstArg = $args[0]->value;
 
-            return $this->propertyExtension->hasProperty($modelReflection, $firstArg->value);
+            return $this->modelPropertyHelper->hasDatabaseProperty(
+                $modelReflection,
+                $firstArg->value,
+                excludePropertyTags: false,
+            );
         }
 
         return false;

--- a/tests/Rules/NoUnnecessaryCollectionCallRuleTest.php
+++ b/tests/Rules/NoUnnecessaryCollectionCallRuleTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Rules;
 
-use Larastan\Larastan\Properties\ModelPropertyExtension;
+use Larastan\Larastan\Properties\ModelPropertyHelper;
 use Larastan\Larastan\Rules\NoUnnecessaryCollectionCallRule;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
@@ -14,7 +14,7 @@ class NoUnnecessaryCollectionCallRuleTest extends RuleTestCase
 {
     protected function getRule(): Rule
     {
-        return new NoUnnecessaryCollectionCallRule($this->createReflectionProvider(), self::getContainer()->getByType(ModelPropertyExtension::class), [], []);
+        return new NoUnnecessaryCollectionCallRule($this->createReflectionProvider(), self::getContainer()->getByType(ModelPropertyHelper::class), [], []);
     }
 
     public function testNoFalsePositives(): void
@@ -41,6 +41,7 @@ class NoUnnecessaryCollectionCallRuleTest extends RuleTestCase
             ['Called \'modelKeys\' on Laravel collection, but could have been retrieved as a query.', 92],
             ['Called \'containsStrict\' on Laravel collection, but could have been retrieved as a query.', 97],
             ['Called \'sum\' on Laravel collection, but could have been retrieved as a query.', 103],
+            ['Called \'pluck\' on Laravel collection, but could have been retrieved as a query.', 121],
         ]);
     }
 

--- a/tests/Rules/data/UnnecessaryCollectionCallsEloquent.php
+++ b/tests/Rules/data/UnnecessaryCollectionCallsEloquent.php
@@ -103,3 +103,27 @@ class UnnecessaryCollectionCallsEloquent
         return User::pluck('id')->sum();
     }
 }
+
+/**
+ * @property int $id
+ * @property string $computed
+ */
+class DocumentedUser extends \Illuminate\Database\Eloquent\Model
+{
+    protected $table = 'users';
+}
+
+class DocumentedModelCollectionCalls
+{
+    /** @return Collection<int, mixed> */
+    public function pluckDatabaseColumn(): Collection
+    {
+        return DocumentedUser::all()->pluck('id');
+    }
+
+    /** @return Collection<int, mixed> */
+    public function pluckComputedProperty(): Collection
+    {
+        return DocumentedUser::all()->pluck('computed');
+    }
+}


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Documented user facing changes

Resolves #2540

**Changes**

- Detect migration-backed columns in `NoUnnecessaryCollectionCallRule` even when the model documents the same property with PHPDoc.
- Preserve the existing PHPDoc precedence for normal model property reflection.
- Cover both a documented database column and a documented computed property that must not produce a diagnostic.

**Verification**

- `composer test:cs`
- `composer test:types`
- `composer test:unit` (1,717 tests, 2 skipped)
- `composer dump-autoload --optimize --strict-psr`

**Breaking changes**

None.

**AI assistance**

Generated with OpenAI Codex. The change has not been independently human-reviewed.
